### PR TITLE
Add filter operators: in, nin, bt, nbt with type conversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -545,3 +545,45 @@ jobs:
       - name: Run Tests
         working-directory: bruno
         run: bru run custom-example --env local --format json --sandbox=developer
+
+  query-example-test:
+    name: Query Example Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.11'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Server
+        working-directory: examples/query
+        run: go build -o /tmp/query-server .
+
+      - name: Start Server
+        run: /tmp/query-server &
+
+      - name: Wait for Server
+        run: |
+          for i in {1..30}; do
+            if curl -f http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - name: Install Bruno CLI
+        run: npm install -g @usebruno/cli
+
+      - name: Run Tests
+        working-directory: bruno
+        run: bru run query-example --env local --format json --sandbox=developer

--- a/AGENT.md
+++ b/AGENT.md
@@ -343,12 +343,18 @@ Built-in support on GetAll endpoints:
 | Parameter | Example | Description |
 |-----------|---------|-------------|
 | Filter | `?filter[status]=active` | Exact match |
-| Filter ops | `?filter[age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like |
+| Filter ops | `?filter[age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
 | Sort | `?sort=name,-created_at` | `-` prefix for descending |
 | Limit | `?limit=10` | Max results |
 | Offset | `?offset=20` | Skip results |
 | Count | `?count=true` | Include X-Total-Count header |
 | Include | `?include=Posts` | Load relations (requires WithRelationName on child route) |
+
+**Filter operator details:**
+- `in` - In list: `?filter[Status][in]=active,pending`
+- `nin` - Not in list: `?filter[Status][nin]=deleted,archived`
+- `bt` - Between (inclusive): `?filter[Age][bt]=18,65`
+- `nbt` - Not between: `?filter[Price][nbt]=100,500`
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -593,6 +593,10 @@ GET /users?filter[Status]=active&filter[Role]=admin
 | `lt` | Less than | `filter[Age][lt]=65` |
 | `lte` | Less than or equal | `filter[Age][lte]=65` |
 | `like` | SQL LIKE pattern | `filter[Name][like]=John%` |
+| `in` | In list | `filter[Status][in]=active,pending` |
+| `nin` | Not in list | `filter[Status][nin]=deleted,archived` |
+| `bt` | Between (inclusive) | `filter[Age][bt]=18,65` |
+| `nbt` | Not between | `filter[Price][nbt]=100,500` |
 
 ### Sorting
 

--- a/bruno/query-example/01-health-check.bru
+++ b/bruno/query-example/01-health-check.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Health Check
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.status: eq ok
+}

--- a/bruno/query-example/02-create-product-apple.bru
+++ b/bruno/query-example/02-create-product-apple.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Create Product - Apple (Fruit, $100, Stock 50)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Apple",
+    "category": "Fruit",
+    "price": 100,
+    "stock": 50,
+    "active": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.name: eq Apple
+  res.body.category: eq Fruit
+  res.body.price: eq 100
+  res.body.stock: eq 50
+  res.body.active: eq true
+}
+
+script:post-response {
+  bru.setVar("appleId", res.body.id);
+}

--- a/bruno/query-example/03-create-product-banana.bru
+++ b/bruno/query-example/03-create-product-banana.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create Product - Banana (Fruit, $50, Stock 100)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Banana",
+    "category": "Fruit",
+    "price": 50,
+    "stock": 100,
+    "active": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq Banana
+  res.body.category: eq Fruit
+  res.body.price: eq 50
+}
+
+script:post-response {
+  bru.setVar("bananaId", res.body.id);
+}

--- a/bruno/query-example/04-create-product-carrot.bru
+++ b/bruno/query-example/04-create-product-carrot.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create Product - Carrot (Vegetable, $30, Stock 200)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Carrot",
+    "category": "Vegetable",
+    "price": 30,
+    "stock": 200,
+    "active": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq Carrot
+  res.body.category: eq Vegetable
+  res.body.price: eq 30
+}
+
+script:post-response {
+  bru.setVar("carrotId", res.body.id);
+}

--- a/bruno/query-example/05-create-product-donut.bru
+++ b/bruno/query-example/05-create-product-donut.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Create Product - Donut (Bakery, $150, Stock 25, Inactive)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Donut",
+    "category": "Bakery",
+    "price": 150,
+    "stock": 25,
+    "active": false
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq Donut
+  res.body.category: eq Bakery
+  res.body.price: eq 150
+  res.body.active: eq false
+}
+
+script:post-response {
+  bru.setVar("donutId", res.body.id);
+}

--- a/bruno/query-example/06-create-product-eggplant.bru
+++ b/bruno/query-example/06-create-product-eggplant.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create Product - Eggplant (Vegetable, $80, Stock 75)
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Eggplant",
+    "category": "Vegetable",
+    "price": 80,
+    "stock": 75,
+    "active": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq Eggplant
+  res.body.category: eq Vegetable
+  res.body.price: eq 80
+}
+
+script:post-response {
+  bru.setVar("eggplantId", res.body.id);
+}

--- a/bruno/query-example/07-create-product-numeric-name.bru
+++ b/bruno/query-example/07-create-product-numeric-name.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Create Product - Numeric Name (Name=123, Category=true)
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "123",
+    "category": "true",
+    "price": 999,
+    "stock": 10,
+    "active": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq "123"
+  res.body.category: eq "true"
+}

--- a/bruno/query-example/08-create-product-false-category.bru
+++ b/bruno/query-example/08-create-product-false-category.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Create Product - False Category (Category=false)
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/products
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "FalseItem",
+    "category": "false",
+    "price": 888,
+    "stock": 5,
+    "active": false
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.name: eq "FalseItem"
+  res.body.category: eq "false"
+}

--- a/bruno/query-example/10-filter-eq.bru
+++ b/bruno/query-example/10-filter-eq.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter EQ - Category equals Fruit
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=Fruit
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("All results have Category = Fruit", function() {
+    expect(res.body.every(p => p.category === "Fruit")).to.be.true;
+  });
+}

--- a/bruno/query-example/11-filter-neq.bru
+++ b/bruno/query-example/11-filter-neq.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter NEQ - Category not equals Fruit
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category][neq]=Fruit
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 5
+}
+
+tests {
+  test("No results have Category = Fruit", function() {
+    expect(res.body.every(p => p.category !== "Fruit")).to.be.true;
+  });
+}

