### PR TITLE
Fix nested relation includes auth and update docs (#42)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -46,8 +46,13 @@ func main() {
     logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
     slog.SetDefault(logger)
 
-    db, _ := datastore.NewSQLite(":memory:")
-    datastore.Initialize(db)
+    db, err := datastore.NewSQLite(":memory:")
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := datastore.Initialize(db); err != nil {
+        log.Fatal(err)
+    }
     defer datastore.Cleanup()
 
     db.GetDB().NewCreateTable().Model((*User)(nil)).IfNotExists().Exec(context.Background())
@@ -93,6 +98,7 @@ router.RegisterRoutes[Model](builder, "/path",
     router.AllPublic(),                    // No auth required
     router.AllScoped("admin"),             // Requires "admin" scope for all methods
     router.IsAuthenticated(),              // Just requires valid auth, no scope check
+    router.PublicList(),                   // Only LIST (collection GET) is public
 
     // Per-method auth
     router.AuthConfig{
@@ -116,6 +122,8 @@ router.RegisterRoutes[Model](builder, "/path",
     router.WithPagination(20, 100),
     router.WithDefaultSort("-CreatedAt"),
     router.WithRelationName("Posts"),  // enables ?include=Posts on parent
+    router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock with X-Sum-* headers
+    router.WithAlternatePK("MyPK"),     // when PK field isn't named "ID"
 
     // Custom handlers
     router.WithCustomGet(customGetFn),
@@ -216,7 +224,7 @@ func customGetAll(
     svc *service.Common[User],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*User, int, error) {
+) ([]*User, int, map[string]float64, error) {
     // Custom logic here
     return svc.GetAll(ctx)
 }
@@ -348,7 +356,8 @@ Built-in support on GetAll endpoints:
 | Limit | `?limit=10` | Max results |
 | Offset | `?offset=20` | Skip results |
 | Count | `?count=true` | Include X-Total-Count header |
-| Include | `?include=Posts` | Load relations (requires WithRelationName on child route) |
+| Include | `?include=Posts` or `?include=Posts.Comments` | Load relations (requires WithRelationName on child route). Dot notation for nested. |
+| Sum | `?sum=Price,Stock` | Sum numeric fields, returns X-Sum-Price, X-Sum-Stock headers (requires WithSums) |
 
 **Filter operator details:**
 - `in` - In list: `?filter[Status][in]=active,pending`
@@ -373,7 +382,7 @@ return nil, apperrors.NewValidationError("title cannot be empty")  // 400
 
 ## Logging
 
-Framework uses `slog`. Default level is Error (quiet).
+Framework uses context-aware `slog`. You configure the level in your application.
 
 ```go
 import "log/slog"
@@ -387,7 +396,7 @@ func main() {
 }
 ```
 
-Logs at Warn level: failed operations, missing parameters, decode errors.
+Log levels: Error (DB failures), Warn (auth rejections, validation), Debug (client 4xx errors).
 
 ## Testing Checklist
 
@@ -418,7 +427,9 @@ sqlDB.SetMaxIdleConns(5)
 
 // Pass to go-restgen
 db := datastore.NewPostgresWithDB(sqlDB)
-datastore.Initialize(db)
+if err := datastore.Initialize(db); err != nil {
+    log.Fatal(err)
+}
 
 // IMPORTANT: Cleanup() will NOT close your *sql.DB
 // You must close it yourself when done

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/dbname?ssl
 if err != nil {
     log.Fatal(err)
 }
-datastore.Initialize(db)
+if err := datastore.Initialize(db); err != nil {
+    log.Fatal(err)
+}
 defer datastore.Cleanup()
 ```
 
@@ -75,7 +77,9 @@ db, err := datastore.NewSQLite(":memory:")
 if err != nil {
     log.Fatal(err)
 }
-datastore.Initialize(db)
+if err := datastore.Initialize(db); err != nil {
+    log.Fatal(err)
+}
 defer datastore.Cleanup()
 
 // Or file-based database
@@ -103,7 +107,9 @@ sqlDB.SetMaxIdleConns(5)
 
 // Pass to go-restgen
 db := datastore.NewPostgresWithDB(sqlDB)
-datastore.Initialize(db)
+if err := datastore.Initialize(db); err != nil {
+    log.Fatal(err)
+}
 
 // IMPORTANT: You own the connection - close it yourself when done
 defer sqlDB.Close()
@@ -164,6 +170,23 @@ type Post struct {
 ```
 
 See the [UUID example](./examples/uuid_pk) for a complete working example with UUID primary keys and nested routes.
+
+### Alternate Primary Key Field Name
+
+By convention, go-restgen assumes the primary key field is named `ID`. Use `WithAlternatePK` when your model uses a different field name:
+
+```go
+type MyModel struct {
+    bun.BaseModel `bun:"table:my_models"`
+    MyPK          int    `bun:"my_pk,pk,autoincrement" json:"my_pk"`
+    Name          string `bun:"name" json:"name"`
+}
+
+router.RegisterRoutes[MyModel](b, "/models",
+    router.AllPublic(),
+    router.WithAlternatePK("MyPK"),
+)
+```
 
 ## Nested Resources
 
@@ -267,7 +290,7 @@ router.RegisterRoutes[Author](b, "/authors",
 - **Unknown relation names are silently ignored** - for security, no error is returned
 - **Works with GET, LIST, and Actions** - `/authors/1?include=Posts`, `/authors?include=Posts`, and `/orders/1/complete?include=Items`
 - **Does not work with Batch operations** - batch create/update return items without relations (reload separately if needed)
-- **Nested includes not supported** - only direct children can be included
+- **Nested includes supported** - use dot notation for deeper relations: `?include=Posts.Comments`
 
 See the [relations example](./examples/relations) for a complete working example.
 
@@ -567,7 +590,10 @@ router.RegisterRoutes[Post](b, "/posts",
 
 ```go
 // HTTP Methods
-router.MethodGet, router.MethodPost, router.MethodPut, router.MethodDelete, router.MethodAll
+router.MethodGet     // Single item: GET /resources/{id}
+router.MethodList    // Collection: GET /resources
+router.MethodPost, router.MethodPut, router.MethodDelete
+router.MethodAll     // Expands to Get, List, Post, Put, Delete (excludes batch)
 
 // Special Scopes
 router.ScopePublic    // "__restgen_public__" - No auth required
@@ -575,6 +601,22 @@ router.ScopeAuthOnly  // "__restgen_auth_only__" - Auth required, no scope check
 
 // Context Key
 router.AuthInfoKey  // "authInfo" - Key for AuthInfo in context
+```
+
+### Auth Helper Functions
+
+```go
+router.AllPublic()                                          // All methods public
+router.AllScoped("admin")                                   // All methods require scope
+router.IsAuthenticated()                                    // All methods require auth, no scope check
+router.AllWithOwnershipUnless([]string{"UserID"}, "admin")  // Ownership with bypass
+
+router.PublicReadOnly()    // GET + LIST public
+router.PublicGet()         // GET single item public
+router.PublicList()        // LIST collection public
+
+router.AllPublicWithBatch()          // All methods + batch public
+router.AllScopedWithBatch("admin")   // All methods + batch require scope
 ```
 
 ## Query Parameters: Filtering, Sorting & Pagination
@@ -670,6 +712,37 @@ GET /users?limit=10&offset=20&count=true
 
 **Response Headers:**
 - `X-Total-Count` - Total number of records (before pagination)
+
+### Sum Aggregation
+
+Request sum totals for numeric fields using the `sum` query parameter:
+
+```go
+router.RegisterRoutes[Product](b, "/products",
+    router.AllPublic(),
+    router.WithFilters("Category", "Price"),
+    router.WithSums("Price", "Stock"),  // Allow summing these fields
+)
+```
+
+```bash
+# Sum a single field
+GET /products?sum=Price
+
+# Sum multiple fields
+GET /products?sum=Price,Stock
+
+# Combine with filters
+GET /products?filter[Category]=Electronics&sum=Price,Stock&count=true
+```
+
+**Response Headers:**
+- `X-Sum-Price` - Sum of the Price field across matching records
+- `X-Sum-Stock` - Sum of the Stock field across matching records
+
+Non-numeric fields (strings, bools) return 0 in the sum header. Fields not listed in `WithSums` are silently ignored.
+
+See the [query example](./examples/query) for a complete working example with all filter operators, sorting, pagination, and sum aggregation.
 
 ### Complete Example
 
@@ -966,7 +1039,7 @@ type CustomGetAllFunc[T any] func(
     svc *service.Common[T],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*T, int, error)
+) ([]*T, int, map[string]float64, error)
 
 // CustomCreateFunc - for POST /resource
 // Includes file parameters for file resource support (nil for regular JSON requests).
@@ -1044,14 +1117,14 @@ router.RegisterRoutes[Task](b, "/tasks",
 ### Example: Filter GetAll by Owner
 
 ```go
-func customGetMyTasks(ctx context.Context, svc *service.Common[Task], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, error) {
+func customGetMyTasks(ctx context.Context, svc *service.Common[Task], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, error) {
     if auth == nil {
-        return nil, 0, fmt.Errorf("not authenticated")
+        return nil, 0, nil, fmt.Errorf("not authenticated")
     }
     // Return only tasks owned by current user
     tasks := []*Task{}
     err := db.GetDB().NewSelect().Model(&tasks).Where("owner_id = ?", auth.UserID).Scan(ctx)
-    return tasks, len(tasks), err
+    return tasks, len(tasks), nil, err
 }
 
 router.RegisterRoutes[Task](b, "/my-tasks",
@@ -1562,15 +1635,19 @@ Service Layer (Business Logic)
     ↓
 Datastore Layer (Database Operations)
     ↓
-Database (PostgreSQL via Bun ORM)
+Database (PostgreSQL / SQLite via Bun ORM)
 ```
 
 ### Packages
 
-- **`router`** - Convenience functions for registering routes
-- **`handler`** - HTTP handlers for CRUD operations
+- **`router`** - Route registration, auth middleware, query config helpers
+- **`handler`** - HTTP handlers for CRUD, batch, action, and file operations
 - **`service`** - Business logic and CRUD services
-- **`datastore`** - Generic database operations
+- **`datastore`** - Generic database operations with filtering, sorting, pagination
+- **`metadata`** - Type metadata, validation context, audit context
+- **`errors`** - Domain error types (ErrNotFound, ErrDuplicate, etc.)
+- **`filestore`** - File storage interface and FileFields embed
+- **`metrics`** - Optional OTEL metrics middleware
 
 ## Custom Database Implementation
 
@@ -1681,7 +1758,9 @@ import "github.com/sjgoldie/go-restgen/metrics"
 
 func main() {
     // Initialize with your meter provider (or nil for global)
-    metrics.Initialize(meterProvider)
+    if err := metrics.Initialize(meterProvider); err != nil {
+        log.Fatal(err)
+    }
 
     r := chi.NewRouter()
     r.Use(metrics.Middleware())
@@ -1710,7 +1789,8 @@ If OTEL is not configured, metrics are no-ops with negligible overhead.
 
 ```go
 // Register standard CRUD
-router.RegisterCRUD[User](r, "/users")
+b := router.NewBuilder(r)
+router.RegisterRoutes[User](b, "/users", router.AllPublic())
 
 // Add custom endpoints
 r.Post("/users/bulk", bulkCreateHandler)
@@ -1729,7 +1809,7 @@ func myCustomHandler(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    users, err := svc.GetAll(r.Context(), []string{})
+    users, _, _, err := svc.GetAll(r.Context())
     // ... handle response
 }
 ```
@@ -1744,6 +1824,7 @@ See the [`examples/`](./examples) directory for complete working examples:
 - **[Authentication & Authorization](./examples/auth)** - Comprehensive auth patterns including scopes, ownership, admin bypass, and multi-ownership
 - **[Validation](./examples/validator)** - Business rule validation with state machine transitions
 - **[Audit](./examples/audit)** - Audit logging with transactional consistency
+- **[Query Parameters](./examples/query)** - Comprehensive filtering, sorting, pagination, and sum aggregation
 - **[Relations](./examples/relations)** - Loading related resources via `?include=` with auth
 - **[File Upload (Proxy)](./examples/files_proxy)** - File upload/download with proxy mode (files stream through server)
 - **[File Upload (Signed URL)](./examples/files_signed)** - File upload/download with signed URL mode (direct to storage)
@@ -1773,7 +1854,9 @@ func TestMyHandler(t *testing.T) {
     }
 
     // Initialize datastore
-    datastore.Initialize(db)
+    if err := datastore.Initialize(db); err != nil {
+        t.Fatal(err)
+    }
     defer datastore.Cleanup()
 
     // Create test tables
@@ -1791,11 +1874,17 @@ func TestMyHandler(t *testing.T) {
 Run tests (excluding examples):
 
 ```bash
-go test ./metadata ./datastore ./router ./service ./handler ./errors -coverprofile=/tmp/coverage.out
+go test ./metadata ./datastore ./router ./service ./handler ./errors ./filestore ./metrics -coverprofile=/tmp/coverage.out
 go tool cover -func=/tmp/coverage.out
 ```
 
-For end-to-end API testing, see the [Bruno tests](./bruno/README.md) with 58 comprehensive API tests covering filtering, sorting, pagination, and ownership.
+For end-to-end API testing, see the [Bruno tests](./bruno/README.md) with 246 API tests across 13 example applications.
+
+You can override the default port (8080) using the `PORT` environment variable:
+
+```bash
+PORT=9090 ./scripts/run-bruno-tests.sh all
+```
 
 ## Dependencies
 
@@ -1836,7 +1925,7 @@ cd go-restgen
 ./scripts/setup-hooks.sh
 
 # Run tests
-go test ./metadata ./datastore ./router ./service ./handler ./errors
+go test ./metadata ./datastore ./router ./service ./handler ./errors ./filestore ./metrics
 
 # Run linting
 golangci-lint run

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -33,11 +33,23 @@ The easiest way to run all Bruno tests is using the automated script:
 # Run all example tests
 ./scripts/run-bruno-tests.sh all
 
+# Override port (default 8080)
+PORT=9090 ./scripts/run-bruno-tests.sh all
+
 # Run specific example tests
 ./scripts/run-bruno-tests.sh simple
 ./scripts/run-bruno-tests.sh nested
-./scripts/run-bruno-tests.sh uuid
 ./scripts/run-bruno-tests.sh auth
+./scripts/run-bruno-tests.sh validator
+./scripts/run-bruno-tests.sh audit
+./scripts/run-bruno-tests.sh uuid
+./scripts/run-bruno-tests.sh custom
+./scripts/run-bruno-tests.sh relations
+./scripts/run-bruno-tests.sh files-proxy
+./scripts/run-bruno-tests.sh files-signed
+./scripts/run-bruno-tests.sh actions
+./scripts/run-bruno-tests.sh batch
+./scripts/run-bruno-tests.sh query
 ```
 
 The script automatically:
@@ -52,7 +64,7 @@ The script automatically:
 
 1. Start one of the example servers (see sections below)
 2. Open Bruno GUI
-3. Navigate to the example folder (simple-example, nested-example, or auth-example)
+3. Navigate to the desired example folder
 4. Click "Run Collection" to run all tests
 
 ### Using Bruno CLI (Manual)
@@ -77,6 +89,10 @@ bru run bruno/simple-example --env local
 bru run bruno/simple-example --env local --reporter json
 bru run bruno/simple-example --env local --reporter junit
 bru run bruno/simple-example --env local --reporter html
+
+# Note: Bruno v3+ defaults to safe sandbox mode.
+# Use --sandbox=developer for tests that use bru.setVar() or script blocks:
+bru run bruno/simple-example --env local --sandbox=developer
 ```
 
 ---
@@ -150,7 +166,7 @@ go run main.go
 - Open the `auth-example` folder
 - Click "Run Collection" to run all tests in sequence
 
-**Tests cover (25 tests):**
+**Tests cover (48 tests):**
 1. **Articles** - Public reads, publisher-only writes
 2. **Blogs** - Ownership filtering with query parameters:
    - Users see only their blogs, admin sees all
@@ -160,6 +176,12 @@ go run main.go
 3. **Posts** - Multi-ownership (accessible by author OR editor)
 4. **Comments** - Mixed auth (GET is public, POST/PUT/DELETE require auth)
 5. **Reports** - MethodList vs MethodGet differentiation
+6. **Parent ownership cascade** - Nested resources blocked when parent ownership fails
+7. **Relation includes with auth** - `?include=Posts`, `?include=Posts.Comments`, `?include=Blog`:
+   - Owner includes child/parent relations
+   - Admin bypasses ownership on includes
+   - No auth blocked (401)
+   - Nested includes through ownership chain
 
 **Test users (bearer tokens):**
 - `user:alice:user` - Regular user
@@ -218,9 +240,127 @@ go run main.go
 - Old and new state captured
 - Audit runs in same transaction
 
+### Query Example Tests
+
+Tests comprehensive filtering, sorting, pagination, and sum aggregation.
+
+**Start the server:**
+```bash
+cd examples/query
+go run main.go
+```
+
+**Tests cover (36 tests):**
+- All filter operators (eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt)
+- Combined filters with sort and pagination
+- Boolean and string edge cases
+- Sum aggregation (single, multiple, with filters, with count)
+- Sum of non-numeric fields (returns 0)
+- Sum of non-allowed and non-existent fields
+
+### Custom Handlers Example Tests
+
+Tests custom handler overrides for Get, GetAll, Create, Update, Delete.
+
+**Start the server:**
+```bash
+cd examples/custom
+go run main.go
+```
+
+**Tests cover (16 tests):**
+- Custom `/me` endpoint (get/update current user)
+- Custom GetAll filtering by owner
+- Custom update with validation logic
+- Custom delete prevention (audit logs)
+
+### Relations Example Tests
+
+Tests relation includes (`?include=`) and single routes (belongs-to).
+
+**Start the server:**
+```bash
+cd examples/relations
+go run main.go
+```
+
+**Tests cover (23 tests):**
+- Include child relations (has-many)
+- Include parent relations (belongs-to)
+- Multiple includes, invalid includes (silently ignored)
+- Ownership filtering on includes
+- Single routes (GET/PUT) for belongs-to relations
+- `/me` endpoint with custom get/update
+- Method restrictions on single routes (no POST/DELETE)
+
+### Files Proxy Example Tests
+
+Tests file upload/download with proxy mode (files stream through server).
+
+**Start the server:**
+```bash
+cd examples/files_proxy
+go run main.go
+```
+
+**Tests cover (13 tests):**
+- Upload files via multipart form
+- Get file metadata
+- List files
+- Download via `/download` endpoint (proxy mode)
+- Delete files
+
+### Files Signed URL Example Tests
+
+Tests file upload/download with signed URL mode (direct download from storage).
+
+**Start the server:**
+```bash
+cd examples/files_signed
+go run main.go
+```
+
+**Tests cover (13 tests):**
+- Upload files via multipart form
+- Get file metadata with `download_url` pointing to storage
+- Download via signed URL (direct)
+- Delete files
+
+### Actions Example Tests
+
+Tests custom action endpoints on resources.
+
+**Start the server:**
+```bash
+cd examples/actions
+go run main.go
+```
+
+**Tests cover (12 tests):**
+- Cancel and complete actions on orders
+- Invalid state transitions rejected
+- Action on non-existent resource (404)
+- Action with `?include=` on response
+
+### Batch Example Tests
+
+Tests bulk create, update, and delete operations.
+
+**Start the server:**
+```bash
+cd examples/batch
+go run main.go
+```
+
+**Tests cover (14 tests):**
+- Batch create, update, delete
+- Empty batch handling
+- Batch update/delete with non-existent IDs
+- Batch create with `?include=` on response
+
 ## Test Coverage
 
-**Total: 96 end-to-end API tests** across all example applications.
+**Total: 246 end-to-end API tests** across 13 example applications.
 
 These Bruno tests provide **end-to-end API coverage** for the example applications. They complement the unit tests by:
 

--- a/bruno/auth-example/40-include-child-posts.bru
+++ b/bruno/auth-example/40-include-child-posts.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Include - Child Posts (Owner)
+  type: http
+  seq: 40
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}?include=Posts
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: isDefined
+  res.body.posts: isDefined
+}
+
+tests {
+  test("Owner can include child Posts on Blog", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.posts).to.be.an('array');
+    expect(res.body.posts.length).to.be.greaterThan(0);
+    expect(res.body.posts[0].title).to.be.a('string');
+  });
+}

--- a/bruno/auth-example/41-include-nested-child-comments.bru
+++ b/bruno/auth-example/41-include-nested-child-comments.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Include - Nested Child Posts.Comments (Owner)
+  type: http
+  seq: 41
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}?include=Posts.Comments
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: isDefined
+  res.body.posts: isDefined
+}
+
+tests {
+  test("Owner can include nested child Posts.Comments on Blog", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.posts).to.be.an('array');
+    expect(res.body.posts.length).to.be.greaterThan(0);
+    expect(res.body.posts[0].comments).to.be.an('array');
+    expect(res.body.posts[0].comments.length).to.be.greaterThan(0);
+    expect(res.body.posts[0].comments[0].text).to.be.a('string');
+  });
+}

