### PR TITLE
Add sum query parameter for numeric field aggregation

### DIFF
--- a/bruno/query-example/40-sum-single-field.bru
+++ b/bruno/query-example/40-sum-single-field.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Sum Single Field - Price
+  type: http
+  seq: 40
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Price
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-Price header contains sum of all prices", function() {
+    // Apple=100 + Banana=50 + Carrot=30 + Donut=150 + Eggplant=80 + 123=999 + FalseItem=888 = 2297
+    expect(res.headers['x-sum-price']).to.equal('2297');
+  });
+}

--- a/bruno/query-example/41-sum-multiple-fields.bru
+++ b/bruno/query-example/41-sum-multiple-fields.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Sum Multiple Fields - Price and Stock
+  type: http
+  seq: 41
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Price,Stock
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-Price header contains sum of all prices", function() {
+    // Apple=100 + Banana=50 + Carrot=30 + Donut=150 + Eggplant=80 + 123=999 + FalseItem=888 = 2297
+    expect(res.headers['x-sum-price']).to.equal('2297');
+  });
+
+  test("X-Sum-Stock header contains sum of all stocks", function() {
+    // Apple=50 + Banana=100 + Carrot=200 + Donut=25 + Eggplant=75 + 123=10 + FalseItem=5 = 465
+    expect(res.headers['x-sum-stock']).to.equal('465');
+  });
+}

--- a/bruno/query-example/42-sum-with-filter.bru
+++ b/bruno/query-example/42-sum-with-filter.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Sum with Filter - Fruit category only
+  type: http
+  seq: 42
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=Fruit&sum=Price
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("X-Sum-Price header contains sum of filtered prices only", function() {
+    // Only Fruit products: Apple=100 + Banana=50 = 150
+    expect(res.headers['x-sum-price']).to.equal('150');
+  });
+
+  test("All returned products are Fruit", function() {
+    expect(res.body.every(p => p.category === 'Fruit')).to.be.true;
+  });
+}

--- a/bruno/query-example/43-sum-with-count.bru
+++ b/bruno/query-example/43-sum-with-count.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Sum with Count - Combined query
+  type: http
+  seq: 43
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Price&count=true&limit=2
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+  res.body: length 2
+}
+
+tests {
+  test("X-Sum-Price header contains sum of ALL prices (not just paginated)", function() {
+    // Sum should be for all 7 products, not just the 2 returned
+    expect(res.headers['x-sum-price']).to.equal('2297');
+  });
+
+  test("X-Total-Count header shows total count", function() {
+    expect(res.headers['x-total-count']).to.equal('7');
+  });
+}

--- a/bruno/query-example/44-sum-string-field.bru
+++ b/bruno/query-example/44-sum-string-field.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Sum String Field - Returns 0
+  type: http
+  seq: 44
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Name
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-Name header returns 0 for non-numeric field", function() {
+    // String fields cannot be summed, should return 0
+    expect(res.headers['x-sum-name']).to.equal('0');
+  });
+}

--- a/bruno/query-example/45-sum-bool-field.bru
+++ b/bruno/query-example/45-sum-bool-field.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Sum Bool Field - Returns 0
+  type: http
+  seq: 45
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Active
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-Active header returns 0 for bool field", function() {
+    // Bool fields cannot be summed, should return 0
+    expect(res.headers['x-sum-active']).to.equal('0');
+  });
+}

--- a/bruno/query-example/46-sum-not-allowed-field.bru
+++ b/bruno/query-example/46-sum-not-allowed-field.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Sum Field Not in Allowlist - Returns 0
+  type: http
+  seq: 46
+}
+
+get {
+  url: {{baseUrl}}/products?sum=CreatedAt
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-CreatedAt header returns 0 for non-allowed field", function() {
+    // Field not in SummableFields should return 0 (security - don't reveal field existence)
+    expect(res.headers['x-sum-createdat']).to.equal('0');
+  });
+}

--- a/bruno/query-example/47-sum-mixed-valid-invalid.bru
+++ b/bruno/query-example/47-sum-mixed-valid-invalid.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Sum Mixed Valid and Invalid Fields
+  type: http
+  seq: 47
+}
+
+get {
+  url: {{baseUrl}}/products?sum=Price,Name
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-Price header contains valid sum", function() {
+    // Price is numeric and allowed, should return actual sum
+    expect(res.headers['x-sum-price']).to.equal('2297');
+  });
+
+  test("X-Sum-Name header returns 0 for invalid field", function() {
+    // Name is string, should return 0 but still be present
+    expect(res.headers['x-sum-name']).to.equal('0');
+  });
+}

