### PR TITLE
Update Go toolchain to 1.24.12 to fix stdlib vulnerabilities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Install golangci-lint v2
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Check formatting
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Run go vet
         run: go vet ./...
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Run tests
         run: go test ./metadata ./datastore ./router ./service ./handler ./errors -race -coverprofile=coverage.out

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -261,7 +261,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -303,7 +303,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -346,7 +346,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@v5
   #       with:
-  #         go-version: '1.24.12'
+  #         go-version: '1.24.13'
 
   #     - name: Set up Node
   #       uses: actions/setup-node@v4
@@ -388,7 +388,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -430,7 +430,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -472,7 +472,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -514,7 +514,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -556,7 +556,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.24.13'
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Update `go-version` from `1.24.11` to `1.24.12` across all CI workflows (lint, test, security, release)
- Fixes GO-2026-4341 (memory exhaustion in `net/url`) and GO-2026-4340 (TLS handshake issue in `crypto/tls`)

## Test plan
- [ ] govulncheck CI job passes with no stdlib vulnerabilities

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)