--- a/bruno/auth-example/42-include-parent-blog.bru
+++ b/bruno/auth-example/42-include-parent-blog.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Include - Parent Blog on Post (Owner)
+  type: http
+  seq: 42
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}/posts/{{alicePostId}}?include=Blog
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: isDefined
+  res.body.blog: isDefined
+}
+
+tests {
+  test("Owner can include parent Blog on Post", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.blog).to.be.an('object');
+    expect(res.body.blog.name).to.equal("Alice's Blog");
+  });
+}

--- a/bruno/auth-example/43-include-parent-post-on-comment.bru
+++ b/bruno/auth-example/43-include-parent-post-on-comment.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Include - Parent Post on Comment (Owner)
+  type: http
+  seq: 43
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}/posts/{{alicePostId}}/comments/{{commentId}}?include=Post
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: isDefined
+  res.body.post: isDefined
+}
+
+tests {
+  test("Owner can include parent Post on Comment", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.post).to.be.an('object');
+    expect(res.body.post.title).to.equal("Alice's First Post");
+  });
+}

--- a/bruno/auth-example/44-include-child-posts-admin.bru
+++ b/bruno/auth-example/44-include-child-posts-admin.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Include - Child Posts as Admin (Bypasses Ownership)
+  type: http
+  seq: 44
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}?include=Posts
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:bob:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: isDefined
+  res.body.posts: isDefined
+}
+
+tests {
+  test("Admin can include child Posts and bypasses ownership", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.posts).to.be.an('array');
+    expect(res.body.posts.length).to.be.greaterThan(0);
+  });
+}