--- a/bruno/query-example/12-filter-gt.bru
+++ b/bruno/query-example/12-filter-gt.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter GT - Price greater than 80
+  type: http
+  seq: 12
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][gt]=80
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 4
+}
+
+tests {
+  test("All results have Price > 80", function() {
+    expect(res.body.every(p => p.price > 80)).to.be.true;
+  });
+}

--- a/bruno/query-example/13-filter-gte.bru
+++ b/bruno/query-example/13-filter-gte.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter GTE - Price greater than or equal to 80
+  type: http
+  seq: 13
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][gte]=80
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 5
+}
+
+tests {
+  test("All results have Price >= 80", function() {
+    expect(res.body.every(p => p.price >= 80)).to.be.true;
+  });
+}

--- a/bruno/query-example/14-filter-lt.bru
+++ b/bruno/query-example/14-filter-lt.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter LT - Price less than 80
+  type: http
+  seq: 14
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][lt]=80
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("All results have Price < 80", function() {
+    expect(res.body.every(p => p.price < 80)).to.be.true;
+  });
+}

--- a/bruno/query-example/15-filter-lte.bru
+++ b/bruno/query-example/15-filter-lte.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter LTE - Price less than or equal to 80
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][lte]=80
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 3
+}
+
+tests {
+  test("All results have Price <= 80", function() {
+    expect(res.body.every(p => p.price <= 80)).to.be.true;
+  });
+}

--- a/bruno/query-example/16-filter-like.bru
+++ b/bruno/query-example/16-filter-like.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Filter LIKE - Name starts with E
+  type: http
+  seq: 16
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Name][like]=E%25
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].name: eq Eggplant
+}

--- a/bruno/query-example/20-filter-combined-category-and-price.bru
+++ b/bruno/query-example/20-filter-combined-category-and-price.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Filter Combined - Category=Vegetable AND Price>=50
+  type: http
+  seq: 20
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=Vegetable&filter[Price][gte]=50
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].name: eq Eggplant
+}
+
+tests {
+  test("Result is Vegetable with Price >= 50", function() {
+    expect(res.body[0].category).to.equal("Vegetable");
+    expect(res.body[0].price).to.be.at.least(50);
+  });
+}

--- a/bruno/query-example/21-filter-combined-with-sort.bru
+++ b/bruno/query-example/21-filter-combined-with-sort.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Filter Combined with Sort - Price>40 sorted by Price desc
+  type: http
+  seq: 21
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][gt]=40&sort=-Price
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 6
+}
+
+tests {
+  test("Results sorted by Price descending", function() {
+    expect(res.body[0].price).to.equal(999);
+    expect(res.body[1].price).to.equal(888);
+    expect(res.body[2].price).to.equal(150);
+    expect(res.body[3].price).to.equal(100);
+    expect(res.body[4].price).to.equal(80);
+    expect(res.body[5].price).to.equal(50);
+  });
+}

--- a/bruno/query-example/22-filter-combined-with-pagination.bru
+++ b/bruno/query-example/22-filter-combined-with-pagination.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Filter Combined with Pagination - Active products, limit 2, offset 1
+  type: http
+  seq: 22
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Active]=true&sort=Name&limit=2&offset=1&count=true
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("Returns 2 active products starting from offset 1", function() {
+    expect(res.body.every(p => p.active === true)).to.be.true;
+    expect(res.body[0].name).to.equal("Apple");
+    expect(res.body[1].name).to.equal("Banana");
+  });
+
+  test("X-Total-Count header shows total active products", function() {
+    expect(res.headers['x-total-count']).to.equal('5');
+  });
+}

--- a/bruno/query-example/23-filter-bool-false.bru
+++ b/bruno/query-example/23-filter-bool-false.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter Bool - Active equals false
+  type: http
+  seq: 23
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Active]=false
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("All returned products are inactive", function() {
+    expect(res.body.every(p => p.active === false)).to.be.true;
+  });
+}

--- a/bruno/query-example/24-filter-string-numeric-value.bru
+++ b/bruno/query-example/24-filter-string-numeric-value.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Filter String - Numeric looking value (Name=123)
+  type: http
+  seq: 24
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Name]=123
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].name: eq "123"
+}
+
+tests {
+  test("String filter with numeric value stays as string", function() {
+    expect(res.body[0].name).to.equal("123");
+  });
+}

--- a/bruno/query-example/25-filter-string-true-value.bru
+++ b/bruno/query-example/25-filter-string-true-value.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Filter String - True looking value (Category=true)
+  type: http
+  seq: 25
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=true
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].category: eq "true"
+}
+
+tests {
+  test("String filter with 'true' value stays as string", function() {
+    expect(res.body[0].category).to.equal("true");
+    expect(res.body[0].name).to.equal("123");
+  });
+}

--- a/bruno/query-example/26-filter-string-false-value.bru
+++ b/bruno/query-example/26-filter-string-false-value.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Filter String - False looking value (Category=false)
+  type: http
+  seq: 26
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=false
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].category: eq "false"
+}
+
+tests {
+  test("String filter with 'false' value stays as string", function() {
+    expect(res.body[0].category).to.equal("false");
+    expect(res.body[0].name).to.equal("FalseItem");
+  });
+}

--- a/bruno/query-example/27-filter-int-string-value.bru
+++ b/bruno/query-example/27-filter-int-string-value.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Filter Int - String value converts to int (Price=100)
+  type: http
+  seq: 27
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price]=100
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 1
+  res.body[0].price: eq 100
+}
+
+tests {
+  test("Int filter with string value converts properly", function() {
+    expect(res.body[0].price).to.equal(100);
+    expect(res.body[0].name).to.equal("Apple");
+  });
+}

--- a/bruno/query-example/30-filter-in.bru
+++ b/bruno/query-example/30-filter-in.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter IN - Category in (Fruit, Bakery)
+  type: http
+  seq: 30
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category][in]=Fruit,Bakery
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 3
+}
+
+tests {
+  test("All results have Category in [Fruit, Bakery]", function() {
+    expect(res.body.every(p => p.category === "Fruit" || p.category === "Bakery")).to.be.true;
+  });
+}