--- a/bruno/query-example/48-sum-nonexistent-field.bru
+++ b/bruno/query-example/48-sum-nonexistent-field.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Sum Non-Existent Field - Returns 0
+  type: http
+  seq: 48
+}
+
+get {
+  url: {{baseUrl}}/products?sum=FakeField
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+tests {
+  test("X-Sum-FakeField header returns 0 for non-existent field", function() {
+    // Non-existent field should return 0 (security - don't reveal field existence)
+    expect(res.headers['x-sum-fakefield']).to.equal('0');
+  });
+}

--- a/datastore/nested_test.go
+++ b/datastore/nested_test.go
@@ -213,7 +213,7 @@ func TestWrapper_Nested_GetAll(t *testing.T) {
 	ctx1 = context.WithValue(ctx1, metadata.ParentIDsKey, map[string]string{
 		"authorId": itoa(author1.ID),
 	})
-	articles1, _, err := articleWrapper.GetAll(ctx1)
+	articles1, _, _, err := articleWrapper.GetAll(ctx1)
 	if err != nil {
 		t.Fatal("Failed to get articles for author1:", err)
 	}
@@ -226,7 +226,7 @@ func TestWrapper_Nested_GetAll(t *testing.T) {
 	ctx2 = context.WithValue(ctx2, metadata.ParentIDsKey, map[string]string{
 		"authorId": itoa(author2.ID),
 	})
-	articles2, _, err := articleWrapper.GetAll(ctx2)
+	articles2, _, _, err := articleWrapper.GetAll(ctx2)
 	if err != nil {
 		t.Fatal("Failed to get articles for author2:", err)
 	}

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -118,7 +118,7 @@ func TestQuery_Filter_Eq(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -150,7 +150,7 @@ func TestQuery_Filter_Gt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -182,7 +182,7 @@ func TestQuery_Filter_Like(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -208,7 +208,7 @@ func TestQuery_Filter_NotAllowed(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -244,7 +244,7 @@ func TestQuery_Sort_Direction(t *testing.T) {
 			}
 			ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-			results, _, err := wrapper.GetAll(ctx)
+			results, _, _, err := wrapper.GetAll(ctx)
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -283,7 +283,7 @@ func TestQuery_Pagination_Limit(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -310,7 +310,7 @@ func TestQuery_Pagination_Offset(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -344,7 +344,7 @@ func TestQuery_Pagination_LimitAndOffset(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -377,7 +377,7 @@ func TestQuery_Count(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, err := wrapper.GetAll(ctx)
+	results, count, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -409,7 +409,7 @@ func TestQuery_CountWithFilter(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, err := wrapper.GetAll(ctx)
+	results, count, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -438,7 +438,7 @@ func TestQuery_MaxLimitEnforced(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -471,7 +471,7 @@ func TestQuery_DefaultLimit(t *testing.T) {
 	}
 
 	// No explicit limit - should use DefaultLimit (10)
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -503,7 +503,7 @@ func TestQuery_CombinedFilterSortPagination(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, err := wrapper.GetAll(ctx)
+	results, count, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -540,7 +540,7 @@ func TestQuery_Sort_InvalidField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -595,7 +595,7 @@ func TestQuery_DefaultSort_Direction(t *testing.T) {
 			seedQueryProducts(t, wrapper, ctx)
 
 			// No explicit sort - should use DefaultSort
-			results, _, err := wrapper.GetAll(ctx)
+			results, _, _, err := wrapper.GetAll(ctx)
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -631,7 +631,7 @@ func TestQuery_MultipleSort(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -662,7 +662,7 @@ func TestQuery_Filter_Neq(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -694,7 +694,7 @@ func TestQuery_Filter_Gte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -726,7 +726,7 @@ func TestQuery_Filter_Lt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -758,7 +758,7 @@ func TestQuery_Filter_Lte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -790,7 +790,7 @@ func TestQuery_Filter_In(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -822,7 +822,7 @@ func TestQuery_Filter_Nin(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -854,7 +854,7 @@ func TestQuery_Filter_Bt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -887,7 +887,7 @@ func TestQuery_Filter_Nbt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -920,7 +920,7 @@ func TestQuery_Filter_Bool_True(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -953,7 +953,7 @@ func TestQuery_Filter_Bool_False(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1004,7 +1004,7 @@ func TestQuery_Filter_Int_StringValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1037,7 +1037,7 @@ func TestQuery_Filter_String_NumericLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1067,7 +1067,7 @@ func TestQuery_Filter_String_TrueLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1097,7 +1097,7 @@ func TestQuery_Filter_String_FalseLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1127,7 +1127,7 @@ func TestQuery_Filter_Bool_OneValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1160,7 +1160,7 @@ func TestQuery_Filter_Int_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1189,7 +1189,7 @@ func TestQuery_Filter_Bt_SingleValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1259,7 +1259,7 @@ func TestQuery_Filter_Float_Gt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1286,7 +1286,7 @@ func TestQuery_Filter_Float_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1313,7 +1313,7 @@ func TestQuery_Filter_Uint_Gte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1340,7 +1340,7 @@ func TestQuery_Filter_Uint_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1367,7 +1367,7 @@ func TestQuery_Filter_Float_Between(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1408,7 +1408,7 @@ func TestQuery_Filter_Bt_UnknownField(t *testing.T) {
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
 	// This will fail to find the column name, but tests the code path
-	results, _, err := wrapper.GetAll(ctx)
+	results, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		// Expected - field doesn't exist
 		return
@@ -1417,5 +1417,297 @@ func TestQuery_Filter_Bt_UnknownField(t *testing.T) {
 	// If no error, we should get all products since filter couldn't be applied
 	if len(results) != 5 {
 		t.Errorf("Expected 5 products (filter skipped), got %d", len(results))
+	}
+}
+
+// testQueryProductMetaWithSums is metadata with SummableFields configured
+var testQueryProductMetaWithSums = &metadata.TypeMetadata{
+	TypeID:           "query_product_sum_id",
+	TypeName:         "TestQueryProduct",
+	TableName:        "query_products",
+	URLParamUUID:     "productId",
+	ModelType:        reflect.TypeOf(TestQueryProduct{}),
+	FilterableFields: []string{"Name", "Category", "Price", "InStock"},
+	SortableFields:   []string{"Name", "Price", "CreatedAt"},
+	SummableFields:   []string{"Price", "Name", "InStock"}, // Price is numeric, Name is string, InStock is bool
+	DefaultLimit:     10,
+	MaxLimit:         100,
+}
+
+func TestQuery_Sum_SingleField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of Price field
+	opts := &metadata.QueryOptions{
+		Sums: []string{"Price"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Total price: Apple=100 + Banana=50 + Carrot=30 + Donut=150 + Eggplant=80 = 410
+	expectedSum := 410.0
+	if sums["Price"] != expectedSum {
+		t.Errorf("Expected sum of Price to be %v, got %v", expectedSum, sums["Price"])
+	}
+}
+
+func TestQuery_Sum_MultipleFields(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of Price (numeric) and Name (string - should return 0)
+	opts := &metadata.QueryOptions{
+		Sums: []string{"Price", "Name"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Price sum should be 410
+	expectedPriceSum := 410.0
+	if sums["Price"] != expectedPriceSum {
+		t.Errorf("Expected sum of Price to be %v, got %v", expectedPriceSum, sums["Price"])
+	}
+
+	// Name (string) sum should be 0 (non-numeric)
+	if sums["Name"] != 0 {
+		t.Errorf("Expected sum of Name (string) to be 0, got %v", sums["Name"])
+	}
+}
+
+func TestQuery_Sum_WithFilter(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of Price with filter Category=Fruit
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: categoryFruit, Operator: metadata.OpEq},
+		},
+		Sums: []string{"Price"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Only Fruit products: Apple=100 + Banana=50 = 150
+	expectedSum := 150.0
+	if sums["Price"] != expectedSum {
+		t.Errorf("Expected sum of Price (filtered) to be %v, got %v", expectedSum, sums["Price"])
+	}
+}
+
+func TestQuery_Sum_WithCount(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request both count and sum - should be combined into one query
+	opts := &metadata.QueryOptions{
+		CountTotal: true,
+		Sums:       []string{"Price"},
+		Limit:      2, // Pagination shouldn't affect sum/count
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, count, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Results should be limited to 2
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// Count should be total (5)
+	if count != 5 {
+		t.Errorf("Expected count of 5, got %d", count)
+	}
+
+	// Sum should be for all items (410), not just the paginated ones
+	expectedSum := 410.0
+	if sums["Price"] != expectedSum {
+		t.Errorf("Expected sum of Price to be %v, got %v", expectedSum, sums["Price"])
+	}
+}
+
+func TestQuery_Sum_NonNumericField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of Name (string field in allowlist)
+	opts := &metadata.QueryOptions{
+		Sums: []string{"Name"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// String field should return 0 (with slog warning)
+	if sums["Name"] != 0 {
+		t.Errorf("Expected sum of Name (string) to be 0, got %v", sums["Name"])
+	}
+}
+
+func TestQuery_Sum_BoolField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of InStock (bool field in allowlist)
+	opts := &metadata.QueryOptions{
+		Sums: []string{"InStock"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Bool field should return 0 (with slog warning)
+	if sums["InStock"] != 0 {
+		t.Errorf("Expected sum of InStock (bool) to be 0, got %v", sums["InStock"])
+	}
+}
+
+func TestQuery_Sum_FieldNotInAllowlist(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of CreatedAt (not in SummableFields)
+	opts := &metadata.QueryOptions{
+		Sums: []string{"CreatedAt"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Field not in allowlist should return 0 (with slog warning)
+	if sums["CreatedAt"] != 0 {
+		t.Errorf("Expected sum of CreatedAt (not allowed) to be 0, got %v", sums["CreatedAt"])
+	}
+}
+
+func TestQuery_Sum_NonExistentField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of a field that doesn't exist
+	opts := &metadata.QueryOptions{
+		Sums: []string{"NonExistentField"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Non-existent field should return 0 (with slog warning)
+	if sums["NonExistentField"] != 0 {
+		t.Errorf("Expected sum of NonExistentField to be 0, got %v", sums["NonExistentField"])
+	}
+}
+
+func TestQuery_Sum_MixedValidAndInvalid(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Request sum of Price (valid numeric) and Name (invalid string in allowlist)
+	opts := &metadata.QueryOptions{
+		Sums: []string{"Price", "Name"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Price should have valid sum
+	expectedPriceSum := 410.0
+	if sums["Price"] != expectedPriceSum {
+		t.Errorf("Expected sum of Price to be %v, got %v", expectedPriceSum, sums["Price"])
+	}
+
+	// Name should be 0 but still present in response
+	if sums["Name"] != 0 {
+		t.Errorf("Expected sum of Name to be 0, got %v", sums["Name"])
+	}
+}
+
+func TestQuery_Sum_NoSumsRequested(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// No sums requested - should return nil map
+	opts := &metadata.QueryOptions{}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Should return nil or empty map when no sums requested
+	if len(sums) > 0 {
+		t.Errorf("Expected nil or empty sums map when no sums requested, got %v", sums)
 	}
 }

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -41,8 +41,8 @@ type preFetchResult[T any] struct {
 // GetAll retrieves all items of type T from the datastore
 // Filters from context are applied automatically
 // Relations can be loaded via ?include= query parameter (parsed into QueryOptions.Include)
-// Returns items, total count (0 if not requested), and error
-func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, error) {
+// Returns items, total count (0 if not requested), sums (nil if not requested), and error
+func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, error) {
 	ctx, cancel := context.WithTimeout(ctx, w.Store.GetTimeout())
 	defer cancel()
 
@@ -52,19 +52,19 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, error) {
 	// Get metadata from context
 	meta, err := metadata.FromContext(ctx)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	// Apply parent filters and JOINs from metadata
 	query, err = w.applyParentFiltersWithMeta(ctx, query, meta)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	// Apply ownership filter for type T
 	query, err = w.applyOwnershipFilterWithMeta(ctx, query, meta)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	// Get query options from context (optional)
@@ -73,20 +73,20 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, error) {
 	// Apply filters from query options
 	query = w.applyQueryFilters(query, opts, meta)
 
-	// Get total count BEFORE sorting/pagination (if requested)
-	// Use the same query with filters already applied
+	// Compute aggregates (count and/or sums) BEFORE sorting/pagination
 	var totalCount int
-	if opts != nil && opts.CountTotal {
-		totalCount, err = query.Count(ctx)
+	var sums map[string]float64
+	if opts != nil && (opts.CountTotal || len(opts.Sums) > 0) {
+		totalCount, sums, err = w.computeAggregates(ctx, query, opts, meta)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, nil, err
 		}
 	}
 
 	// Apply sorting from query options (or default sort)
 	query = w.applyQuerySorting(query, opts, meta)
 
-	// Apply pagination AFTER count
+	// Apply pagination AFTER aggregates
 	query = w.applyQueryPagination(query, opts, meta)
 
 	// Apply relation includes from query options
@@ -95,16 +95,16 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, error) {
 	if err := query.Scan(ctx); err != nil {
 		// Pass through context errors unchanged
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, 0, err
+			return nil, 0, nil, err
 		}
 		// Check for connection issues
 		if errors.Is(err, sql.ErrConnDone) {
-			return nil, 0, apperrors.ErrUnavailable
+			return nil, 0, nil, apperrors.ErrUnavailable
 		}
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
-	return items, totalCount, nil
+	return items, totalCount, sums, nil
 }
 
 // Get retrieves a single item of type T by ID from the datastore
@@ -839,6 +839,135 @@ func splitStringValues(vals []any) []any {
 		result[i] = strings.TrimSpace(p)
 	}
 	return result
+}
+
+// isNumericField checks if a field on the model type is a numeric type (int, uint, float)
+func isNumericField(modelType reflect.Type, fieldName string) bool {
+	field, found := modelType.FieldByName(fieldName)
+	if !found {
+		return false
+	}
+	switch field.Type.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	}
+	return false
+}
+
+// computeAggregates computes count and/or sum aggregates for the query.
+// When both count and sums are requested, they're combined into a single query.
+// Invalid sum fields (not in allowlist, non-numeric, or non-existent) return 0 with slog warning.
+func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) (int, map[string]float64, error) {
+	var totalCount int
+	var sums map[string]float64
+
+	// Build aggregation query - clone the base query to preserve WHERE conditions
+	aggQuery := w.Store.GetDB().NewSelect().
+		TableExpr("(?) AS subq", query.Clone())
+
+	// Track which fields to actually sum (valid ones)
+	validSumFields := make(map[string]string) // fieldName -> colName
+
+	// Initialize sums map if any sums requested
+	if len(opts.Sums) > 0 {
+		sums = make(map[string]float64)
+
+		for _, field := range opts.Sums {
+			// Initialize all requested fields to 0 (security: don't reveal which fields are valid)
+			sums[field] = 0
+
+			// Check if field is in allowlist
+			if !slices.Contains(meta.SummableFields, field) {
+				slog.Warn("sum requested for field not in SummableFields", "field", field, "type", meta.TypeName)
+				continue
+			}
+
+			// Check if field exists and is numeric
+			if !isNumericField(meta.ModelType, field) {
+				slog.Warn("sum requested for non-numeric field", "field", field, "type", meta.TypeName)
+				continue
+			}
+
+			// Get column name
+			colName, err := fieldToColumnName(meta.ModelType, field)
+			if err != nil {
+				slog.Warn("sum requested for field with invalid column mapping", "field", field, "type", meta.TypeName, "error", err)
+				continue
+			}
+
+			validSumFields[field] = colName
+		}
+	}
+
+	// Build the SELECT clause with aggregates
+	hasCount := opts.CountTotal
+	hasSums := len(validSumFields) > 0
+
+	switch {
+	case hasCount && hasSums:
+		// Both count and sums - combine into one query
+		selectParts := []string{"COUNT(*) AS count"}
+		for field, colName := range validSumFields {
+			selectParts = append(selectParts, fmt.Sprintf("COALESCE(SUM(%s), 0) AS sum_%s", colName, field))
+		}
+		aggQuery = aggQuery.ColumnExpr(strings.Join(selectParts, ", "))
+	case hasCount:
+		// Count only
+		aggQuery = aggQuery.ColumnExpr("COUNT(*) AS count")
+	case hasSums:
+		// Sums only
+		selectParts := []string{}
+		for field, colName := range validSumFields {
+			selectParts = append(selectParts, fmt.Sprintf("COALESCE(SUM(%s), 0) AS sum_%s", colName, field))
+		}
+		aggQuery = aggQuery.ColumnExpr(strings.Join(selectParts, ", "))
+	default:
+		// No valid aggregates - return early
+		return 0, sums, nil
+	}
+
+	// Execute the aggregate query
+	rows, err := aggQuery.Rows(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if rows.Next() {
+		// Build scan destinations based on what we're selecting
+		cols, _ := rows.Columns()
+		scanDests := make([]any, len(cols))
+		results := make(map[string]float64)
+
+		for i, col := range cols {
+			var val float64
+			scanDests[i] = &val
+			results[col] = 0
+		}
+
+		if err := rows.Scan(scanDests...); err != nil {
+			return 0, nil, err
+		}
+
+		// Extract results
+		for i, col := range cols {
+			results[col] = *scanDests[i].(*float64)
+		}
+
+		if opts.CountTotal {
+			totalCount = int(results["count"])
+		}
+
+		for field := range validSumFields {
+			if val, ok := results["sum_"+field]; ok {
+				sums[field] = val
+			}
+		}
+	}
+
+	return totalCount, sums, nil
 }
 
 // applyQueryFilters applies filters from QueryOptions to the query

--- a/datastore/wrapper_test.go
+++ b/datastore/wrapper_test.go
@@ -147,7 +147,7 @@ func TestWrapper_GetAll(t *testing.T) {
 	}
 
 	// Get all users
-	retrieved, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -278,13 +278,27 @@ func TestWrapper_GetAll_Empty(t *testing.T) {
 	wrapper := &datastore.Wrapper[TestUser]{Store: server}
 	ctx := ctxWithMeta(testUserMeta)
 
-	retrieved, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
 
 	if len(retrieved) != 0 {
 		t.Errorf("Expected 0 users, got %d", len(retrieved))
+	}
+}
+
+func TestWrapper_GetAll_NoMetadata(t *testing.T) {
+	server, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestUser]{Store: server}
+	// Use a context without metadata
+	ctx := context.Background()
+
+	_, _, _, err := wrapper.GetAll(ctx)
+	if err == nil {
+		t.Error("Expected error when metadata is missing from context")
 	}
 }
 
@@ -336,7 +350,7 @@ func TestWrapper_GetAll_WithRelations(t *testing.T) {
 
 	// Get all with relations (even though we don't have any relations in this test model)
 	// This tests that the relations parameter is properly handled
-	retrieved, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users with relations:", err)
 	}
@@ -387,7 +401,7 @@ func TestWrapper_Create_UpdateDelete_Lifecycle(t *testing.T) {
 	}
 
 	// GetAll
-	all, _, err := wrapper.GetAll(ctx)
+	all, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -542,7 +556,7 @@ func TestOwnership_SingleField_GetAll(t *testing.T) {
 	ctxWithOwnership := context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctxWithOwnership = context.WithValue(ctxWithOwnership, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, err := wrapper.GetAll(ctxWithOwnership)
+	retrieved, _, _, err := wrapper.GetAll(ctxWithOwnership)
 	if err != nil {
 		t.Fatal("Failed to get blogs:", err)
 	}
@@ -636,7 +650,7 @@ func TestOwnership_MultipleFields_GetAll(t *testing.T) {
 	ctxAlice := context.WithValue(ctxPost, metadata.OwnershipEnforcedKey, true)
 	ctxAlice = context.WithValue(ctxAlice, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, err := postWrapper.GetAll(ctxAlice)
+	retrieved, _, _, err := postWrapper.GetAll(ctxAlice)
 	if err != nil {
 		t.Fatal("Failed to get posts:", err)
 	}
@@ -684,7 +698,7 @@ func TestOwnership_BypassScope_Admin(t *testing.T) {
 	}
 	ctxCharlie = context.WithValue(ctxCharlie, metadata.AuthInfoKey, authInfo)
 
-	retrieved, _, err := wrapper.GetAll(ctxCharlie)
+	retrieved, _, _, err := wrapper.GetAll(ctxCharlie)
 	if err != nil {
 		t.Fatal("Failed to get articles:", err)
 	}
@@ -726,7 +740,7 @@ func TestOwnership_BypassScope_Moderator(t *testing.T) {
 	}
 	ctxDiana = context.WithValue(ctxDiana, metadata.AuthInfoKey, authInfoDiana)
 
-	retrieved, _, err := wrapper.GetAll(ctxDiana)
+	retrieved, _, _, err := wrapper.GetAll(ctxDiana)
 	if err != nil {
 		t.Fatal("Failed to get articles:", err)
 	}
@@ -785,7 +799,7 @@ func TestOwnership_NoOwnershipContext_GetAll(t *testing.T) {
 	}
 
 	// GetAll without ownership enforcement - should get all
-	retrieved, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all blogs:", err)
 	}
@@ -820,7 +834,7 @@ func TestOwnership_TypeWithoutOwnershipConfig(t *testing.T) {
 	ctxAlice := context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctxAlice = context.WithValue(ctxAlice, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, err := wrapper.GetAll(ctxAlice)
+	retrieved, _, _, err := wrapper.GetAll(ctxAlice)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -1737,7 +1751,7 @@ func TestWrapper_UUID_GetAll(t *testing.T) {
 	}
 
 	// Get all blogs
-	blogs, count, err := wrapper.GetAll(ctx)
+	blogs, count, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all blogs:", err)
 	}
@@ -2187,7 +2201,7 @@ func TestInclude_GetAllWithRelation(t *testing.T) {
 	getCtx = context.WithValue(getCtx, metadata.OwnershipEnforcedKey, true)
 	getCtx = context.WithValue(getCtx, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, err := authorWrapper.GetAll(getCtx)
+	retrieved, _, _, err := authorWrapper.GetAll(getCtx)
 	if err != nil {
 		t.Fatal("Failed to get all authors with include:", err)
 	}
@@ -2584,7 +2598,7 @@ func TestWrapper_BatchCreate_Success(t *testing.T) {
 	}
 
 	// Verify items are in the database
-	all, _, err := wrapper.GetAll(ctx)
+	all, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -2720,7 +2734,7 @@ func TestWrapper_BatchDelete_Success(t *testing.T) {
 	}
 
 	// Verify only one remains
-	all, _, err := wrapper.GetAll(ctx)
+	all, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -2808,7 +2822,7 @@ func TestWrapper_BatchCreate_Transactional(t *testing.T) {
 	}
 
 	// Verify transaction was rolled back - no items should be in database
-	all, _, err := wrapper.GetAll(ctx)
+	all, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -2938,7 +2952,7 @@ func TestWrapper_BatchDelete_Transactional(t *testing.T) {
 	}
 
 	// Verify both users still exist (transaction rolled back)
-	all, _, err := wrapper.GetAll(ctx)
+	all, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3073,7 +3087,7 @@ func TestParentOwnership_FiltersByParentOwner(t *testing.T) {
 	taskCtx = context.WithValue(taskCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Bob should see empty results (parent ownership filtered)
-	tasks, _, err := taskWrapper.GetAll(taskCtx)
+	tasks, _, _, err := taskWrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3094,7 +3108,7 @@ func TestParentOwnership_FiltersByParentOwner(t *testing.T) {
 	aliceCtx = context.WithValue(aliceCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Alice should see her tasks
-	tasks, _, err = taskWrapper.GetAll(aliceCtx)
+	tasks, _, _, err = taskWrapper.GetAll(aliceCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3138,7 +3152,7 @@ func TestParentOwnership_AdminBypass(t *testing.T) {
 	// No ParentOwnershipKey set - admin bypasses ownership checks
 
 	// Admin should see all tasks
-	tasks, _, err := taskWrapper.GetAll(adminCtx)
+	tasks, _, _, err := taskWrapper.GetAll(adminCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3204,7 +3218,7 @@ func TestParentOwnership_NoOwnershipFields(t *testing.T) {
 	taskCtx = context.WithValue(taskCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Should see task because parent has no ownership fields to filter on
-	tasks, _, err := taskWrapper.GetAll(taskCtx)
+	tasks, _, _, err := taskWrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3270,7 +3284,7 @@ func TestParentOwnership_MultipleOwnershipFields(t *testing.T) {
 	})
 	aliceCtx = context.WithValue(aliceCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
-	tasks, _, err := taskWrapper.GetAll(aliceCtx)
+	tasks, _, _, err := taskWrapper.GetAll(aliceCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -218,18 +218,18 @@ func customUpdateMe(ctx context.Context, svc *service.Common[User], _ *metadata.
 }
 
 // Custom handler: GetAll tasks filtered by current user
-func customGetMyTasks(ctx context.Context, svc *service.Common[Task], _ *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, error) {
+func customGetMyTasks(ctx context.Context, svc *service.Common[Task], _ *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, error) {
 	if auth == nil {
-		return nil, 0, fmt.Errorf("not authenticated")
+		return nil, 0, nil, fmt.Errorf("not authenticated")
 	}
 	// Get all tasks for current user
 	tasks := []*Task{} // Initialize as empty slice, not nil
 	err := db.GetDB().NewSelect().Model(&tasks).Where("owner_id = ?", auth.UserID).Order("priority DESC", "created_at DESC").Scan(ctx)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	_ = svc
-	return tasks, len(tasks), nil
+	return tasks, len(tasks), nil, nil
 }
 
 // Custom handler: Create task with auto-set owner

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -85,6 +85,7 @@ func main() {
 		router.AllPublic(),
 		router.WithFilters("Name", "Category", "Price", "Stock", "Active"),
 		router.WithSorts("Name", "Category", "Price", "Stock", "CreatedAt"),
+		router.WithSums("Price", "Stock", "Name", "Active"), // Name and Active are non-numeric (return 0)
 		router.WithPagination(20, 100),
 		router.WithDefaultSort("Name"),
 	)
@@ -111,5 +112,8 @@ func main() {
 	fmt.Println("  nin  - Not in list:         filter[Category][nin]=Electronics,Books")
 	fmt.Println("  bt   - Between:             filter[Price][bt]=50,150")
 	fmt.Println("  nbt  - Not between:         filter[Price][nbt]=50,150")
+	fmt.Println("\nAggregation:")
+	fmt.Println("  sum  - Sum numeric fields:  sum=Price,Stock")
+	fmt.Println("         Returns X-Sum-Price and X-Sum-Stock headers")
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -55,14 +55,14 @@ type CustomGetFunc[T any] func(
 ) (*T, error)
 
 // CustomGetAllFunc is the signature for custom GetAll handlers.
-// The custom function receives all parsed/validated inputs and returns items with count.
+// The custom function receives all parsed/validated inputs and returns items with count and sums.
 // Query options are available via metadata.QueryOptionsFromContext(ctx) if needed.
 type CustomGetAllFunc[T any] func(
 	ctx context.Context,
 	svc *service.Common[T],
 	meta *metadata.TypeMetadata,
 	auth *metadata.AuthInfo,
-) ([]*T, int, error)
+) ([]*T, int, map[string]float64, error)
 
 // CustomCreateFunc is the signature for custom Create handlers.
 // The custom function receives the decoded item and optional file data.
@@ -185,7 +185,7 @@ func handleMutationError(w http.ResponseWriter, err error, operation string) {
 
 // StandardGetAll is the default GetAll implementation that calls svc.GetAll.
 // Use this when no custom logic is needed.
-func StandardGetAll[T any](ctx context.Context, svc *service.Common[T], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*T, int, error) {
+func StandardGetAll[T any](ctx context.Context, svc *service.Common[T], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*T, int, map[string]float64, error) {
 	return svc.GetAll(ctx)
 }
 
@@ -223,7 +223,7 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 		opts := metadata.QueryOptionsFromContext(ctx)
 
 		// Call the provided function
-		items, totalCount, err := getAllFunc(ctx, svc, meta, auth)
+		items, totalCount, sums, err := getAllFunc(ctx, svc, meta, auth)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return // Client disconnected, no response needed
@@ -251,6 +251,16 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 		}
 		if opts.Offset > 0 {
 			w.Header().Set("X-Offset", strconv.Itoa(opts.Offset))
+		}
+
+		// Set sum headers
+		for field, value := range sums {
+			headerName := "X-Sum-" + field
+			if value == float64(int64(value)) {
+				w.Header().Set(headerName, strconv.FormatInt(int64(value), 10))
+			} else {
+				w.Header().Set(headerName, strconv.FormatFloat(value, 'f', -1, 64))
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1972,11 +1972,11 @@ func TestCustomGetAll(t *testing.T) {
 	}()
 
 	// Custom function that filters to only return users with ID > 201
-	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, error) {
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
 		// Get all, then filter
-		all, _, err := svc.GetAll(ctx)
+		all, _, _, err := svc.GetAll(ctx)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, nil, err
 		}
 		var filtered []*TestUser
 		for _, u := range all {
@@ -1984,7 +1984,7 @@ func TestCustomGetAll(t *testing.T) {
 				filtered = append(filtered, u)
 			}
 		}
-		return filtered, len(filtered), nil
+		return filtered, len(filtered), nil, nil
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/users", nil)
@@ -2686,5 +2686,217 @@ func TestStandardCreate_CleansUpFileOnDBError(t *testing.T) {
 	// Verify file was cleaned up
 	if len(deletedKeys) == 0 {
 		t.Error("Expected file to be deleted after DB error")
+	}
+}
+
+// TestSumProduct is a test model for sum header tests
+type TestSumProduct struct {
+	bun.BaseModel `bun:"table:sum_products"`
+	ID            int     `bun:"id,pk,autoincrement" json:"id"`
+	Name          string  `bun:"name,notnull" json:"name"`
+	Price         int     `bun:"price,notnull" json:"price"`
+	Rating        float64 `bun:"rating,notnull" json:"rating"`
+	InStock       bool    `bun:"in_stock,notnull" json:"in_stock"`
+}
+
+func TestHandler_GetAll_SumHeaders(t *testing.T) {
+	// Setup: create sum_products table
+	db, _ := datastore.Get()
+	_, err := db.GetDB().NewCreateTable().Model((*TestSumProduct)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create sum_products table:", err)
+	}
+	defer db.GetDB().NewDropTable().Model((*TestSumProduct)(nil)).IfExists().Exec(context.Background())
+
+	// Clean table and reset sequence
+	_, _ = db.GetDB().NewDelete().Model((*TestSumProduct)(nil)).Where("1=1").Exec(context.Background())
+	_, _ = db.GetDB().Exec("DELETE FROM sqlite_sequence WHERE name = 'sum_products'")
+
+	// Insert test data
+	products := []TestSumProduct{
+		{Name: "Apple", Price: 100, Rating: 4.5, InStock: true},
+		{Name: "Banana", Price: 50, Rating: 3.8, InStock: true},
+		{Name: "Carrot", Price: 30, Rating: 4.2, InStock: false},
+	}
+	for _, p := range products {
+		_, err := db.GetDB().NewInsert().Model(&p).Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert test product:", err)
+		}
+	}
+
+	sumMeta := &metadata.TypeMetadata{
+		TypeID:           "test_sum_product_id",
+		TypeName:         "TestSumProduct",
+		TableName:        "sum_products",
+		URLParamUUID:     "id",
+		PKField:          "ID",
+		ModelType:        reflect.TypeOf(TestSumProduct{}),
+		FilterableFields: []string{"Name", "Price", "InStock"},
+		SortableFields:   []string{"Name", "Price"},
+		SummableFields:   []string{"Price", "Rating", "Name", "InStock"},
+		DefaultLimit:     10,
+		MaxLimit:         100,
+	}
+
+	tests := []struct {
+		name            string
+		queryString     string
+		expectedHeaders map[string]string
+	}{
+		{
+			name:        "single integer sum",
+			queryString: "sum=Price",
+			expectedHeaders: map[string]string{
+				"X-Sum-Price": "180", // 100 + 50 + 30
+			},
+		},
+		{
+			name:        "single float sum",
+			queryString: "sum=Rating",
+			expectedHeaders: map[string]string{
+				"X-Sum-Rating": "12.5", // 4.5 + 3.8 + 4.2
+			},
+		},
+		{
+			name:        "multiple sums",
+			queryString: "sum=Price,Rating",
+			expectedHeaders: map[string]string{
+				"X-Sum-Price":  "180",
+				"X-Sum-Rating": "12.5",
+			},
+		},
+		{
+			name:        "non-numeric field returns 0",
+			queryString: "sum=Name",
+			expectedHeaders: map[string]string{
+				"X-Sum-Name": "0",
+			},
+		},
+		{
+			name:        "bool field returns 0",
+			queryString: "sum=InStock",
+			expectedHeaders: map[string]string{
+				"X-Sum-InStock": "0",
+			},
+		},
+		{
+			name:        "mixed valid and invalid",
+			queryString: "sum=Price,Name",
+			expectedHeaders: map[string]string{
+				"X-Sum-Price": "180",
+				"X-Sum-Name":  "0",
+			},
+		},
+		{
+			name:        "sum with count combined",
+			queryString: "sum=Price&count=true",
+			expectedHeaders: map[string]string{
+				"X-Sum-Price":   "180",
+				"X-Total-Count": "3",
+			},
+		},
+		{
+			name:        "sum with filter",
+			queryString: "sum=Price&filter[InStock]=true",
+			expectedHeaders: map[string]string{
+				"X-Sum-Price": "150", // Only Apple(100) + Banana(50)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Use(withMeta(sumMeta))
+			r.Get("/products", handler.GetAll[TestSumProduct](handler.StandardGetAll[TestSumProduct]))
+
+			url := "/products"
+			if tt.queryString != "" {
+				url += "?" + tt.queryString
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+				return
+			}
+
+			// Check expected headers
+			for header, expected := range tt.expectedHeaders {
+				actual := w.Header().Get(header)
+				if actual != expected {
+					t.Errorf("Expected header %s=%s, got %s", header, expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestHandler_GetAll_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		getAllFunc   handler.CustomGetAllFunc[TestUser]
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name: "context canceled",
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+				return nil, 0, nil, context.Canceled
+			},
+			expectedCode: http.StatusOK, // No response written when context is canceled
+		},
+		{
+			name: "context deadline exceeded",
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+				return nil, 0, nil, context.DeadlineExceeded
+			},
+			expectedCode: http.StatusGatewayTimeout,
+			expectedBody: "request timeout",
+		},
+		{
+			name: "service unavailable",
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+				return nil, 0, nil, apperrors.ErrUnavailable
+			},
+			expectedCode: http.StatusServiceUnavailable,
+			expectedBody: "service temporarily unavailable",
+		},
+		{
+			name: "generic error",
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+				return nil, 0, nil, fmt.Errorf("some internal error")
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: "internal server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Use(withMeta(userMeta))
+			r.Get(testUsersPath, handler.GetAll[TestUser](tt.getAllFunc))
+
+			req := httptest.NewRequest(http.MethodGet, testUsersPath, nil)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("Expected status %d, got %d: %s", tt.expectedCode, w.Code, w.Body.String())
+			}
+
+			if tt.expectedBody != "" {
+				body := w.Body.String()
+				if !bytes.Contains([]byte(body), []byte(tt.expectedBody)) {
+					t.Errorf("Expected body to contain '%s', got '%s'", tt.expectedBody, body)
+				}
+			}
+		})
 	}
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -121,6 +121,7 @@ type TypeMetadata struct {
 	// Query options for GetAll
 	FilterableFields []string // Field names allowed for filtering (empty = no filtering)
 	SortableFields   []string // Field names allowed for sorting (empty = no sorting)
+	SummableFields   []string // Field names allowed for sum aggregation (empty = no sums)
 	DefaultSort      string   // Default sort field (prefix with - for descending)
 	DefaultLimit     int      // Default page size (0 = no limit)
 	MaxLimit         int      // Maximum allowed limit (0 = no max)
@@ -179,6 +180,10 @@ func (m *TypeMetadata) Clone() *TypeMetadata {
 		result.SortableFields = make([]string, len(m.SortableFields))
 		copy(result.SortableFields, m.SortableFields)
 	}
+	if len(m.SummableFields) > 0 {
+		result.SummableFields = make([]string, len(m.SummableFields))
+		copy(result.SummableFields, m.SummableFields)
+	}
 
 	// Deep copy map
 	if m.ChildMeta != nil {
@@ -199,6 +204,7 @@ type QueryOptions struct {
 	Offset     int                    // 0 means start from beginning
 	CountTotal bool                   // whether to return total count
 	Include    []string               // relation names to include via ?include=
+	Sums       []string               // field names to compute sum aggregates via ?sum=
 }
 
 // AllowedIncludes maps relation names to whether ownership filtering should be applied.
@@ -354,6 +360,16 @@ func ParseQueryOptions(query url.Values) *QueryOptions {
 			rel = strings.TrimSpace(rel)
 			if rel != "" {
 				opts.Include = append(opts.Include, rel)
+			}
+		}
+	}
+
+	// Parse sum: sum=Field1,Field2
+	if sumStr := query.Get("sum"); sumStr != "" {
+		for _, field := range strings.Split(sumStr, ",") {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				opts.Sums = append(opts.Sums, field)
 			}
 		}
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -9,6 +9,9 @@ import (
 	apperrors "github.com/sjgoldie/go-restgen/errors"
 )
 
+// Test constants
+const testModifiedValue = "Modified"
+
 // Test types
 type TestUser struct {
 	ID   int
@@ -387,8 +390,8 @@ func TestTypeMetadata_Clone(t *testing.T) {
 		}
 
 		// Modify cloned slice and verify original is unchanged
-		cloned.OwnershipFields[0] = "Modified"
-		if original.OwnershipFields[0] == "Modified" {
+		cloned.OwnershipFields[0] = testModifiedValue
+		if original.OwnershipFields[0] == testModifiedValue {
 			t.Error("modifying cloned OwnershipFields affected original - not a deep copy")
 		}
 
@@ -827,5 +830,94 @@ func TestParseQueryOptions_EmptyValues(t *testing.T) {
 	// Should have no filters since value array is empty
 	if len(opts.Filters) != 0 {
 		t.Errorf("Expected 0 filters for empty value array, got %d", len(opts.Filters))
+	}
+}
+
+func TestParseQueryOptions_Sum(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    url.Values
+		expected []string
+	}{
+		{
+			name:     "single sum field",
+			query:    url.Values{"sum": {"Price"}},
+			expected: []string{"Price"},
+		},
+		{
+			name:     "multiple sum fields",
+			query:    url.Values{"sum": {"Price,Stock,Quantity"}},
+			expected: []string{"Price", "Stock", "Quantity"},
+		},
+		{
+			name:     "with spaces",
+			query:    url.Values{"sum": {"Price, Stock"}},
+			expected: []string{"Price", "Stock"},
+		},
+		{
+			name:     "empty sum ignored",
+			query:    url.Values{"sum": {"Price,,Stock"}},
+			expected: []string{"Price", "Stock"},
+		},
+		{
+			name:     "no sum param",
+			query:    url.Values{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ParseQueryOptions(tt.query)
+
+			if len(opts.Sums) != len(tt.expected) {
+				t.Fatalf("Sums: expected %d, got %d", len(tt.expected), len(opts.Sums))
+			}
+
+			for i, exp := range tt.expected {
+				if opts.Sums[i] != exp {
+					t.Errorf("Sums[%d]: expected %q, got %q", i, exp, opts.Sums[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTypeMetadata_Clone_SummableFields(t *testing.T) {
+	original := &TypeMetadata{
+		TypeID:         "test_id",
+		TypeName:       "TestType",
+		SummableFields: []string{"Price", "Stock"},
+	}
+
+	cloned := original.Clone()
+
+	// Verify SummableFields are copied
+	if len(cloned.SummableFields) != len(original.SummableFields) {
+		t.Fatalf("SummableFields length: expected %d, got %d", len(original.SummableFields), len(cloned.SummableFields))
+	}
+	for i, v := range original.SummableFields {
+		if cloned.SummableFields[i] != v {
+			t.Errorf("SummableFields[%d]: expected %q, got %q", i, v, cloned.SummableFields[i])
+		}
+	}
+
+	// Verify it's a deep copy
+	cloned.SummableFields[0] = testModifiedValue
+	if original.SummableFields[0] == testModifiedValue {
+		t.Error("modifying cloned SummableFields affected original - not a deep copy")
+	}
+}
+
+func TestTypeMetadata_Clone_NilSummableFields(t *testing.T) {
+	original := &TypeMetadata{
+		TypeID:   "test_id",
+		TypeName: "TestType",
+	}
+
+	cloned := original.Clone()
+
+	if cloned.SummableFields != nil {
+		t.Error("nil SummableFields should remain nil after clone")
 	}
 }

--- a/router/builder.go
+++ b/router/builder.go
@@ -557,6 +557,9 @@ func mergeQueryConfigs(meta *metadata.TypeMetadata, queryConfigs []QueryConfig) 
 		if len(qc.SortableFields) > 0 {
 			result.SortableFields = qc.SortableFields
 		}
+		if len(qc.SummableFields) > 0 {
+			result.SummableFields = qc.SummableFields
+		}
 		if qc.DefaultSort != "" {
 			result.DefaultSort = qc.DefaultSort
 		}

--- a/router/builder_test.go
+++ b/router/builder_test.go
@@ -1303,7 +1303,7 @@ func TestBuilder_CustomHandlers(t *testing.T) {
 			customGetCalled = true
 			return svc.Get(ctx, id)
 		}),
-		router.WithCustomGetAll(func(ctx context.Context, svc *service.Common[MultiRegItem], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*MultiRegItem, int, error) {
+		router.WithCustomGetAll(func(ctx context.Context, svc *service.Common[MultiRegItem], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*MultiRegItem, int, map[string]float64, error) {
 			customGetAllCalled = true
 			return svc.GetAll(ctx)
 		}),

--- a/router/custom_test.go
+++ b/router/custom_test.go
@@ -33,8 +33,8 @@ func TestWithCustomGet(t *testing.T) {
 }
 
 func TestWithCustomGetAll(t *testing.T) {
-	customFunc := func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, error) {
-		return []*CustomTestModel{{ID: 1, Name: "test"}}, 1, nil
+	customFunc := func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
+		return []*CustomTestModel{{ID: 1, Name: "test"}}, 1, nil, nil
 	}
 
 	config := WithCustomGetAll(customFunc)
@@ -95,8 +95,8 @@ func TestCustomConfigTypesInSwitch(t *testing.T) {
 		return nil, nil
 	})
 
-	getAllConfig := WithCustomGetAll(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, error) {
-		return nil, 0, nil
+	getAllConfig := WithCustomGetAll(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
+		return nil, 0, nil, nil
 	})
 
 	createConfig := WithCustomCreate(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, item CustomTestModel, _ io.Reader, _ filestore.FileMetadata) (*CustomTestModel, error) {
@@ -154,8 +154,8 @@ func TestCustomFuncTypesMatchHandler(t *testing.T) {
 		return nil, nil
 	}
 
-	var _ handler.CustomGetAllFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, error) {
-		return nil, 0, nil
+	var _ handler.CustomGetAllFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
+		return nil, 0, nil, nil
 	}
 
 	var _ handler.CustomCreateFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, item CustomTestModel, _ io.Reader, _ filestore.FileMetadata) (*CustomTestModel, error) {

--- a/router/query.go
+++ b/router/query.go
@@ -4,6 +4,7 @@ package router
 type QueryConfig struct {
 	FilterableFields []string // Field names allowed for filtering
 	SortableFields   []string // Field names allowed for sorting
+	SummableFields   []string // Field names allowed for sum aggregation
 	DefaultSort      string   // Default sort field (prefix with - for descending)
 	DefaultLimit     int      // Default page size (0 = no limit)
 	MaxLimit         int      // Maximum allowed limit (0 = no max)
@@ -41,5 +42,13 @@ func WithPagination(defaultLimit, maxLimit int) QueryConfig {
 func WithDefaultSort(field string) QueryConfig {
 	return QueryConfig{
 		DefaultSort: field,
+	}
+}
+
+// WithSums returns a QueryConfig that enables sum aggregation on the specified fields
+// Only numeric fields (int, float, uint) can be summed; non-numeric fields return 0
+func WithSums(fields ...string) QueryConfig {
+	return QueryConfig{
+		SummableFields: fields,
 	}
 }

--- a/router/query_test.go
+++ b/router/query_test.go
@@ -94,3 +94,36 @@ func TestWithQuery(t *testing.T) {
 		t.Errorf("expected max limit 50, got %d", config.MaxLimit)
 	}
 }
+
+func TestWithSums(t *testing.T) {
+	config := WithSums("Price", "Stock", "Quantity")
+
+	if len(config.SummableFields) != 3 {
+		t.Errorf("expected 3 summable fields, got %d", len(config.SummableFields))
+	}
+	if config.SummableFields[0] != "Price" {
+		t.Errorf("expected first field to be 'Price', got '%s'", config.SummableFields[0])
+	}
+	if config.SummableFields[1] != "Stock" {
+		t.Errorf("expected second field to be 'Stock', got '%s'", config.SummableFields[1])
+	}
+	if config.SummableFields[2] != "Quantity" {
+		t.Errorf("expected third field to be 'Quantity', got '%s'", config.SummableFields[2])
+	}
+}
+
+func TestWithQuery_IncludesSummableFields(t *testing.T) {
+	input := QueryConfig{
+		FilterableFields: []string{"Name"},
+		SummableFields:   []string{"Price", "Stock"},
+	}
+
+	config := WithQuery(input)
+
+	if len(config.SummableFields) != 2 {
+		t.Errorf("expected 2 summable fields, got %d", len(config.SummableFields))
+	}
+	if config.SummableFields[0] != "Price" {
+		t.Errorf("expected first summable field to be 'Price', got '%s'", config.SummableFields[0])
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -25,8 +25,8 @@ type DownloadResult struct {
 }
 
 // GetAll retrieves all items of type T
-// Returns items, total count (0 if not requested), and error
-func (s *Common[T]) GetAll(ctx context.Context) ([]*T, int, error) {
+// Returns items, total count (0 if not requested), sums (nil if not requested), and error
+func (s *Common[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, error) {
 	return s.store.GetAll(ctx)
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -164,7 +164,7 @@ func TestService_GetAll(t *testing.T) {
 				t.Fatal("Failed to create service:", err)
 			}
 
-			items, _, err := svc.GetAll(ctxWithMeta(testModelMeta))
+			items, _, _, err := svc.GetAll(ctxWithMeta(testModelMeta))
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -1054,7 +1054,7 @@ func TestService_BatchDelete(t *testing.T) {
 	}
 
 	// Verify they're gone
-	all, _, err := svc.GetAll(ctx)
+	all, _, _, err := svc.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}


### PR DESCRIPTION
## Description

Adds `?sum=Field1,Field2` query parameter that returns aggregate sums of numeric fields in `X-Sum-*` response headers. 

Key features:
- Invalid fields (non-numeric, not in allowlist, non-existent) return 0 with slog warning for security (don't reveal field existence)
- Count and sum queries are combined into a single SQL query when both requested
- Sums respect filters applied to the request

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `go fmt` and `go vet`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have added Bruno API tests for new example functionality (if applicable)

## Test Coverage

```
total: (statements) 84.4%
```

## Related Issues

Closes #25