--- a/bruno/auth-example/45-include-child-posts-no-auth.bru
+++ b/bruno/auth-example/45-include-child-posts-no-auth.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Include - Child Posts No Auth (Blocked)
+  type: http
+  seq: 45
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}?include=Posts
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 401
+}
+
+docs {
+  Blog has ownership configured (AuthorID).
+  Accessing without auth returns 401 before include logic runs.
+}

--- a/bruno/auth-example/46-include-nested-comments-no-auth.bru
+++ b/bruno/auth-example/46-include-nested-comments-no-auth.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Include - Nested Posts.Comments No Auth (Blocked)
+  type: http
+  seq: 46
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}?include=Posts.Comments
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 401
+}
+
+docs {
+  Blog has ownership configured (AuthorID).
+  Accessing without auth returns 401 before nested include logic runs.
+  Even though Comments have PublicReadOnly(), the parent Blog blocks first.
+}

--- a/bruno/auth-example/47-include-parent-blog-no-auth.bru
+++ b/bruno/auth-example/47-include-parent-blog-no-auth.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Include - Parent Blog on Post No Auth (Blocked)
+  type: http
+  seq: 47
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}/posts/{{alicePostId}}?include=Blog
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 401
+}
+
+docs {
+  Post has ownership configured (AuthorID, EditorID).
+  Blog parent also has ownership (AuthorID).
+  Accessing without auth returns 401 due to parent ownership checks.
+}

--- a/bruno/auth-example/48-include-parent-post-no-auth.bru
+++ b/bruno/auth-example/48-include-parent-post-no-auth.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Include - Parent Post on Comment No Auth (Blocked)
+  type: http
+  seq: 48
+}
+
+get {
+  url: {{baseUrl}}/blogs/{{aliceBlogId}}/posts/{{alicePostId}}/comments/{{commentId}}?include=Post
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 401
+}
+
+docs {
+  Even though Comment GET has PublicReadOnly(), parent ownership checks
+  cascade from Blog (AuthorID) and Post (AuthorID, EditorID).
+  Accessing without auth returns 401 due to parent chain ownership.
+}