--- a/bruno/query-example/31-filter-nin.bru
+++ b/bruno/query-example/31-filter-nin.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter NIN - Category not in (Fruit, Bakery)
+  type: http
+  seq: 31
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category][nin]=Fruit,Bakery
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 4
+}
+
+tests {
+  test("No results have Category in [Fruit, Bakery]", function() {
+    expect(res.body.every(p => p.category !== "Fruit" && p.category !== "Bakery")).to.be.true;
+  });
+}

--- a/bruno/query-example/32-filter-bt.bru
+++ b/bruno/query-example/32-filter-bt.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter BT - Price between 50 and 100
+  type: http
+  seq: 32
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][bt]=50,100
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 3
+}
+
+tests {
+  test("All results have Price between 50 and 100 (inclusive)", function() {
+    expect(res.body.every(p => p.price >= 50 && p.price <= 100)).to.be.true;
+  });
+}

--- a/bruno/query-example/33-filter-nbt.bru
+++ b/bruno/query-example/33-filter-nbt.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Filter NBT - Price not between 50 and 100
+  type: http
+  seq: 33
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Price][nbt]=50,100
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 4
+}
+
+tests {
+  test("All results have Price outside 50-100 range", function() {
+    expect(res.body.every(p => p.price < 50 || p.price > 100)).to.be.true;
+  });
+}

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -12,13 +12,17 @@ import (
 	"github.com/sjgoldie/go-restgen/metadata"
 )
 
-// Test product names as constants to avoid duplication
+// Test constants to avoid duplication
 const (
 	productApple    = "Apple"
 	productBanana   = "Banana"
 	productCarrot   = "Carrot"
 	productDonut    = "Donut"
 	productEggplant = "Eggplant"
+
+	categoryFruit     = "Fruit"
+	categoryVegetable = "Vegetable"
+	categoryBakery    = "Bakery"
 )
 
 // TestQueryProduct is a test model for query tests
@@ -44,7 +48,7 @@ var testQueryProductMeta = &metadata.TypeMetadata{
 	MaxLimit:         100,
 }
 
-func setupQueryTestDB(t *testing.T) (*datastore.SQLite, func()) {
+func setupTestDBWithModel(t *testing.T, model any, dropModel any) (*datastore.SQLite, func()) {
 	t.Helper()
 
 	db, err := datastore.NewSQLite(":memory:")
@@ -52,14 +56,12 @@ func setupQueryTestDB(t *testing.T) (*datastore.SQLite, func()) {
 		t.Fatal("Failed to create database:", err)
 	}
 
-	// Initialize global singleton for the wrapper
 	if err := datastore.Initialize(db); err != nil {
 		db.Cleanup()
 		t.Fatal("Failed to initialize datastore:", err)
 	}
 
-	// Create table
-	_, err = db.GetDB().NewCreateTable().Model((*TestQueryProduct)(nil)).IfNotExists().Exec(context.Background())
+	_, err = db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(context.Background())
 	if err != nil {
 		datastore.Cleanup()
 		db.Cleanup()
@@ -67,10 +69,14 @@ func setupQueryTestDB(t *testing.T) (*datastore.SQLite, func()) {
 	}
 
 	return db, func() {
-		_, _ = db.GetDB().NewDropTable().Model((*TestQueryProduct)(nil)).IfExists().Exec(context.Background())
+		_, _ = db.GetDB().NewDropTable().Model(dropModel).IfExists().Exec(context.Background())
 		datastore.Cleanup()
 		db.Cleanup()
 	}
+}
+
+func setupQueryTestDB(t *testing.T) (*datastore.SQLite, func()) {
+	return setupTestDBWithModel(t, (*TestQueryProduct)(nil), (*TestQueryProduct)(nil))
 }
 
 func ctxWithQueryMeta(meta *metadata.TypeMetadata) context.Context {
@@ -81,11 +87,11 @@ func seedQueryProducts(t *testing.T, wrapper *datastore.Wrapper[TestQueryProduct
 	t.Helper()
 
 	products := []TestQueryProduct{
-		{Name: productApple, Category: "Fruit", Price: 100, InStock: true},
-		{Name: productBanana, Category: "Fruit", Price: 50, InStock: true},
-		{Name: productCarrot, Category: "Vegetable", Price: 30, InStock: true},
-		{Name: productDonut, Category: "Bakery", Price: 150, InStock: false},
-		{Name: productEggplant, Category: "Vegetable", Price: 80, InStock: true},
+		{Name: productApple, Category: categoryFruit, Price: 100, InStock: true},
+		{Name: productBanana, Category: categoryFruit, Price: 50, InStock: true},
+		{Name: productCarrot, Category: categoryVegetable, Price: 30, InStock: true},
+		{Name: productDonut, Category: categoryBakery, Price: 150, InStock: false},
+		{Name: productEggplant, Category: categoryVegetable, Price: 80, InStock: true},
 	}
 
 	for _, p := range products {
@@ -104,10 +110,10 @@ func TestQuery_Filter_Eq(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMeta)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Filter by category = Fruit
+	// Filter by category = categoryFruit
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: "Fruit", Operator: "eq"},
+			"Category": {Value: categoryFruit, Operator: metadata.OpEq},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -122,7 +128,7 @@ func TestQuery_Filter_Eq(t *testing.T) {
 	}
 
 	for _, p := range results {
-		if p.Category != "Fruit" {
+		if p.Category != categoryFruit {
 			t.Errorf("Expected category Fruit, got %s", p.Category)
 		}
 	}
@@ -139,7 +145,7 @@ func TestQuery_Filter_Gt(t *testing.T) {
 	// Filter by price > 75
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Price": {Value: "75", Operator: "gt"},
+			"Price": {Value: "75", Operator: metadata.OpGt},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -171,7 +177,7 @@ func TestQuery_Filter_Like(t *testing.T) {
 	// Filter by name LIKE %an%
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Name": {Value: "%an%", Operator: "like"},
+			"Name": {Value: "%an%", Operator: metadata.OpLike},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -197,7 +203,7 @@ func TestQuery_Filter_NotAllowed(t *testing.T) {
 	// Filter by ID (not in FilterableFields) - should be silently ignored
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"ID": {Value: "1", Operator: "eq"},
+			"ID": {Value: "1", Operator: metadata.OpEq},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -393,10 +399,10 @@ func TestQuery_CountWithFilter(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMeta)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Filter by category = Fruit with count
+	// Filter by category = categoryFruit with count
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: "Fruit", Operator: "eq"},
+			"Category": {Value: categoryFruit, Operator: metadata.OpEq},
 		},
 		Limit:      1,
 		CountTotal: true,
@@ -412,7 +418,7 @@ func TestQuery_CountWithFilter(t *testing.T) {
 		t.Errorf("Expected 1 result, got %d", len(results))
 	}
 
-	// Count should reflect filter (2 Fruit products)
+	// Count should reflect filter (2 categoryFruit products)
 	if count != 2 {
 		t.Errorf("Expected filtered count of 2, got %d", count)
 	}
@@ -483,10 +489,10 @@ func TestQuery_CombinedFilterSortPagination(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMeta)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Filter by Category=Fruit, sort by price desc, limit 1, offset 1, with count
+	// Filter by Category=categoryFruit, sort by price desc, limit 1, offset 1, with count
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: "Fruit", Operator: "eq"},
+			"Category": {Value: categoryFruit, Operator: metadata.OpEq},
 		},
 		Sort: []metadata.SortField{
 			{Field: "Price", Desc: true},
@@ -502,7 +508,7 @@ func TestQuery_CombinedFilterSortPagination(t *testing.T) {
 		t.Fatal("GetAll failed:", err)
 	}
 
-	// 2 Fruit items: Apple(100), Banana(50)
+	// 2 categoryFruit items: Apple(100), Banana(50)
 	// Sorted by price desc: Apple(100), Banana(50)
 	// Offset 1, limit 1: Banana
 	if len(results) != 1 {
@@ -510,7 +516,7 @@ func TestQuery_CombinedFilterSortPagination(t *testing.T) {
 	}
 
 	if count != 2 {
-		t.Errorf("Expected count of 2 Fruit items, got %d", count)
+		t.Errorf("Expected count of 2 categoryFruit items, got %d", count)
 	}
 
 	if len(results) > 0 && results[0].Name != productBanana {
@@ -648,10 +654,10 @@ func TestQuery_Filter_Neq(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMeta)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Filter by category != Fruit
+	// Filter by category != categoryFruit
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: "Fruit", Operator: "neq"},
+			"Category": {Value: categoryFruit, Operator: metadata.OpNeq},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -666,7 +672,7 @@ func TestQuery_Filter_Neq(t *testing.T) {
 	}
 
 	for _, p := range results {
-		if p.Category == "Fruit" {
+		if p.Category == categoryFruit {
 			t.Errorf("Expected non-Fruit category, got %s", p.Category)
 		}
 	}
@@ -683,7 +689,7 @@ func TestQuery_Filter_Gte(t *testing.T) {
 	// Filter by price >= 80
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Price": {Value: "80", Operator: "gte"},
+			"Price": {Value: "80", Operator: metadata.OpGte},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -715,7 +721,7 @@ func TestQuery_Filter_Lt(t *testing.T) {
 	// Filter by price < 80
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Price": {Value: "80", Operator: "lt"},
+			"Price": {Value: "80", Operator: metadata.OpLt},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -747,7 +753,7 @@ func TestQuery_Filter_Lte(t *testing.T) {
 	// Filter by price <= 80
 	opts := &metadata.QueryOptions{
 		Filters: map[string]metadata.FilterValue{
-			"Price": {Value: "80", Operator: "lte"},
+			"Price": {Value: "80", Operator: metadata.OpLte},
 		},
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
@@ -765,5 +771,651 @@ func TestQuery_Filter_Lte(t *testing.T) {
 		if p.Price > 80 {
 			t.Errorf("Expected price <= 80, got %d", p.Price)
 		}
+	}
+}
+
+func TestQuery_Filter_In(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by category IN (Fruit, Bakery)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpIn},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("Expected 3 products with category IN (Fruit, Bakery), got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.Category != categoryFruit && p.Category != categoryBakery {
+			t.Errorf("Expected category Fruit or Bakery, got %s", p.Category)
+		}
+	}
+}
+
+func TestQuery_Filter_Nin(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by category NOT IN (Fruit, Bakery)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpNin},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 products with category NOT IN (Fruit, Bakery), got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.Category == categoryFruit || p.Category == categoryBakery {
+			t.Errorf("Expected category NOT Fruit or Bakery, got %s", p.Category)
+		}
+	}
+}
+
+func TestQuery_Filter_Bt(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by price BETWEEN 50 AND 100
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Price": {Value: "50,100", Operator: metadata.OpBt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Apple=100, Banana=50, Eggplant=80 are between 50-100
+	if len(results) != 3 {
+		t.Errorf("Expected 3 products with price BETWEEN 50 AND 100, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.Price < 50 || p.Price > 100 {
+			t.Errorf("Expected price between 50 and 100, got %d", p.Price)
+		}
+	}
+}
+
+func TestQuery_Filter_Nbt(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by price NOT BETWEEN 50 AND 100
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Price": {Value: "50,100", Operator: metadata.OpNbt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Carrot=30, Donut=150 are NOT between 50-100
+	if len(results) != 2 {
+		t.Errorf("Expected 2 products with price NOT BETWEEN 50 AND 100, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.Price >= 50 && p.Price <= 100 {
+			t.Errorf("Expected price outside 50-100 range, got %d", p.Price)
+		}
+	}
+}
+
+func TestQuery_Filter_Bool_True(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by InStock = true (string "true" should convert to bool)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"InStock": {Value: "true", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Apple, Banana, Carrot, Eggplant are in stock (4 products)
+	if len(results) != 4 {
+		t.Errorf("Expected 4 products with InStock=true, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if !p.InStock {
+			t.Errorf("Expected InStock=true, got false for %s", p.Name)
+		}
+	}
+}
+
+func TestQuery_Filter_Bool_False(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by InStock = false (string "false" should convert to bool)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"InStock": {Value: "false", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Only Donut is not in stock (1 product)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 product with InStock=false, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.InStock {
+			t.Errorf("Expected InStock=false, got true for %s", p.Name)
+		}
+	}
+}
+
+// seedTypeConversionProducts creates products with edge-case values for type conversion testing
+func seedTypeConversionProducts(t *testing.T, wrapper *datastore.Wrapper[TestQueryProduct], ctx context.Context) {
+	t.Helper()
+
+	products := []TestQueryProduct{
+		{Name: "123", Category: "true", Price: 100, InStock: true},       // numeric name, "true" category
+		{Name: "456", Category: "false", Price: 200, InStock: false},     // numeric name, "false" category
+		{Name: "Normal", Category: "Regular", Price: 100, InStock: true}, // normal values, same price as first
+	}
+
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed product:", err)
+		}
+	}
+}
+
+func TestQuery_Filter_Int_StringValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedTypeConversionProducts(t, wrapper, ctx)
+
+	// Filter by Price = "100" (string should convert to int 100)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Price": {Value: "100", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Products "123" and "Normal" both have Price=100
+	if len(results) != 2 {
+		t.Errorf("Expected 2 products with Price=100, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if p.Price != 100 {
+			t.Errorf("Expected Price=100, got %d for %s", p.Price, p.Name)
+		}
+	}
+}
+
+func TestQuery_Filter_String_NumericLookingValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedTypeConversionProducts(t, wrapper, ctx)
+
+	// Filter by Name = "123" (should stay as string, not convert to int)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Name": {Value: "123", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 product with Name='123', got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0].Name != "123" {
+		t.Errorf("Expected Name='123', got %s", results[0].Name)
+	}
+}
+
+func TestQuery_Filter_String_TrueLookingValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedTypeConversionProducts(t, wrapper, ctx)
+
+	// Filter by Category = "true" (should stay as string, not convert to bool)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: "true", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 product with Category='true', got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0].Category != "true" {
+		t.Errorf("Expected Category='true', got %s", results[0].Category)
+	}
+}
+
+func TestQuery_Filter_String_FalseLookingValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedTypeConversionProducts(t, wrapper, ctx)
+
+	// Filter by Category = "false" (should stay as string, not convert to bool)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: "false", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 product with Category='false', got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0].Category != "false" {
+		t.Errorf("Expected Category='false', got %s", results[0].Category)
+	}
+}
+
+func TestQuery_Filter_Bool_OneValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by InStock = "1" (should convert to true)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"InStock": {Value: "1", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Should get all in-stock products (Apple, Banana, Carrot, Eggplant)
+	if len(results) != 4 {
+		t.Errorf("Expected 4 in-stock products with '1' filter, got %d", len(results))
+	}
+
+	for _, p := range results {
+		if !p.InStock {
+			t.Errorf("Expected InStock=true, got false for %s", p.Name)
+		}
+	}
+}
+
+func TestQuery_Filter_Int_InvalidValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter by Price = "notanumber" (should log warning, use string comparison which won't match)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Price": {Value: "notanumber", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// No products should match since "notanumber" won't equal any int price
+	if len(results) != 0 {
+		t.Errorf("Expected 0 products with invalid int filter, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Bt_SingleValue(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter with bt operator but only one value - should use zero value for second
+	// Price bt 50 (with zero as second value) means Price BETWEEN 50 AND 0
+	// SQL BETWEEN requires first <= second, so this matches nothing
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Price": {Value: "50", Operator: metadata.OpBt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// BETWEEN 50 AND 0 matches nothing (first value > second value)
+	// This tests the documented edge case behavior
+	if len(results) != 0 {
+		t.Errorf("Expected 0 products with bt single value (BETWEEN 50 AND 0), got %d", len(results))
+	}
+}
+
+// TestNumericProduct is a test model with various numeric types
+type TestNumericProduct struct {
+	bun.BaseModel `bun:"table:numeric_products"`
+	ID            int     `bun:"id,pk,autoincrement" json:"id"`
+	Name          string  `bun:"name,notnull" json:"name"`
+	Rating        float64 `bun:"rating,notnull" json:"rating"`
+	Stock         uint    `bun:"stock,notnull" json:"stock"`
+}
+
+var testNumericProductMeta = &metadata.TypeMetadata{
+	TypeID:           "numeric_product_id",
+	TypeName:         "TestNumericProduct",
+	TableName:        "numeric_products",
+	URLParamUUID:     "productId",
+	ModelType:        reflect.TypeOf(TestNumericProduct{}),
+	FilterableFields: []string{"Name", "Rating", "Stock"},
+	SortableFields:   []string{"Name", "Rating", "Stock"},
+	DefaultLimit:     10,
+	MaxLimit:         100,
+}
+
+func setupNumericTestDB(t *testing.T) (*datastore.SQLite, func()) {
+	return setupTestDBWithModel(t, (*TestNumericProduct)(nil), (*TestNumericProduct)(nil))
+}
+
+func seedNumericProducts(t *testing.T, wrapper *datastore.Wrapper[TestNumericProduct], ctx context.Context) {
+	t.Helper()
+
+	products := []TestNumericProduct{
+		{Name: "HighRated", Rating: 4.5, Stock: 100},
+		{Name: "LowRated", Rating: 2.0, Stock: 50},
+		{Name: "MidRated", Rating: 3.5, Stock: 75},
+	}
+
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed numeric product:", err)
+		}
+	}
+}
+
+func TestQuery_Filter_Float_Gt(t *testing.T) {
+	db, cleanup := setupNumericTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestNumericProduct]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, testNumericProductMeta)
+	seedNumericProducts(t, wrapper, ctx)
+
+	// Filter by Rating > 3.0
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Rating": {Value: "3.0", Operator: metadata.OpGt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Should get HighRated (4.5) and MidRated (3.5)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 products with Rating > 3.0, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Float_InvalidValue(t *testing.T) {
+	db, cleanup := setupNumericTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestNumericProduct]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, testNumericProductMeta)
+	seedNumericProducts(t, wrapper, ctx)
+
+	// Filter by Rating = "notafloat"
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Rating": {Value: "notafloat", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// No products should match
+	if len(results) != 0 {
+		t.Errorf("Expected 0 products with invalid float filter, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Uint_Gte(t *testing.T) {
+	db, cleanup := setupNumericTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestNumericProduct]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, testNumericProductMeta)
+	seedNumericProducts(t, wrapper, ctx)
+
+	// Filter by Stock >= 75
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Stock": {Value: "75", Operator: metadata.OpGte},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Should get HighRated (100) and MidRated (75)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 products with Stock >= 75, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Uint_InvalidValue(t *testing.T) {
+	db, cleanup := setupNumericTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestNumericProduct]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, testNumericProductMeta)
+	seedNumericProducts(t, wrapper, ctx)
+
+	// Filter by Stock = "notauint"
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Stock": {Value: "notauint", Operator: metadata.OpEq},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// No products should match
+	if len(results) != 0 {
+		t.Errorf("Expected 0 products with invalid uint filter, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Float_Between(t *testing.T) {
+	db, cleanup := setupNumericTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestNumericProduct]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, testNumericProductMeta)
+	seedNumericProducts(t, wrapper, ctx)
+
+	// Filter by Rating between 2.5 and 4.0
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Rating": {Value: "2.5,4.0", Operator: metadata.OpBt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Should get MidRated (3.5)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 product with Rating between 2.5 and 4.0, got %d", len(results))
+	}
+}
+
+func TestQuery_Filter_Bt_UnknownField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+
+	// Create metadata that allows filtering on a field that doesn't exist in the model
+	badMeta := &metadata.TypeMetadata{
+		TypeID:           "query_product_id",
+		TypeName:         "TestQueryProduct",
+		TableName:        "query_products",
+		URLParamUUID:     "productId",
+		ModelType:        reflect.TypeOf(TestQueryProduct{}),
+		FilterableFields: []string{"NonExistentField"},
+		SortableFields:   []string{"Name"},
+		DefaultLimit:     10,
+		MaxLimit:         100,
+	}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, badMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter on non-existent field with bt operator to trigger getZeroValue edge case
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"NonExistentField": {Value: "50", Operator: metadata.OpBt},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	// This will fail to find the column name, but tests the code path
+	results, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		// Expected - field doesn't exist
+		return
+	}
+
+	// If no error, we should get all products since filter couldn't be applied
+	if len(results) != 5 {
+		t.Errorf("Expected 5 products (filter skipped), got %d", len(results))
 	}
 }

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/uptrace/bun"
@@ -14,6 +16,15 @@ import (
 
 	apperrors "github.com/sjgoldie/go-restgen/errors"
 	"github.com/sjgoldie/go-restgen/metadata"
+)
+
+var (
+	singleValueOps = map[string]bool{
+		metadata.OpEq: true, "": true,
+		metadata.OpNeq: true, metadata.OpGt: true, metadata.OpGte: true,
+		metadata.OpLt: true, metadata.OpLte: true, metadata.OpLike: true,
+	}
+	rangeOps = map[string]bool{metadata.OpBt: true, metadata.OpNbt: true}
 )
 
 // Wrapper is a generic struct that wraps a Store interface to provide CRUD operations