--- a/examples/actions/main.go
+++ b/examples/actions/main.go
@@ -200,5 +200,9 @@ func main() {
 	fmt.Println("")
 	fmt.Println("  # Or complete the order")
 	fmt.Println("  curl -X POST http://localhost:8080/orders/1/complete")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/audit/main.go
+++ b/examples/audit/main.go
@@ -179,5 +179,9 @@ func main() {
 	fmt.Println("")
 	fmt.Println("  # View audit log again to see all operations")
 	fmt.Println("  curl http://localhost:8080/audit-logs")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -72,7 +72,7 @@ type Blog struct {
 	Status        string    `bun:"status,notnull,default:'draft'" json:"status"` // draft, published, archived
 	CreatedAt     time.Time `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
 	UpdatedAt     time.Time `bun:"updated_at,notnull" json:"updated_at,omitempty"`
-	Posts         []*Post   `bun:"rel:has-many,join:id=blog_id" json:"-"`
+	Posts         []*Post   `bun:"rel:has-many,join:id=blog_id" json:"posts,omitempty"`
 }
 
 func (b *Blog) BeforeAppendModel(ctx context.Context, query bun.Query) error {
@@ -92,14 +92,14 @@ type Post struct {
 	bun.BaseModel `bun:"table:posts"`
 	ID            int        `bun:"id,pk,autoincrement" json:"id"`
 	BlogID        int        `bun:"blog_id,notnull,skipupdate" json:"blog_id"`
-	Blog          *Blog      `bun:"rel:belongs-to,join:blog_id=id" json:"-"`
+	Blog          *Blog      `bun:"rel:belongs-to,join:blog_id=id" json:"blog,omitempty"`
 	AuthorID      string     `bun:"author_id,notnull" json:"author_id"` // Owner field 1
 	EditorID      string     `bun:"editor_id" json:"editor_id"`         // Owner field 2 (optional)
 	Title         string     `bun:"title,notnull" json:"title"`
 	Content       string     `bun:"content" json:"content"`
 	CreatedAt     time.Time  `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
 	UpdatedAt     time.Time  `bun:"updated_at,notnull" json:"updated_at,omitempty"`
-	Comments      []*Comment `bun:"rel:has-many,join:id=post_id" json:"-"`
+	Comments      []*Comment `bun:"rel:has-many,join:id=post_id" json:"comments,omitempty"`
 }
 
 func (p *Post) BeforeAppendModel(ctx context.Context, query bun.Query) error {
@@ -119,7 +119,7 @@ type Comment struct {
 	bun.BaseModel `bun:"table:comments"`
 	ID            int       `bun:"id,pk,autoincrement" json:"id"`
 	PostID        int       `bun:"post_id,notnull,skipupdate" json:"post_id"`
-	Post          *Post     `bun:"rel:belongs-to,join:post_id=id" json:"-"`
+	Post          *Post     `bun:"rel:belongs-to,join:post_id=id" json:"post,omitempty"`
 	AuthorName    string    `bun:"author_name,notnull" json:"author_name"`
 	Text          string    `bun:"text,notnull" json:"text"`
 	CreatedAt     time.Time `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
@@ -302,11 +302,13 @@ func main() {
 			// Post - multiple ownership fields (AuthorID OR EditorID), admin bypass
 			router.RegisterRoutes[Post](b, "/posts",
 				router.AllWithOwnershipUnless([]string{"AuthorID", "EditorID"}, "admin"),
+				router.WithRelationName("Posts"),
 				func(b *router.Builder) {
 					// Comment - MethodAll override: default auth-only, but GET is public
 					router.RegisterRoutes[Comment](b, "/comments",
 						router.IsAuthenticated(), // Default: all methods require auth
 						router.PublicReadOnly(),  // Override: GET is public
+						router.WithRelationName("Comments"),
 					)
 				},
 			)
@@ -374,5 +376,9 @@ func main() {
 	fmt.Println("   DELETE /reports/{id}       (requires auth)")
 	fmt.Println("\nSee README.md for complete curl examples")
 
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -142,5 +142,9 @@ func main() {
 	fmt.Println("  # Batch delete products (just need id)")
 	fmt.Println("  curl -X DELETE http://localhost:8080/products/batch -H 'Content-Type: application/json' \\")
 	fmt.Println("    -d '[{\"id\": 1}, {\"id\": 2}]'")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -377,5 +377,9 @@ func main() {
 	fmt.Println("   DELETE /audit-logs/{id} -> Always returns error")
 	fmt.Println("\nTest user seeded: alice (external_id: alice)")
 
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/files_proxy/main.go
+++ b/examples/files_proxy/main.go
@@ -155,5 +155,9 @@ func main() {
 	fmt.Println(`  curl -X POST http://localhost:8080/posts/1/images \`)
 	fmt.Println(`    -F "file=@image.png" \`)
 	fmt.Println(`    -F 'metadata={"alt_text":"My image"}'`)
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/files_signed/main.go
+++ b/examples/files_signed/main.go
@@ -160,5 +160,9 @@ func main() {
 	fmt.Println(`  curl -X POST http://localhost:8080/posts/1/images \`)
 	fmt.Println(`    -F "file=@image.png" \`)
 	fmt.Println(`    -F 'metadata={"alt_text":"My image"}'`)
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/nested_routes/main.go
+++ b/examples/nested_routes/main.go
@@ -181,5 +181,9 @@ func main() {
 	fmt.Println("  POST /users/1/posts/1/comments")
 	fmt.Println("       {\"text\": \"Great post\", \"author\": \"Bob\"}")
 	fmt.Println("  GET /users/1/posts/1/comments")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -115,5 +115,9 @@ func main() {
 	fmt.Println("\nAggregation:")
 	fmt.Println("  sum  - Sum numeric fields:  sum=Price,Stock")
 	fmt.Println("         Returns X-Sum-Price and X-Sum-Stock headers")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/relations/main.go
+++ b/examples/relations/main.go
@@ -270,5 +270,9 @@ func main() {
 	fmt.Println("\nUse AsSingleRoute() for belongs-to relations that return a single object.")
 	fmt.Println("The child's ID is resolved from the parent's relation field.")
 
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -112,5 +112,9 @@ func main() {
 	fmt.Println("  curl 'http://localhost:8080/users?filter[Name]=Alice'")
 	fmt.Println("  curl 'http://localhost:8080/users?sort=-CreatedAt&limit=10'")
 	fmt.Println("  curl 'http://localhost:8080/users?limit=10&offset=20&count=true'")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/uuid_pk/main.go
+++ b/examples/uuid_pk/main.go
@@ -158,5 +158,9 @@ func main() {
 	fmt.Println("  curl http://localhost:8080/blogs")
 	fmt.Println("\n  # Create a post under a blog (replace {uuid} with actual blog ID)")
 	fmt.Println("  curl -X POST http://localhost:8080/blogs/{uuid}/posts -H 'Content-Type: application/json' -d '{\"title\":\"First Post\",\"content\":\"Hello World\"}'")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/examples/validator/main.go
+++ b/examples/validator/main.go
@@ -190,5 +190,9 @@ func main() {
 	fmt.Println("  # Transition from pending to in_progress")
 	fmt.Println("  curl -X PUT http://localhost:8080/tasks/1 -H 'Content-Type: application/json' \\")
 	fmt.Println("    -d '{\"title\": \"My Task\", \"status\": \"in_progress\", \"priority\": 3}'")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }

--- a/router/auth.go
+++ b/router/auth.go
@@ -43,6 +43,16 @@ type AuthConfig struct {
 	// Populated automatically when child routes are registered with WithRelationName().
 	// Key is the relation name (e.g., "Posts"), value is the child's merged auth config for MethodGet.
 	ChildAuth map[string]*AuthConfig
+
+	// ParentAuth points to the parent route's GET auth config (for ?include= authorization of
+	// parent types in the belongs-to direction). Forms a linked list up the parent chain.
+	// Populated automatically during route registration.
+	ParentAuth *AuthConfig
+
+	// ParentIncludeName is the belongs-to relation field name used in ?include= paths
+	// (e.g., "Author" for a Post that belongs to Author). Derived from the model's struct
+	// field during route registration.
+	ParentIncludeName string
 }
 
 // OwnershipConfig defines ownership validation rules.

--- a/router/auth_middleware.go
+++ b/router/auth_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/sjgoldie/go-restgen/metadata"
 )
@@ -67,16 +68,19 @@ func wrapWithAuth(next http.Handler, config *AuthConfig) http.Handler {
 		// Extract AuthInfo from context (may be nil for unauthenticated requests)
 		authInfo, _ := ctx.Value(AuthInfoKey).(*AuthInfo)
 
-		// Build AllowedIncludes for child routes first
+		// Build AllowedIncludes for child and parent routes
 		// This must happen before the parent auth check so public parents still get child includes
+		allowedIncludes := make(metadata.AllowedIncludes)
+
 		if len(config.ChildAuth) > 0 {
-			allowedIncludes := make(metadata.AllowedIncludes)
-			for relationName, childConfig := range config.ChildAuth {
-				childResult := checkAuth(authInfo, childConfig)
-				if childResult.Status == authOK {
-					allowedIncludes[relationName] = childResult.ApplyOwnership
-				}
-			}
+			buildChildAllowedIncludes(authInfo, config.ChildAuth, "", false, allowedIncludes)
+		}
+
+		if config.ParentAuth != nil {
+			buildParentAllowedIncludes(authInfo, config, allowedIncludes)
+		}
+
+		if len(allowedIncludes) > 0 {
 			ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, allowedIncludes)
 		}
 
@@ -166,6 +170,55 @@ func checkParentOwnership(authInfo *AuthInfo, meta *metadata.TypeMetadata) paren
 	return parentOwnershipResult{
 		status:                  authOK,
 		parentsNeedingOwnership: parentsNeedingOwnership,
+	}
+}
+
+// buildChildAllowedIncludes recursively walks the ChildAuth tree, running checkAuth at each
+// level and building dotted paths for AllowedIncludes. Auth is cumulative (AND): a deeper
+// level is only reachable if its parent passes. Ownership flag is cumulative (OR): if any
+// level in the chain has ApplyOwnership, the dotted path gets true.
+func buildChildAllowedIncludes(authInfo *AuthInfo, childAuth map[string]*AuthConfig, prefix string, parentApplyOwnership bool, includes metadata.AllowedIncludes) {
+	for relationName, childConfig := range childAuth {
+		childResult := checkAuth(authInfo, childConfig)
+		if childResult.Status != authOK {
+			continue
+		}
+
+		path := relationName
+		if prefix != "" {
+			path = prefix + "." + relationName
+		}
+
+		applyOwnership := parentApplyOwnership || childResult.ApplyOwnership
+		includes[path] = applyOwnership
+
+		if len(childConfig.ChildAuth) > 0 {
+			buildChildAllowedIncludes(authInfo, childConfig.ChildAuth, path, applyOwnership, includes)
+		}
+	}
+}
+
+// buildParentAllowedIncludes walks the ParentAuth chain, running checkAuth at each level
+// and building dotted paths for parent includes (belongs-to direction).
+// Auth is cumulative (AND): stops at the first level that fails.
+// Ownership flag is cumulative (OR).
+func buildParentAllowedIncludes(authInfo *AuthInfo, config *AuthConfig, includes metadata.AllowedIncludes) {
+	var parts []string
+	var cumulativeOwnership bool
+	current := config
+
+	for current.ParentAuth != nil {
+		parentResult := checkAuth(authInfo, current.ParentAuth)
+		if parentResult.Status != authOK {
+			break
+		}
+
+		parts = append(parts, current.ParentIncludeName)
+		cumulativeOwnership = cumulativeOwnership || parentResult.ApplyOwnership
+		path := strings.Join(parts, ".")
+		includes[path] = cumulativeOwnership
+
+		current = current.ParentAuth
 	}
 }
 

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -669,11 +669,20 @@ type IncludeTestAuthor struct {
 
 type IncludeTestPost struct {
 	bun.BaseModel `bun:"table:include_test_posts"`
-	ID            int                `bun:"id,pk,autoincrement"`
-	AuthorID      int                `bun:"author_id,notnull"`
-	Author        *IncludeTestAuthor `bun:"rel:belongs-to,join:author_id=id"`
-	OwnerID       string             `bun:"owner_id,notnull"`
-	Title         string             `bun:"title"`
+	ID            int                   `bun:"id,pk,autoincrement"`
+	AuthorID      int                   `bun:"author_id,notnull"`
+	Author        *IncludeTestAuthor    `bun:"rel:belongs-to,join:author_id=id"`
+	OwnerID       string                `bun:"owner_id,notnull"`
+	Title         string                `bun:"title"`
+	Comments      []*IncludeTestComment `bun:"rel:has-many,join:id=post_id"`
+}
+
+type IncludeTestComment struct {
+	bun.BaseModel `bun:"table:include_test_comments"`
+	ID            int              `bun:"id,pk,autoincrement"`
+	PostID        int              `bun:"post_id,notnull"`
+	Post          *IncludeTestPost `bun:"rel:belongs-to,join:post_id=id"`
+	Body          string           `bun:"body"`
 }
 
 // TestAuth_ChildAuthPopulated tests that ChildAuth is populated when WithRelationName is used
@@ -908,10 +917,692 @@ func TestAuth_ChildAuthNoAuth(t *testing.T) {
 	}
 
 	// The posts field should be nil/empty since user isn't authorized for includes
-	if posts, ok := response["posts"]; ok && posts != nil {
+	if posts, ok := response["Posts"]; ok && posts != nil {
 		postsSlice, isSlice := posts.([]interface{})
 		if isSlice && len(postsSlice) > 0 {
 			t.Errorf("expected no posts for unauthenticated user, got %v", posts)
+		}
+	}
+}
+
+// =============================================================================
+// Issue #42 Tests: Nested relation includes rejected by AllowedIncludes auth
+// =============================================================================
+
+func setupNestedIncludeTest(t *testing.T) *bun.DB {
+	ds, err := datastore.Get()
+	if err != nil {
+		t.Fatalf("failed to get datastore: %v", err)
+	}
+	db := ds.GetDB()
+	ctx := context.Background()
+
+	if _, err := db.NewCreateTable().Model((*IncludeTestAuthor)(nil)).IfNotExists().Exec(ctx); err != nil {
+		t.Fatalf("failed to create authors table: %v", err)
+	}
+	if _, err := db.NewCreateTable().Model((*IncludeTestPost)(nil)).IfNotExists().Exec(ctx); err != nil {
+		t.Fatalf("failed to create posts table: %v", err)
+	}
+	if _, err := db.NewCreateTable().Model((*IncludeTestComment)(nil)).IfNotExists().Exec(ctx); err != nil {
+		t.Fatalf("failed to create comments table: %v", err)
+	}
+
+	_, _ = db.NewDelete().Model((*IncludeTestComment)(nil)).Where("1=1").Exec(ctx)
+	_, _ = db.NewDelete().Model((*IncludeTestPost)(nil)).Where("1=1").Exec(ctx)
+	_, _ = db.NewDelete().Model((*IncludeTestAuthor)(nil)).Where("1=1").Exec(ctx)
+	_, _ = db.Exec("DELETE FROM sqlite_sequence WHERE name IN ('include_test_authors', 'include_test_posts', 'include_test_comments')")
+
+	return db
+}
+
+func registerNestedIncludeRoutes(b *router.Builder, commentAuth router.AuthConfig) {
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllPublic(),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllWithOwnershipUnless([]string{"OwnerID"}, "admin"),
+				router.WithRelationName("Posts"),
+				func(b *router.Builder) {
+					router.RegisterRoutes[IncludeTestComment](b, "/comments",
+						commentAuth,
+						router.WithRelationName("Comments"),
+					)
+				},
+			)
+		},
+	)
+}
+
+func seedNestedIncludeData(t *testing.T, db *bun.DB) (author *IncludeTestAuthor, post *IncludeTestPost, comment *IncludeTestComment) {
+	ctx := context.Background()
+
+	author = &IncludeTestAuthor{Name: "Test Author"}
+	if _, err := db.NewInsert().Model(author).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create author: %v", err)
+	}
+
+	post = &IncludeTestPost{AuthorID: author.ID, OwnerID: "alice", Title: "Test Post"}
+	if _, err := db.NewInsert().Model(post).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create post: %v", err)
+	}
+
+	comment = &IncludeTestComment{PostID: post.ID, Body: "Test Comment"}
+	if _, err := db.NewInsert().Model(comment).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create comment: %v", err)
+	}
+
+	return
+}
+
+// TestAuth_NestedChildInclude tests that nested child includes (e.g., ?include=Posts.Comments)
+// work through the full middleware stack when all levels are authorized.
+func TestAuth_NestedChildInclude(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllPublic())
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts.Comments"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	posts, ok := response["Posts"].([]interface{})
+	if !ok || len(posts) == 0 {
+		t.Fatalf("expected posts to be included in response, got: %s", w.Body.String())
+	}
+
+	firstPost, ok := posts[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected first post to be an object")
+	}
+
+	comments, ok := firstPost["Comments"].([]interface{})
+	if !ok || len(comments) == 0 {
+		t.Fatal("expected comments to be included in posts (nested child include)")
+	}
+}
+
+// TestAuth_NestedChildInclude_DeeperLevelBlocked tests that nested child includes are blocked
+// when a deeper level's auth check fails, even though the first level passes.
+func TestAuth_NestedChildInclude_DeeperLevelBlocked(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	// Comments require "premium" scope; user only has "user"
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllScoped("premium"))
+
+	// Single-level Posts include should still work
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if posts, ok := response["Posts"].([]interface{}); !ok || len(posts) == 0 {
+		t.Fatal("expected single-level Posts include to work")
+	}
+
+	// Nested Posts.Comments should be blocked (user lacks "premium")
+	url = "/authors/" + strconv.Itoa(author.ID) + "?include=Posts.Comments"
+	req = httptest.NewRequest("GET", url, nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response2 map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response2); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// The whole Posts.Comments path should be dropped (not in AllowedIncludes)
+	if postsArr, ok := response2["Posts"].([]interface{}); ok && len(postsArr) > 0 {
+		firstPost, _ := postsArr[0].(map[string]interface{})
+		if comments, exists := firstPost["Comments"]; exists && comments != nil {
+			if commentsArr, isArr := comments.([]interface{}); isArr && len(commentsArr) > 0 {
+				t.Error("expected comments to be blocked (user lacks 'premium' scope)")
+			}
+		}
+	}
+}
+
+// TestAuth_NestedParentInclude tests that parent includes (e.g., ?include=Post.Author)
+// work through the full middleware stack when all levels are authorized.
+func TestAuth_NestedParentInclude(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, post, comment := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllPublic())
+
+	// GET comment with ?include=Post.Author
+	url := "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post.Author"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	postObj, ok := response["Post"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected post to be included in response (parent include)")
+	}
+
+	authorObj, ok := postObj["Author"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected author to be included in post (nested parent include)")
+	}
+
+	if authorObj["Name"] != "Test Author" {
+		t.Errorf("expected author name 'Test Author', got %v", authorObj["Name"])
+	}
+}
+
+// TestAuth_ParentInclude_SingleLevel tests that single-level parent includes
+// (e.g., ?include=Post from Comment route) work through the full middleware stack.
+func TestAuth_ParentInclude_SingleLevel(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, post, comment := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllPublic())
+
+	url := "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	postObj, ok := response["Post"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected post to be included in response (single-level parent include)")
+	}
+
+	if postObj["Title"] != "Test Post" {
+		t.Errorf("expected post title 'Test Post', got %v", postObj["Title"])
+	}
+}
+
+// TestAuth_NestedParentInclude_DeeperLevelBlocked tests that nested parent includes
+// are blocked when a deeper level's auth check fails.
+// Setup: Author requires "admin", Post is ownership-based, Comment is public.
+// User without "admin" can include Post but not Post.Author.
+func TestAuth_NestedParentInclude_DeeperLevelBlocked(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	ctx := context.Background()
+
+	author := &IncludeTestAuthor{Name: "Test Author"}
+	if _, err := db.NewInsert().Model(author).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create author: %v", err)
+	}
+
+	post := &IncludeTestPost{AuthorID: author.ID, OwnerID: "alice", Title: "Test Post"}
+	if _, err := db.NewInsert().Model(post).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create post: %v", err)
+	}
+
+	comment := &IncludeTestComment{PostID: post.ID, Body: "Test Comment"}
+	if _, err := db.NewInsert().Model(comment).Returning("*").Exec(ctx); err != nil {
+		t.Fatalf("failed to create comment: %v", err)
+	}
+
+	// Author requires "admin" scope; user only has "user"
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllScoped("admin"),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllWithOwnershipUnless([]string{"OwnerID"}, "admin"),
+				router.WithRelationName("Posts"),
+				func(b *router.Builder) {
+					router.RegisterRoutes[IncludeTestComment](b, "/comments",
+						router.AllPublic(),
+						router.WithRelationName("Comments"),
+					)
+				},
+			)
+		},
+	)
+
+	// Single-level parent include (Post) should work
+	url := "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if _, ok := response["Post"].(map[string]interface{}); !ok {
+		t.Fatal("expected single-level Post parent include to work")
+	}
+
+	// Nested Post.Author should be blocked (Author requires "admin")
+	url = "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post.Author"
+	req = httptest.NewRequest("GET", url, nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response2 map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response2); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if postObj, ok := response2["Post"].(map[string]interface{}); ok {
+		if authorObj, exists := postObj["Author"]; exists && authorObj != nil {
+			if authorMap, isMap := authorObj.(map[string]interface{}); isMap && len(authorMap) > 0 {
+				t.Error("expected Author to be blocked in Post.Author include (user lacks 'admin' scope)")
+			}
+		}
+	}
+}
+
+// TestAuth_SimpleChildInclude tests that single-level child includes work.
+func TestAuth_SimpleChildInclude(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllPublic())
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	posts, ok := response["Posts"].([]interface{})
+	if !ok || len(posts) == 0 {
+		t.Fatal("expected Posts to be included in response")
+	}
+}
+
+// TestAuth_ChildInclude_NoAuth tests that scoped child includes are silently
+// dropped when the user is not authenticated.
+func TestAuth_ChildInclude_NoAuth(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	// No auth middleware — unauthenticated request
+	r := chi.NewRouter()
+	b := router.NewBuilder(r)
+	registerNestedIncludeRoutes(b, router.AllPublic())
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 (author is public), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// Posts require ownership auth — should not be included for unauthenticated user
+	if posts, ok := response["Posts"].([]interface{}); ok && len(posts) > 0 {
+		t.Error("expected Posts to not be included for unauthenticated user")
+	}
+}
+
+// TestAuth_ChildInclude_WrongScope tests that child includes are silently
+// dropped when the user lacks the required scope.
+func TestAuth_ChildInclude_WrongScope(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+
+	// Posts require "premium" scope
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllPublic(),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllScoped("premium"),
+				router.WithRelationName("Posts"),
+			)
+		},
+	)
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if posts, ok := response["Posts"].([]interface{}); ok && len(posts) > 0 {
+		t.Error("expected Posts to not be included (user lacks 'premium' scope)")
+	}
+}
+
+// TestAuth_ChildInclude_ScopeGrantsAccess tests that having the required scope
+// allows including a child relation that would otherwise be blocked.
+func TestAuth_ChildInclude_ScopeGrantsAccess(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	// User has "premium" scope which matches the child's requirement
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user", "premium"})
+	b := router.NewBuilder(r)
+
+	// Author is public, Posts require "premium" scope
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllPublic(),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllScoped("premium"),
+				router.WithRelationName("Posts"),
+			)
+		},
+	)
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	posts, ok := response["Posts"].([]interface{})
+	if !ok || len(posts) == 0 {
+		t.Fatal("expected Posts to be included (user has 'premium' scope)")
+	}
+}
+
+// TestAuth_ParentInclude_NoAuth tests that scoped parent includes are silently
+// dropped when the user is not authenticated.
+func TestAuth_ParentInclude_NoAuth(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, post, comment := seedNestedIncludeData(t, db)
+
+	r := chi.NewRouter()
+	b := router.NewBuilder(r)
+
+	// Author requires "admin" scope, Post requires "editor" scope, Comment is public.
+	// No ownership at any level — avoids issue #28 parent ownership check blocking the request.
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllScoped("admin"),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllScoped("editor"),
+				router.WithRelationName("Posts"),
+				func(b *router.Builder) {
+					router.RegisterRoutes[IncludeTestComment](b, "/comments",
+						router.AllPublic(),
+						router.WithRelationName("Comments"),
+					)
+				},
+			)
+		},
+	)
+
+	// Comment GET is public, but Post parent include requires "editor" scope (no auth = dropped)
+	url := "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 (comment is public), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// Post include should be dropped (requires "editor" scope, user is unauthenticated)
+	if postObj, ok := response["Post"].(map[string]interface{}); ok && len(postObj) > 0 {
+		t.Error("expected Post to not be included for unauthenticated user")
+	}
+}
+
+// TestAuth_ParentInclude_WrongScope tests that parent includes are silently
+// dropped when the user lacks the required scope.
+func TestAuth_ParentInclude_WrongScope(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, post, comment := seedNestedIncludeData(t, db)
+
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+
+	// Author requires "admin", Post is ownership, Comment is public
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllScoped("admin"),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllWithOwnershipUnless([]string{"OwnerID"}, "admin"),
+				router.WithRelationName("Posts"),
+				func(b *router.Builder) {
+					router.RegisterRoutes[IncludeTestComment](b, "/comments",
+						router.AllPublic(),
+						router.WithRelationName("Comments"),
+					)
+				},
+			)
+		},
+	)
+
+	// User has "user" scope, trying to include Post.Author where Author needs "admin"
+	url := "/authors/" + strconv.Itoa(author.ID) +
+		"/posts/" + strconv.Itoa(post.ID) +
+		"/comments/" + strconv.Itoa(comment.ID) +
+		"?include=Post.Author"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// Post include should work (alice owns it), but Author should be dropped (needs admin)
+	if postObj, ok := response["Post"].(map[string]interface{}); ok {
+		if authorObj, exists := postObj["Author"]; exists && authorObj != nil {
+			if authorMap, isMap := authorObj.(map[string]interface{}); isMap && len(authorMap) > 0 {
+				t.Error("expected Author to be blocked in Post.Author include (user lacks 'admin' scope)")
+			}
+		}
+	}
+}
+
+// TestAuth_MixedPublicParent_ScopedChildInclude tests that a public parent endpoint
+// serves correctly while scoped child includes are silently dropped for unauthorized users.
+func TestAuth_MixedPublicParent_ScopedChildInclude(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	// No auth — unauthenticated request
+	r := chi.NewRouter()
+	b := router.NewBuilder(r)
+
+	// Author is public, Posts require "premium" scope
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllPublic(),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllScoped("premium"),
+				router.WithRelationName("Posts"),
+			)
+		},
+	)
+
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Parent request should succeed (public)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 (author is public), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// Author data should be present
+	if response["Name"] != "Test Author" {
+		t.Errorf("expected author name 'Test Author', got %v", response["Name"])
+	}
+
+	// Posts should not be included (requires "premium", user has no auth)
+	if posts, ok := response["Posts"].([]interface{}); ok && len(posts) > 0 {
+		t.Error("expected Posts to not be included for unauthenticated user (requires 'premium' scope)")
+	}
+}
+
+// TestAuth_NestedChildInclude_MiddleLevelBlocked tests that when a middle level
+// in a child include chain fails auth, the entire deeper path is also blocked.
+func TestAuth_NestedChildInclude_MiddleLevelBlocked(t *testing.T) {
+	db := setupNestedIncludeTest(t)
+	author, _, _ := seedNestedIncludeData(t, db)
+
+	// User has "user" scope only
+	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
+	b := router.NewBuilder(r)
+
+	// Author is public, Posts require "editor" scope, Comments are public
+	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
+		router.AllPublic(),
+		func(b *router.Builder) {
+			router.RegisterRoutes[IncludeTestPost](b, "/posts",
+				router.AllScoped("editor"),
+				router.WithRelationName("Posts"),
+				func(b *router.Builder) {
+					router.RegisterRoutes[IncludeTestComment](b, "/comments",
+						router.AllPublic(),
+						router.WithRelationName("Comments"),
+					)
+				},
+			)
+		},
+	)
+
+	// Request Posts.Comments — Posts is blocked (user lacks "editor"),
+	// so Comments can't be reached either
+	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts.Comments"
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	// Neither Posts nor Posts.Comments should be in AllowedIncludes
+	if posts, ok := response["Posts"].([]interface{}); ok && len(posts) > 0 {
+		t.Error("expected Posts to be blocked (user lacks 'editor' scope)")
+		firstPost, _ := posts[0].(map[string]interface{})
+		if comments, exists := firstPost["Comments"]; exists && comments != nil {
+			t.Error("expected Comments to also be blocked (parent Posts is blocked)")
 		}
 	}
 }

--- a/router/builder.go
+++ b/router/builder.go
@@ -22,6 +22,7 @@ type Builder struct {
 	router                  chi.Router             // Chi router being configured
 	parentMeta              *metadata.TypeMetadata // Metadata of the immediate parent (nil for root)
 	parentChildRelationAuth map[string]*AuthConfig // Parent's shared child relation auth map (children add to this via registerChildAuthConfig)
+	parentGetAuth           *AuthConfig            // Parent's GET auth config (for ParentAuth chain on child configs)
 }
 
 // customHandlers holds optional custom handler functions for a route registration
@@ -169,7 +170,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	if b.parentMeta != nil {
 		parentType = b.parentMeta.ModelType
 	}
-	foreignKeyCol, err := findParentRelationshipFromType(tType, parentType)
+	parentRel, err := findParentRelationshipFromType(tType, parentType)
 	if err != nil {
 		slog.WarnContext(context.Background(), "could not find parent relationship",
 			"type", typeName,
@@ -177,7 +178,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	}
 
 	// Validate parent relationship
-	validateParentRelationship(b.parentMeta, foreignKeyCol, typeName)
+	validateParentRelationship(b.parentMeta, parentRel.foreignKeyCol, typeName)
 
 	// Determine PK field name - default to "ID" convention
 	if pkField == "" {
@@ -194,15 +195,9 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 		ModelType:      tType,
 		ParentType:     parentType,
 		ParentMeta:     b.parentMeta,
-		ForeignKeyCol:  foreignKeyCol,
+		ForeignKeyCol:  parentRel.foreignKeyCol,
 		ChildMeta:      make(map[string]*metadata.TypeMetadata),
 		IsFileResource: isFileResource,
-	}
-
-	// Register this type as a child of the parent (for ?include= support)
-	// Only register if relationName is explicitly provided via WithRelationName
-	if b.parentMeta != nil && relationName != "" {
-		b.parentMeta.ChildMeta[relationName] = meta
 	}
 
 	// Merge auth configs (last wins for each method)
@@ -215,6 +210,17 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	for _, config := range authMap {
 		if config != nil {
 			config.ChildAuth = childRelationAuth
+		}
+	}
+
+	// Link parent auth chain for ?include= authorization of parent types (belongs-to direction).
+	// Same pattern as ParentMeta on TypeMetadata — piggybacking on the same registration flow.
+	if b.parentGetAuth != nil {
+		for _, config := range authMap {
+			if config != nil {
+				config.ParentAuth = b.parentGetAuth
+				config.ParentIncludeName = parentRel.fieldName
+			}
 		}
 	}
 
@@ -239,6 +245,14 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 
 	// Merge query configs (last wins for each setting)
 	meta = mergeQueryConfigs(meta, queryConfigs)
+
+	// Register this type as a child of the parent (for ?include= support).
+	// Must happen AFTER mergeQueryConfigs because Clone() creates a new ChildMeta map.
+	// If registered before, the parent's ChildMeta would point to the pre-clone metadata,
+	// and grandchild registrations (which mutate the post-clone metadata) would be invisible.
+	if b.parentMeta != nil && relationName != "" {
+		b.parentMeta.ChildMeta[relationName] = meta
+	}
 
 	// Set validator if provided
 	if validator != nil {
@@ -397,8 +411,12 @@ func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc
 
 				// Register action endpoints - POST /resources/{id}/{action-name}
 				for i := range actions {
-					// Assign shared childRelationAuth to action's auth config for ?include= support
+					// Assign shared auth references to action's auth config for ?include= support
 					actions[i].auth.ChildAuth = setup.childRelationAuth
+					if parentGetAuth := setup.authMap[MethodGet]; parentGetAuth != nil {
+						actions[i].auth.ParentAuth = parentGetAuth.ParentAuth
+						actions[i].auth.ParentIncludeName = parentGetAuth.ParentIncludeName
+					}
 					r.Method("POST", "/"+actions[i].name, wrapHandler(handler.Action[T](actions[i].fn), &actions[i].auth))
 				}
 
@@ -412,6 +430,7 @@ func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc
 				router:                  nestedRouter,
 				parentMeta:              meta,
 				parentChildRelationAuth: setup.childRelationAuth,
+				parentGetAuth:           setup.authMap[MethodGet],
 			}
 			nested(childBuilder)
 		}
@@ -475,29 +494,36 @@ func createParentIDMiddleware(paramUUID string) func(http.Handler) http.Handler 
 	}
 }
 
+// parentRelation holds the results of finding a parent relationship
+type parentRelation struct {
+	foreignKeyCol string // FK column name (e.g., "author_id")
+	fieldName     string // Struct field name for belongs-to (e.g., "Author")
+}
+
 // findParentRelationshipFromType looks for a belongs-to relationship between child and parent types
-// and extracts the foreign key from the bun relation tag. Returns the foreign key column name.
+// and extracts the foreign key from the bun relation tag. Returns the foreign key column name
+// and the belongs-to field name.
 // Handles two cases:
 // 1. Child has belongs-to Parent (e.g., Comment belongs-to Post) - FK is on child
 // 2. Parent has belongs-to Child (e.g., Post belongs-to User/Author) - FK is on parent
-func findParentRelationshipFromType(childType reflect.Type, parentType reflect.Type) (foreignKeyCol string, err error) {
+func findParentRelationshipFromType(childType reflect.Type, parentType reflect.Type) (parentRelation, error) {
 	if parentType == nil {
-		return "", nil
+		return parentRelation{}, nil
 	}
 	// Case 1: child belongs-to parent
-	if fk := parseForeignKeyFromRelation(childType, parentType); fk != "" {
-		return fk, nil
+	if rel := parseBelongsToRelation(childType, parentType); rel.foreignKeyCol != "" {
+		return rel, nil
 	}
 	// Case 2: parent belongs-to child (inverted)
-	if fk := parseForeignKeyFromRelation(parentType, childType); fk != "" {
-		return fk, nil
+	if rel := parseBelongsToRelation(parentType, childType); rel.foreignKeyCol != "" {
+		return rel, nil
 	}
-	return "", fmt.Errorf("no relationship between %s and %s found", childType.Name(), parentType.Name())
+	return parentRelation{}, fmt.Errorf("no relationship between %s and %s found", childType.Name(), parentType.Name())
 }
 
-// parseForeignKeyFromRelation looks for a belongs-to field on sourceType pointing to targetType
-// Returns the FK column name from the bun tag, or empty string if not found
-func parseForeignKeyFromRelation(sourceType, targetType reflect.Type) string {
+// parseBelongsToRelation looks for a belongs-to field on sourceType pointing to targetType.
+// Returns the FK column name and the struct field name.
+func parseBelongsToRelation(sourceType, targetType reflect.Type) parentRelation {
 	for i := 0; i < sourceType.NumField(); i++ {
 		field := sourceType.Field(i)
 
@@ -517,13 +543,16 @@ func parseForeignKeyFromRelation(sourceType, targetType reflect.Type) string {
 				if strings.HasPrefix(part, "join:") {
 					joinClause := strings.TrimPrefix(part, "join:")
 					if idx := strings.Index(joinClause, "="); idx != -1 {
-						return strings.TrimSpace(joinClause[:idx])
+						return parentRelation{
+							foreignKeyCol: strings.TrimSpace(joinClause[:idx]),
+							fieldName:     field.Name,
+						}
 					}
 				}
 			}
 		}
 	}
-	return ""
+	return parentRelation{}
 }
 
 // getTableName extracts table name from bun tag on the struct

--- a/scripts/run-bruno-tests.sh
+++ b/scripts/run-bruno-tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Bruno API test runner for go-restgen examples
 # Usage: ./scripts/run-bruno-tests.sh [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|all]
+# Set PORT env var to override the default port (8080), e.g.: PORT=9090 ./scripts/run-bruno-tests.sh all
 
 set -e
 
@@ -13,6 +14,9 @@ NC='\033[0m' # No Color
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Port configuration: use PORT env var, default to 8080
+TEST_PORT="${PORT:-8080}"
 
 # Default to running all tests
 TEST_SUITE="${1:-all}"
@@ -55,25 +59,23 @@ run_bruno() {
 # Start server and wait for it to be ready
 start_server() {
     local example_dir="$1"
-    local port="${2:-8080}"
 
     # Check if port is already in use
-    if lsof -ti :"$port" > /dev/null 2>&1; then
-        print_error "Port $port is already in use. Please stop the existing server first."
+    if lsof -ti :"$TEST_PORT" > /dev/null 2>&1; then
+        print_error "Port $TEST_PORT is already in use. Please stop the existing server first."
         exit 1
     fi
 
-    print_info "Starting server from $example_dir..."
+    print_info "Starting server from $example_dir on port $TEST_PORT..."
 
     cd "$PROJECT_ROOT/$example_dir"
-    go run . &
+    PORT="$TEST_PORT" go run . &
     SERVER_PID=$!
-    SERVER_PORT=$port
 
     # Wait for server to be ready (max 10 seconds)
     local max_attempts=20
     local attempt=0
-    while ! curl -s "http://localhost:$port/health" > /dev/null 2>&1; do
+    while ! curl -s "http://localhost:$TEST_PORT/health" > /dev/null 2>&1; do
         sleep 0.5
         attempt=$((attempt + 1))
         if [ $attempt -ge $max_attempts ]; then
@@ -94,9 +96,7 @@ stop_server() {
         kill $SERVER_PID 2>/dev/null || true
         # Also kill any process listening on the port (the compiled binary)
         # go run spawns the actual server as a child process
-        if [ -n "$SERVER_PORT" ]; then
-            lsof -ti :"$SERVER_PORT" | xargs kill 2>/dev/null || true
-        fi
+        lsof -ti :"$TEST_PORT" | xargs kill 2>/dev/null || true
         wait $SERVER_PID 2>/dev/null || true
         print_success "Server stopped"
     fi
@@ -113,14 +113,13 @@ run_tests() {
     local name="$1"
     local example_dir="$2"
     local bruno_dir="$3"
-    local port="${4:-8080}"
 
     print_header "Running $name Tests"
 
-    start_server "$example_dir" "$port"
+    start_server "$example_dir"
 
     cd "$PROJECT_ROOT/bruno"
-    if run_bruno run "$bruno_dir" --env local --format json --sandbox=developer; then
+    if run_bruno run "$bruno_dir" --env local --env-var "baseUrl=http://localhost:$TEST_PORT" --format json --sandbox=developer; then
         print_success "$name tests passed"
         RESULT=0
     else
@@ -130,7 +129,6 @@ run_tests() {
 
     stop_server
     SERVER_PID=""
-    SERVER_PORT=""
 
     return $RESULT
 }


### PR DESCRIPTION
## Summary

- Fix pre-existing bug where child metadata registered before `mergeQueryConfigs` clone made grandchild `?include=` paths invisible from the parent
- Add recursive `AllowedIncludes` building in `wrapWithAuth` for nested include paths (e.g., `?include=Posts.Comments`)
- Add 13 Go unit tests and 9 Bruno integration tests covering all include auth permutations
- Update all 13 example servers to accept `PORT` env var, fix `run-bruno-tests.sh` to pass it through
- Update README.md, AGENT.md, and bruno/README.md to reflect current features and fix incorrect claims

## Test plan

- [x] `go test ./... -count=1` — all packages green
- [x] `go test ./handler/ -bench=. -benchmem` — all 17 benchmarks pass, no regressions
- [x] `PORT=9090 ./scripts/run-bruno-tests.sh auth` — 48/48 passed, 94 assertions, 23 tests
- [x] Pre-commit hooks pass (fmt, imports, vet, golangci-lint, core tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)