@@ -749,8 +760,93 @@ func fieldToColumnName(tType reflect.Type, fieldName string) (string, error) {
 	return parts[0], nil
 }
 
+// convertFilterValues converts a string filter value to the appropriate Go type(s)
+// based on the model field's type. For non-string types, comma-separated values
+// are split and each value is converted. For string types, the value is kept intact
+// since commas could be part of the string value itself.
+// Returns a slice of converted values.
+func convertFilterValues(modelType reflect.Type, fieldName string, val string) []any {
+	field, found := modelType.FieldByName(fieldName)
+	if !found {
+		return []any{val}
+	}
+
+	// String fields: don't split - comma could be part of the value
+	if field.Type.Kind() == reflect.String {
+		return []any{val}
+	}
+
+	// Non-string fields: split by comma and convert each
+	parts := strings.Split(val, ",")
+	result := make([]any, len(parts))
+	for i, part := range parts {
+		result[i] = convertSingleValue(field.Type.Kind(), fieldName, strings.TrimSpace(part))
+	}
+	return result
+}
+
+// convertSingleValue converts a single string value to the appropriate Go type
+func convertSingleValue(kind reflect.Kind, fieldName string, val string) any {
+	switch kind {
+	case reflect.Bool:
+		return val == "true" || val == "1"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			slog.Warn("failed to parse filter value as int", "field", fieldName, "value", val, "error", err)
+			return val
+		}
+		return i
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			slog.Warn("failed to parse filter value as uint", "field", fieldName, "value", val, "error", err)
+			return val
+		}
+		return u
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			slog.Warn("failed to parse filter value as float", "field", fieldName, "value", val, "error", err)
+			return val
+		}
+		return f
+	}
+	return val
+}
+
+// getZeroValue returns the zero value for a field type
+func getZeroValue(modelType reflect.Type, fieldName string) any {
+	field, found := modelType.FieldByName(fieldName)
+	if !found {
+		return ""
+	}
+	return reflect.Zero(field.Type).Interface()
+}
+
+// splitStringValues splits a single comma-separated string value into multiple trimmed values
+func splitStringValues(vals []any) []any {
+	if len(vals) != 1 {
+		return vals
+	}
+	strVal, ok := vals[0].(string)
+	if !ok || !strings.Contains(strVal, ",") {
+		return vals
+	}
+	parts := strings.Split(strVal, ",")
+	result := make([]any, len(parts))
+	for i, p := range parts {
+		result[i] = strings.TrimSpace(p)
+	}
+	return result
+}
+
 // applyQueryFilters applies filters from QueryOptions to the query
 // Only fields in metadata.FilterableFields are allowed (others silently ignored)
+//
+// Single-value operators (eq, neq, gt, gte, lt, lte, like): use first value if multiple provided
+// Multi-value operators (in, nin): use all values
+// Range operators (bt, nbt): require exactly 2 values; if fewer provided, zero value is used for missing
 func (w *Wrapper[T]) applyQueryFilters(query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) *bun.SelectQuery {
 	if opts == nil || len(opts.Filters) == 0 {
 		return query
@@ -767,22 +863,51 @@ func (w *Wrapper[T]) applyQueryFilters(query *bun.SelectQuery, opts *metadata.Qu
 			continue // skip if can't resolve column
 		}
 
+		vals := convertFilterValues(meta.ModelType, field, filter.Value)
+
+		// Warn if single-value operator received multiple values
+		if len(vals) > 1 && singleValueOps[filter.Operator] {
+			slog.Warn("filter operator expects single value, using first", "operator", filter.Operator, "field", field, "values", len(vals))
+		}
+
+		// Warn and pad if range operator doesn't have exactly 2 values
+		if rangeOps[filter.Operator] && len(vals) != 2 {
+			slog.Warn("filter operator expects exactly 2 values, padding with zero value", "operator", filter.Operator, "field", field, "values", len(vals))
+			for len(vals) < 2 {
+				vals = append(vals, getZeroValue(meta.ModelType, field))
+			}
+		}
+
 		// Apply operator
 		switch filter.Operator {
-		case "eq", "":
-			query = query.Where("?TableAlias.? = ?", bun.Ident(colName), filter.Value)
-		case "neq":
-			query = query.Where("?TableAlias.? != ?", bun.Ident(colName), filter.Value)
-		case "gt":
-			query = query.Where("?TableAlias.? > ?", bun.Ident(colName), filter.Value)
-		case "gte":
-			query = query.Where("?TableAlias.? >= ?", bun.Ident(colName), filter.Value)
-		case "lt":
-			query = query.Where("?TableAlias.? < ?", bun.Ident(colName), filter.Value)
-		case "lte":
-			query = query.Where("?TableAlias.? <= ?", bun.Ident(colName), filter.Value)
-		case "like":
-			query = query.Where("?TableAlias.? LIKE ?", bun.Ident(colName), filter.Value)
+		case metadata.OpEq, "":
+			query = query.Where("?TableAlias.? = ?", bun.Ident(colName), vals[0])
+		case metadata.OpNeq:
+			query = query.Where("?TableAlias.? != ?", bun.Ident(colName), vals[0])
+		case metadata.OpGt:
+			query = query.Where("?TableAlias.? > ?", bun.Ident(colName), vals[0])
+		case metadata.OpGte:
+			query = query.Where("?TableAlias.? >= ?", bun.Ident(colName), vals[0])
+		case metadata.OpLt:
+			query = query.Where("?TableAlias.? < ?", bun.Ident(colName), vals[0])
+		case metadata.OpLte:
+			query = query.Where("?TableAlias.? <= ?", bun.Ident(colName), vals[0])
+		case metadata.OpLike:
+			query = query.Where("?TableAlias.? LIKE ?", bun.Ident(colName), vals[0])
+		case metadata.OpIn:
+			// For string fields, convertFilterValues doesn't split (comma could be in value),
+			// but for in/nin operators, users explicitly want multiple values, so split here
+			vals = splitStringValues(vals)
+			query = query.Where("?TableAlias.? IN (?)", bun.Ident(colName), bun.In(vals))
+		case metadata.OpNin:
+			// For string fields, convertFilterValues doesn't split (comma could be in value),
+			// but for in/nin operators, users explicitly want multiple values, so split here
+			vals = splitStringValues(vals)
+			query = query.Where("?TableAlias.? NOT IN (?)", bun.Ident(colName), bun.In(vals))
+		case metadata.OpBt:
+			query = query.Where("?TableAlias.? BETWEEN ? AND ?", bun.Ident(colName), vals[0], vals[1])
+		case metadata.OpNbt:
+			query = query.Where("?TableAlias.? NOT BETWEEN ? AND ?", bun.Ident(colName), vals[0], vals[1])
 		}
 	}
 	return query

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -1,0 +1,115 @@
+//nolint:gosec,gocritic,unparam,errcheck // Example code - simplified for demonstration
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/uptrace/bun"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+	"github.com/sjgoldie/go-restgen/router"
+)
+
+// Product model with various field types for comprehensive filter testing
+type Product struct {
+	bun.BaseModel `bun:"table:products"`
+	ID            int       `bun:"id,pk,autoincrement" json:"id"`
+	Name          string    `bun:"name,notnull" json:"name"`
+	Category      string    `bun:"category,notnull" json:"category"`
+	Price         int       `bun:"price,notnull" json:"price"`
+	Stock         int       `bun:"stock,notnull" json:"stock"`
+	Active        bool      `bun:"active,notnull" json:"active"`
+	CreatedAt     time.Time `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
+	UpdatedAt     time.Time `bun:"updated_at,notnull" json:"updated_at,omitempty"`
+}
+
+// BeforeAppendModel hook for timestamps
+func (p *Product) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+	now := time.Now()
+	switch query.(type) {
+	case *bun.InsertQuery:
+		p.CreatedAt = now
+		p.UpdatedAt = now
+	case *bun.UpdateQuery:
+		p.UpdatedAt = now
+	}
+	return nil
+}
+
+func main() {
+	// Configure logging
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	slog.SetDefault(logger)
+
+	// Create SQLite in-memory database
+	db, err := datastore.NewSQLite(":memory:")
+	if err != nil {
+		log.Fatal("Failed to create datastore:", err)
+	}
+
+	if err := datastore.Initialize(db); err != nil {
+		log.Fatal("Failed to initialize datastore:", err)
+	}
+	defer datastore.Cleanup()
+
+	// Create schema
+	if _, err := db.GetDB().NewCreateTable().Model((*Product)(nil)).IfNotExists().Exec(context.Background()); err != nil {
+		log.Fatal("Failed to create schema:", err)
+	}
+
+	// Setup router
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	// Health check
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	// Register CRUD routes with comprehensive filter/sort/pagination options
+	b := router.NewBuilder(r)
+	router.RegisterRoutes[Product](b, "/products",
+		router.AllPublic(),
+		router.WithFilters("Name", "Category", "Price", "Stock", "Active"),
+		router.WithSorts("Name", "Category", "Price", "Stock", "CreatedAt"),
+		router.WithPagination(20, 100),
+		router.WithDefaultSort("Name"),
+	)
+
+	// Start server
+	fmt.Println("Server starting on :8080")
+	fmt.Println("Using SQLite in-memory database")
+	fmt.Println("\nThis example demonstrates query filtering, sorting, and pagination.")
+	fmt.Println("\nAvailable endpoints:")
+	fmt.Println("  POST   http://localhost:8080/products")
+	fmt.Println("  GET    http://localhost:8080/products")
+	fmt.Println("  GET    http://localhost:8080/products/{id}")
+	fmt.Println("  PUT    http://localhost:8080/products/{id}")
+	fmt.Println("  DELETE http://localhost:8080/products/{id}")
+	fmt.Println("\nFilter operators:")
+	fmt.Println("  eq   - Equal (default):     filter[Price]=100")
+	fmt.Println("  neq  - Not equal:           filter[Price][neq]=100")
+	fmt.Println("  gt   - Greater than:        filter[Price][gt]=100")
+	fmt.Println("  gte  - Greater or equal:    filter[Price][gte]=100")
+	fmt.Println("  lt   - Less than:           filter[Price][lt]=100")
+	fmt.Println("  lte  - Less or equal:       filter[Price][lte]=100")
+	fmt.Println("  like - Pattern match:       filter[Name][like]=Widget%")
+	fmt.Println("  in   - In list:             filter[Category][in]=Electronics,Books")
+	fmt.Println("  nin  - Not in list:         filter[Category][nin]=Electronics,Books")
+	fmt.Println("  bt   - Between:             filter[Price][bt]=50,150")
+	fmt.Println("  nbt  - Not between:         filter[Price][nbt]=50,150")
+	log.Fatal(http.ListenAndServe(":8080", r))
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -221,10 +221,25 @@ func AllowedIncludesFromContext(ctx context.Context) AllowedIncludes {
 	return includes
 }
 
+// Filter operators
+const (
+	OpEq   = "eq"   // Equals (default)
+	OpNeq  = "neq"  // Not equals
+	OpGt   = "gt"   // Greater than
+	OpGte  = "gte"  // Greater than or equal
+	OpLt   = "lt"   // Less than
+	OpLte  = "lte"  // Less than or equal
+	OpLike = "like" // SQL LIKE pattern
+	OpIn   = "in"   // In list
+	OpNin  = "nin"  // Not in list
+	OpBt   = "bt"   // Between (inclusive)
+	OpNbt  = "nbt"  // Not between
+)
+
 // FilterValue represents a filter with value and operator
 type FilterValue struct {
 	Value    string
-	Operator string // eq, gt, gte, lt, lte, like, neq (eq is default)
+	Operator string // One of Op* constants (OpEq is default)
 }
 
 // SortField represents a single sort field with direction
@@ -293,7 +308,7 @@ func ParseQueryOptions(query url.Values) *QueryOptions {
 				opts.Filters[field] = FilterValue{Value: value, Operator: op}
 			} else {
 				// Simple filter: filter[field]=value (default eq operator)
-				opts.Filters[inner] = FilterValue{Value: value, Operator: "eq"}
+				opts.Filters[inner] = FilterValue{Value: value, Operator: OpEq}
 			}
 		}
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -208,7 +208,7 @@ func TestQueryOptionsFromContext(t *testing.T) {
 	// Create QueryOptions
 	opts := &QueryOptions{
 		Filters: map[string]FilterValue{
-			"Name": {Value: "test", Operator: "eq"},
+			"Name": {Value: "test", Operator: OpEq},
 		},
 		Sort: []SortField{
 			{Field: "Name", Desc: false},
@@ -537,56 +537,56 @@ func TestParseQueryOptions_Filters(t *testing.T) {
 			query:         url.Values{"filter[name]": {"John"}},
 			expectedField: "name",
 			expectedValue: "John",
-			expectedOp:    "eq",
+			expectedOp:    OpEq,
 		},
 		{
 			name:          "filter with eq operator",
 			query:         url.Values{"filter[status][eq]": {"active"}},
 			expectedField: "status",
 			expectedValue: "active",
-			expectedOp:    "eq",
+			expectedOp:    OpEq,
 		},
 		{
 			name:          "filter with neq operator",
 			query:         url.Values{"filter[status][neq]": {"deleted"}},
 			expectedField: "status",
 			expectedValue: "deleted",
-			expectedOp:    "neq",
+			expectedOp:    OpNeq,
 		},
 		{
 			name:          "filter with gt operator",
 			query:         url.Values{"filter[age][gt]": {"18"}},
 			expectedField: "age",
 			expectedValue: "18",
-			expectedOp:    "gt",
+			expectedOp:    OpGt,
 		},
 		{
 			name:          "filter with gte operator",
 			query:         url.Values{"filter[age][gte]": {"21"}},
 			expectedField: "age",
 			expectedValue: "21",
-			expectedOp:    "gte",
+			expectedOp:    OpGte,
 		},
 		{
 			name:          "filter with lt operator",
 			query:         url.Values{"filter[age][lt]": {"65"}},
 			expectedField: "age",
 			expectedValue: "65",
-			expectedOp:    "lt",
+			expectedOp:    OpLt,
 		},
 		{
 			name:          "filter with lte operator",
 			query:         url.Values{"filter[age][lte]": {"100"}},
 			expectedField: "age",
 			expectedValue: "100",
-			expectedOp:    "lte",
+			expectedOp:    OpLte,
 		},
 		{
 			name:          "filter with like operator",
 			query:         url.Values{"filter[name][like]": {"%john%"}},
 			expectedField: "name",
 			expectedValue: "%john%",
-			expectedOp:    "like",
+			expectedOp:    OpLike,
 		},
 	}
 

--- a/scripts/run-bruno-tests.sh
+++ b/scripts/run-bruno-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Bruno API test runner for go-restgen examples
-# Usage: ./scripts/run-bruno-tests.sh [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|all]
+# Usage: ./scripts/run-bruno-tests.sh [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|all]
 
 set -e
 
@@ -177,6 +177,9 @@ case "$TEST_SUITE" in
     batch)
         run_tests "Batch Example" "examples/batch" "batch-example" || FAILED=1
         ;;
+    query)
+        run_tests "Query Example" "examples/query" "query-example" || FAILED=1
+        ;;
     all)
         run_tests "Simple Example" "examples/simple" "simple-example" || FAILED=1
         run_tests "Nested Example" "examples/nested_routes" "nested-example" || FAILED=1
@@ -190,9 +193,10 @@ case "$TEST_SUITE" in
         run_tests "Files Signed Example" "examples/files_signed" "files-signed-example" || FAILED=1
         run_tests "Actions Example" "examples/actions" "actions-example" || FAILED=1
         run_tests "Batch Example" "examples/batch" "batch-example" || FAILED=1
+        run_tests "Query Example" "examples/query" "query-example" || FAILED=1
         ;;
     *)
-        echo "Usage: $0 [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|all]"
+        echo "Usage: $0 [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|all]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Add `in` (in list), `nin` (not in list), `bt` (between), `nbt` (not between) filter operators
- Implement type-aware filter value conversion using reflection (bool, int, uint, float)
- Add `Op*` constants for filter operators in metadata package
- Add query example app and Bruno test collection with 27 API tests

## Test plan
- [x] Unit tests for all new operators (in, nin, bt, nbt)
- [x] Unit tests for type conversion (bool, int, uint, float, string edge cases)
- [x] Bruno integration tests for all filter operators
- [x] Coverage on new code >80%

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)