### PR TITLE
Add WithJoinOn for non-FK relationships (#48)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -547,6 +547,48 @@ jobs:
         working-directory: bruno
         run: bru run custom-example --env local --format json --sandbox=developer
 
+  custom-join-example-test:
+    name: Custom Join Example Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.13'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Server
+        working-directory: examples/custom_join
+        run: go build -o /tmp/custom-join-server .
+
+      - name: Start Server
+        run: /tmp/custom-join-server &
+
+      - name: Wait for Server
+        run: |
+          for i in {1..30}; do
+            if curl -f http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
+
+      - name: Install Bruno CLI
+        run: npm install -g @usebruno/cli
+
+      - name: Run Tests
+        working-directory: bruno
+        run: bru run custom-join-example --env local --format json --sandbox=developer
+
   query-example-test:
     name: Query Example Test
     runs-on: ubuntu-latest

--- a/AGENT.md
+++ b/AGENT.md
@@ -63,7 +63,7 @@ func main() {
         w.Write([]byte("OK"))
     })
 
-    b := router.NewBuilder(r)
+    b := router.NewBuilder(r, db.GetDB())
     router.RegisterRoutes[User](b, "/users", router.AllPublic())
 
     log.Fatal(http.ListenAndServe(":8080", r))
@@ -122,6 +122,7 @@ router.RegisterRoutes[Model](builder, "/path",
     router.WithPagination(20, 100),
     router.WithDefaultSort("-CreatedAt"),
     router.WithRelationName("Posts"),  // enables ?include=Posts on parent
+    router.WithJoinOn("NMI", "NMI"),  // custom join: child.NMI = parent.NMI (no belongs-to tag needed)
     router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock with X-Sum-* headers
     router.WithAlternatePK("MyPK"),     // when PK field isn't named "ID"
 
@@ -160,7 +161,7 @@ type Post struct {
     Title         string `bun:"title,notnull" json:"title"`
 }
 
-b := router.NewBuilder(r)
+b := router.NewBuilder(r, db.GetDB())
 router.RegisterRoutes[Blog](b, "/blogs", router.AllPublic(), func(b *router.Builder) {
     router.RegisterRoutes[Post](b, "/posts", router.AllPublic())
 })

--- a/README.md
+++ b/README.md
@@ -201,6 +201,46 @@ go-restgen automatically handles parent-child relationships with full chain vali
 
 See the [nested routes example](./examples/nested_routes) for a complete working example with 3-level nesting.
 
+## Custom Join Columns
+
+By default, go-restgen discovers parent-child relationships from Bun `rel:belongs-to` tags. For relationships that join on a non-primary-key column (e.g., a shared NMI identifier), use `WithJoinOn()`:
+
+```go
+type Site struct {
+    bun.BaseModel `bun:"table:sites"`
+    ID            int    `bun:"id,pk,autoincrement" json:"id"`
+    NMI           string `bun:"nmi,notnull" json:"nmi"`
+    Name          string `bun:"name" json:"name"`
+}
+
+type UsageData struct {
+    bun.BaseModel `bun:"table:usage_data"`
+    ID            int    `bun:"id,pk,autoincrement" json:"id"`
+    NMI           string `bun:"nmi,notnull" json:"nmi"`
+    Reading       int    `bun:"reading" json:"reading"`
+}
+
+b := router.NewBuilder(r, db.GetDB())
+router.RegisterRoutes[Site](b, "/sites", router.AllPublic(), func(b *router.Builder) {
+    router.RegisterRoutes[UsageData](b, "/usage",
+        router.AllPublic(),
+        router.WithJoinOn("NMI", "NMI"),  // child.NMI = parent.NMI
+    )
+})
+```
+
+This creates routes:
+- `GET/POST /sites/{siteId}/usage` — filtered by `usage_data.nmi = sites.nmi`
+- `GET/PUT/DELETE /sites/{siteId}/usage/{usageId}` — validated against parent NMI
+
+**When to use `WithJoinOn`:**
+- The child model has no `rel:belongs-to` tag pointing to the parent
+- The relationship joins on a shared attribute rather than the parent's primary key
+
+Both field names are Go struct field names (e.g., `"NMI"`, not `"nmi"`). The framework resolves them to SQL column names via the Bun schema.
+
+See the [custom join example](./examples/custom_join) for a complete working example.
+
 ## Relation Includes
 
 Load related resources in a single request using the `?include=` query parameter. This avoids N+1 queries when you need parent and child data together.
@@ -774,7 +814,7 @@ type Item struct {
     Name          string `bun:"name" json:"name"`
 }
 
-b := router.NewBuilder(r)
+b := router.NewBuilder(r, db.GetDB())
 
 // Root registration - public read, admin write
 router.RegisterRoutes[Item](b, "/items",
@@ -1535,7 +1575,7 @@ if err := filestore.Initialize(storage); err != nil {
 }
 
 // Register parent with nested file resource
-b := router.NewBuilder(r)
+b := router.NewBuilder(r, db.GetDB())
 router.RegisterRoutes[Post](b, "/posts",
     router.AllPublic(),
     func(b *router.Builder) {
@@ -1789,7 +1829,7 @@ If OTEL is not configured, metrics are no-ops with negligible overhead.
 
 ```go
 // Register standard CRUD
-b := router.NewBuilder(r)
+b := router.NewBuilder(r, db.GetDB())
 router.RegisterRoutes[User](b, "/users", router.AllPublic())
 
 // Add custom endpoints
@@ -1831,6 +1871,7 @@ See the [`examples/`](./examples) directory for complete working examples:
 - **[Action Endpoints](./examples/actions)** - Custom actions on resources (cancel, complete)
 - **[Batch Operations](./examples/batch)** - Bulk create, update, and delete operations
 - **[Custom Handlers](./examples/custom)** - Override default CRUD behavior with custom handler functions
+- **[Custom Join Columns](./examples/custom_join)** - Non-FK relationships using `WithJoinOn` for shared attribute joins
 
 All examples include comprehensive Bruno API tests. See [`bruno/README.md`](./bruno/README.md) for details.
 
@@ -1908,6 +1949,7 @@ go-restgen builds on these excellent projects:
 - [x] File upload/download with pluggable storage (proxy and signed URL modes)
 - [x] Action endpoints for custom operations (`POST /resource/{id}/action`)
 - [x] Batch operations for bulk create/update/delete (`/resource/batch`)
+- [x] Custom join columns via `WithJoinOn` for non-FK relationships
 - [ ] MySQL support
 - [ ] OpenAPI/Swagger generation
 - [ ] Standalone examples (separate go.mod per example to avoid polluting main module)

--- a/bruno/custom-join-example/01-health-check.bru
+++ b/bruno/custom-join-example/01-health-check.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Health Check
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.status: eq ok
+}

--- a/bruno/custom-join-example/02-create-user.bru
+++ b/bruno/custom-join-example/02-create-user.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Create User
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/users
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Alice",
+    "email": "alice@example.com"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.name: eq Alice
+}
+
+script:post-response {
+  bru.setVar("userId", res.body.id);
+}

--- a/bruno/custom-join-example/03-create-account.bru
+++ b/bruno/custom-join-example/03-create-account.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Create Account
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/users/{{userId}}/accounts
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Home Account"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.user_id: eq {{userId}}
+  res.body.name: eq Home Account
+}
+
+script:post-response {
+  bru.setVar("accountId", res.body.id);
+}

--- a/bruno/custom-join-example/04-create-site-nmi001.bru
+++ b/bruno/custom-join-example/04-create-site-nmi001.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Create Site with NMI001
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{accountId}}/sites
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "nmi": "NMI001",
+    "address": "123 Main St"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.account_id: eq {{accountId}}
+  res.body.nmi: eq NMI001
+}
+
+script:post-response {
+  bru.setVar("siteId", res.body.id);
+}

--- a/bruno/custom-join-example/05-get-site.bru
+++ b/bruno/custom-join-example/05-get-site.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Site
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{accountId}}/sites/{{siteId}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.nmi: eq NMI001
+  res.body.address: eq 123 Main St
+}

--- a/bruno/custom-join-example/06-list-usage-data.bru
+++ b/bruno/custom-join-example/06-list-usage-data.bru
@@ -1,0 +1,28 @@
+meta {
+  name: List Usage Data for Site (NMI join)
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{accountId}}/sites/{{siteId}}/usage-data
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+script:post-response {
+  if (res.body.length !== 5) {
+    throw new Error(`Expected 5 usage records for NMI001, got ${res.body.length}`);
+  }
+  for (const record of res.body) {
+    if (record.nmi !== "NMI001") {
+      throw new Error(`Expected NMI001, got ${record.nmi}`);
+    }
+  }
+  bru.setVar("usageId", res.body[0].id);
+}

--- a/bruno/custom-join-example/07-get-usage-data.bru
+++ b/bruno/custom-join-example/07-get-usage-data.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Single Usage Data Record
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{accountId}}/sites/{{siteId}}/usage-data/{{usageId}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: eq {{usageId}}
+  res.body.nmi: eq NMI001
+}

--- a/bruno/custom-join-example/08-create-second-account-nmi002.bru
+++ b/bruno/custom-join-example/08-create-second-account-nmi002.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Create Second Account with NMI002 Site
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/users/{{userId}}/accounts
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Holiday House"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+}
+
+script:post-response {
+  bru.setVar("account2Id", res.body.id);
+}

--- a/bruno/custom-join-example/09-create-site-nmi002.bru
+++ b/bruno/custom-join-example/09-create-site-nmi002.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Create Site with NMI002
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{account2Id}}/sites
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "nmi": "NMI002",
+    "address": "456 Beach Rd"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.nmi: eq NMI002
+}
+
+script:post-response {
+  bru.setVar("site2Id", res.body.id);
+}

--- a/bruno/custom-join-example/10-list-usage-nmi002.bru
+++ b/bruno/custom-join-example/10-list-usage-nmi002.bru
@@ -1,0 +1,27 @@
+meta {
+  name: List Usage Data for NMI002 Site
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{account2Id}}/sites/{{site2Id}}/usage-data
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: isArray
+}
+
+script:post-response {
+  if (res.body.length !== 3) {
+    throw new Error(`Expected 3 usage records for NMI002, got ${res.body.length}`);
+  }
+  for (const record of res.body) {
+    if (record.nmi !== "NMI002") {
+      throw new Error(`Expected NMI002, got ${record.nmi}`);
+    }
+  }
+}

--- a/bruno/custom-join-example/11-usage-wrong-parent.bru
+++ b/bruno/custom-join-example/11-usage-wrong-parent.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Usage Data with Wrong Parent (404)
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{baseUrl}}/users/{{userId}}/accounts/{{account2Id}}/sites/{{site2Id}}/usage-data/{{usageId}}
+  body: none
+  auth: none
+}
+
+script:post-response {
+  // usageId belongs to NMI001 but we're querying under site2 (NMI002)
+  // This should return 404 because the NMI doesn't match
+  if (res.status !== 404) {
+    throw new Error(`Expected 404 for usage data under wrong NMI parent, got ${res.status}`);
+  }
+}

--- a/datastore/nested_test.go
+++ b/datastore/nested_test.go
@@ -48,39 +48,45 @@ type TestComment struct {
 
 // Nested test metadata with parent chain
 var testAuthorMeta = &metadata.TypeMetadata{
-	TypeID:        "test_author_id",
-	TypeName:      "TestAuthor",
-	TableName:     "authors",
-	URLParamUUID:  "authorId",
-	PKField:       "ID",
-	ModelType:     reflect.TypeOf(TestAuthor{}),
-	ParentType:    nil,
-	ParentMeta:    nil,
-	ForeignKeyCol: "",
+	TypeID:          "test_author_id",
+	TypeName:        "TestAuthor",
+	TableName:       "authors",
+	URLParamUUID:    "authorId",
+	PKField:         "ID",
+	ModelType:       reflect.TypeOf(TestAuthor{}),
+	ParentType:      nil,
+	ParentMeta:      nil,
+	ForeignKeyCol:   "",
+	ParentJoinCol:   "id",
+	ParentJoinField: "ID",
 }
 
 var testArticleMeta = &metadata.TypeMetadata{
-	TypeID:        "test_article_id",
-	TypeName:      "TestArticle",
-	TableName:     "articles",
-	URLParamUUID:  "articleId",
-	PKField:       "ID",
-	ModelType:     reflect.TypeOf(TestArticle{}),
-	ParentType:    reflect.TypeOf(TestAuthor{}),
-	ParentMeta:    testAuthorMeta,
-	ForeignKeyCol: "author_id",
+	TypeID:          "test_article_id",
+	TypeName:        "TestArticle",
+	TableName:       "articles",
+	URLParamUUID:    "articleId",
+	PKField:         "ID",
+	ModelType:       reflect.TypeOf(TestArticle{}),
+	ParentType:      reflect.TypeOf(TestAuthor{}),
+	ParentMeta:      testAuthorMeta,
+	ForeignKeyCol:   "author_id",
+	ParentJoinCol:   "id",
+	ParentJoinField: "ID",
 }
 
 var testCommentMeta = &metadata.TypeMetadata{
-	TypeID:        "test_comment_id",
-	TypeName:      "TestComment",
-	TableName:     "comments",
-	URLParamUUID:  "commentId",
-	PKField:       "ID",
-	ModelType:     reflect.TypeOf(TestComment{}),
-	ParentType:    reflect.TypeOf(TestArticle{}),
-	ParentMeta:    testArticleMeta,
-	ForeignKeyCol: "article_id",
+	TypeID:          "test_comment_id",
+	TypeName:        "TestComment",
+	TableName:       "comments",
+	URLParamUUID:    "commentId",
+	PKField:         "ID",
+	ModelType:       reflect.TypeOf(TestComment{}),
+	ParentType:      reflect.TypeOf(TestArticle{}),
+	ParentMeta:      testArticleMeta,
+	ForeignKeyCol:   "article_id",
+	ParentJoinCol:   "id",
+	ParentJoinField: "ID",
 }
 
 // ctxWithNestedMeta creates a context with the given metadata
@@ -392,5 +398,270 @@ func TestWrapper_Nested_Delete(t *testing.T) {
 	_, err = articleWrapper.Get(ctx, itoa(article.ID))
 	if err == nil {
 		t.Error("Expected error when getting deleted article")
+	}
+}
+
+// Custom join test models — Site -> UsageData joined on NMI (not FK)
+type TestSite struct {
+	bun.BaseModel `bun:"table:sites"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	AccountID     int    `bun:"account_id,notnull"`
+	NMI           string `bun:"nmi,notnull"`
+}
+
+type TestUsageData struct {
+	bun.BaseModel `bun:"table:usage_data"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	NMI           string `bun:"nmi,notnull"`
+	Reading       int    `bun:"reading"`
+}
+
+var testSiteMeta = &metadata.TypeMetadata{
+	TypeID:          "test_site_id",
+	TypeName:        "TestSite",
+	TableName:       "sites",
+	URLParamUUID:    "siteId",
+	PKField:         "ID",
+	ModelType:       reflect.TypeOf(TestSite{}),
+	ParentType:      nil,
+	ParentMeta:      nil,
+	ForeignKeyCol:   "",
+	ParentJoinCol:   "id",
+	ParentJoinField: "ID",
+}
+
+var testUsageDataMeta = &metadata.TypeMetadata{
+	TypeID:          "test_usage_data_id",
+	TypeName:        "TestUsageData",
+	TableName:       "usage_data",
+	URLParamUUID:    "usageDataId",
+	PKField:         "ID",
+	ModelType:       reflect.TypeOf(TestUsageData{}),
+	ParentType:      reflect.TypeOf(TestSite{}),
+	ParentMeta:      testSiteMeta,
+	ForeignKeyCol:   "nmi",
+	ParentJoinCol:   "nmi",
+	ParentJoinField: "NMI",
+}
+
+func setupCustomJoinTestDB(t *testing.T) (*datastore.SQLite, func()) {
+	t.Helper()
+
+	db, err := datastore.NewSQLite(":memory:")
+	if err != nil {
+		t.Fatal("Failed to create test database:", err)
+	}
+
+	if err := datastore.Initialize(db); err != nil {
+		db.Cleanup()
+		t.Fatal("Failed to initialize datastore:", err)
+	}
+
+	ctx := context.Background()
+	_, err = db.GetDB().NewCreateTable().Model((*TestSite)(nil)).IfNotExists().Exec(ctx)
+	if err != nil {
+		db.Cleanup()
+		t.Fatal("Failed to create sites table:", err)
+	}
+
+	_, err = db.GetDB().NewCreateTable().Model((*TestUsageData)(nil)).IfNotExists().Exec(ctx)
+	if err != nil {
+		db.Cleanup()
+		t.Fatal("Failed to create usage_data table:", err)
+	}
+
+	cleanup := func() {
+		_, _ = db.GetDB().NewDropTable().Model((*TestUsageData)(nil)).IfExists().Exec(ctx)
+		_, _ = db.GetDB().NewDropTable().Model((*TestSite)(nil)).IfExists().Exec(ctx)
+		datastore.Cleanup()
+		db.Cleanup()
+	}
+
+	return db, cleanup
+}
+
+func TestCustomJoin_ListFiltersByParentJoinCol(t *testing.T) {
+	db, cleanup := setupCustomJoinTestDB(t)
+	defer cleanup()
+
+	// Create a site with NMI "ABC123"
+	siteWrapper := &datastore.Wrapper[TestSite]{Store: db}
+	ctxSite := ctxWithNestedMeta(testSiteMeta)
+	site, err := siteWrapper.Create(ctxSite, TestSite{AccountID: 1, NMI: "ABC123"})
+	if err != nil {
+		t.Fatal("Failed to create site:", err)
+	}
+
+	// Insert usage data directly — some matching NMI, some not
+	ctx := context.Background()
+	_, _ = db.GetDB().NewInsert().Model(&TestUsageData{NMI: "ABC123", Reading: 100}).Exec(ctx)
+	_, _ = db.GetDB().NewInsert().Model(&TestUsageData{NMI: "ABC123", Reading: 200}).Exec(ctx)
+	_, _ = db.GetDB().NewInsert().Model(&TestUsageData{NMI: "XYZ999", Reading: 300}).Exec(ctx)
+
+	// List usage data scoped to site — should only return NMI="ABC123" rows
+	usageWrapper := &datastore.Wrapper[TestUsageData]{Store: db}
+	ctxList := ctxWithNestedMeta(testUsageDataMeta)
+	ctxList = context.WithValue(ctxList, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site.ID),
+	})
+	results, _, _, err := usageWrapper.GetAll(ctxList)
+	if err != nil {
+		t.Fatal("Failed to list usage data:", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Expected 2 usage records for NMI ABC123, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.NMI != "ABC123" {
+			t.Errorf("Expected NMI 'ABC123', got '%s'", r.NMI)
+		}
+	}
+}
+
+func TestCustomJoin_GetValidatesParentJoinCol(t *testing.T) {
+	db, cleanup := setupCustomJoinTestDB(t)
+	defer cleanup()
+
+	// Create two sites with different NMIs
+	siteWrapper := &datastore.Wrapper[TestSite]{Store: db}
+	ctxSite := ctxWithNestedMeta(testSiteMeta)
+	site1, _ := siteWrapper.Create(ctxSite, TestSite{AccountID: 1, NMI: "ABC123"})
+	site2, _ := siteWrapper.Create(ctxSite, TestSite{AccountID: 1, NMI: "XYZ999"})
+
+	// Insert usage data for site1's NMI
+	ctx := context.Background()
+	usage := &TestUsageData{NMI: "ABC123", Reading: 100}
+	_, _ = db.GetDB().NewInsert().Model(usage).Exec(ctx)
+
+	usageWrapper := &datastore.Wrapper[TestUsageData]{Store: db}
+
+	// Get with correct parent (site1, NMI=ABC123) — should succeed
+	ctxCorrect := ctxWithNestedMeta(testUsageDataMeta)
+	ctxCorrect = context.WithValue(ctxCorrect, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site1.ID),
+	})
+	retrieved, err := usageWrapper.Get(ctxCorrect, itoa(usage.ID))
+	if err != nil {
+		t.Fatal("Failed to get usage data with correct parent:", err)
+	}
+	if retrieved.Reading != 100 {
+		t.Errorf("Expected reading 100, got %d", retrieved.Reading)
+	}
+
+	// Get with wrong parent (site2, NMI=XYZ999) — should fail (404)
+	ctxWrong := ctxWithNestedMeta(testUsageDataMeta)
+	ctxWrong = context.WithValue(ctxWrong, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site2.ID),
+	})
+	_, err = usageWrapper.Get(ctxWrong, itoa(usage.ID))
+	if err == nil {
+		t.Error("Expected error when getting usage data with wrong parent NMI")
+	}
+}
+
+func TestCustomJoin_CreateSetsJoinCol(t *testing.T) {
+	db, cleanup := setupCustomJoinTestDB(t)
+	defer cleanup()
+
+	// Create site
+	siteWrapper := &datastore.Wrapper[TestSite]{Store: db}
+	ctxSite := ctxWithNestedMeta(testSiteMeta)
+	site, err := siteWrapper.Create(ctxSite, TestSite{AccountID: 1, NMI: "ABC123"})
+	if err != nil {
+		t.Fatal("Failed to create site:", err)
+	}
+
+	// Create usage data under the site — NMI should be auto-set
+	usageWrapper := &datastore.Wrapper[TestUsageData]{Store: db}
+	ctxCreate := ctxWithNestedMeta(testUsageDataMeta)
+	ctxCreate = context.WithValue(ctxCreate, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site.ID),
+	})
+	created, err := usageWrapper.Create(ctxCreate, TestUsageData{Reading: 500})
+	if err != nil {
+		t.Fatal("Failed to create usage data:", err)
+	}
+	if created.NMI != "ABC123" {
+		t.Errorf("Expected NMI 'ABC123' auto-set from parent, got '%s'", created.NMI)
+	}
+}
+
+func TestCustomJoin_MultipleParentsShareJoinCol(t *testing.T) {
+	db, cleanup := setupCustomJoinTestDB(t)
+	defer cleanup()
+
+	// Two sites with the same NMI (different accounts, same physical meter)
+	siteWrapper := &datastore.Wrapper[TestSite]{Store: db}
+	ctxSite := ctxWithNestedMeta(testSiteMeta)
+	site1, _ := siteWrapper.Create(ctxSite, TestSite{AccountID: 1, NMI: "SHARED_NMI"})
+	site2, _ := siteWrapper.Create(ctxSite, TestSite{AccountID: 2, NMI: "SHARED_NMI"})
+
+	// Insert usage data for the shared NMI
+	ctx := context.Background()
+	_, _ = db.GetDB().NewInsert().Model(&TestUsageData{NMI: "SHARED_NMI", Reading: 100}).Exec(ctx)
+	_, _ = db.GetDB().NewInsert().Model(&TestUsageData{NMI: "SHARED_NMI", Reading: 200}).Exec(ctx)
+
+	usageWrapper := &datastore.Wrapper[TestUsageData]{Store: db}
+
+	// Both sites should see the same usage data
+	ctxSite1 := ctxWithNestedMeta(testUsageDataMeta)
+	ctxSite1 = context.WithValue(ctxSite1, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site1.ID),
+	})
+	results1, _, _, err := usageWrapper.GetAll(ctxSite1)
+	if err != nil {
+		t.Fatal("Failed to list usage data for site1:", err)
+	}
+
+	ctxSite2 := ctxWithNestedMeta(testUsageDataMeta)
+	ctxSite2 = context.WithValue(ctxSite2, metadata.ParentIDsKey, map[string]string{
+		"siteId": itoa(site2.ID),
+	})
+	results2, _, _, err := usageWrapper.GetAll(ctxSite2)
+	if err != nil {
+		t.Fatal("Failed to list usage data for site2:", err)
+	}
+
+	if len(results1) != 2 {
+		t.Errorf("Expected 2 usage records for site1, got %d", len(results1))
+	}
+	if len(results2) != 2 {
+		t.Errorf("Expected 2 usage records for site2, got %d", len(results2))
+	}
+}
+
+func TestCustomJoin_StandardFKUnchanged(t *testing.T) {
+	db, cleanup := setupNestedTestDB(t)
+	defer cleanup()
+
+	// Standard FK flow: Author -> Article
+	authorWrapper := &datastore.Wrapper[TestAuthor]{Store: db}
+	ctxAuthor := ctxWithNestedMeta(testAuthorMeta)
+	author, _ := authorWrapper.Create(ctxAuthor, TestAuthor{Name: "Author", Email: "a@example.com"})
+
+	articleWrapper := &datastore.Wrapper[TestArticle]{Store: db}
+	ctxCreate := ctxWithNestedMeta(testArticleMeta)
+	ctxCreate = context.WithValue(ctxCreate, metadata.ParentIDsKey, map[string]string{
+		"authorId": itoa(author.ID),
+	})
+	article, err := articleWrapper.Create(ctxCreate, TestArticle{Title: "Test", Content: "Content"})
+	if err != nil {
+		t.Fatal("Standard FK create failed:", err)
+	}
+	if article.AuthorID != author.ID {
+		t.Errorf("Expected AuthorID %d, got %d", author.ID, article.AuthorID)
+	}
+
+	// Verify get still works
+	ctxGet := ctxWithNestedMeta(testArticleMeta)
+	ctxGet = context.WithValue(ctxGet, metadata.ParentIDsKey, map[string]string{
+		"authorId": itoa(author.ID),
+	})
+	retrieved, err := articleWrapper.Get(ctxGet, itoa(article.ID))
+	if err != nil {
+		t.Fatal("Standard FK get failed:", err)
+	}
+	if retrieved.Title != "Test" {
+		t.Errorf("Expected title 'Test', got '%s'", retrieved.Title)
 	}
 }

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -165,8 +165,14 @@ func (w *Wrapper[T]) Create(ctx context.Context, item T) (*T, error) {
 			return nil, err
 		}
 
-		// Set the foreign key field on the item using the parent's actual PK value
-		if err := w.setForeignKey(&item, meta.ForeignKeyCol, parentItem, parentMeta.PKField); err != nil {
+		// Set the foreign key field on the item using the parent's join field value.
+		// For standard FK relationships (ParentJoinField="ID"), this copies parent.ID into child.FK.
+		// For custom joins (e.g., ParentJoinField="NMI"), this copies parent.NMI into child.NMI.
+		parentField := meta.ParentJoinField
+		if parentField == "" {
+			parentField = parentMeta.PKField
+		}
+		if err := w.setForeignKey(&item, meta.ForeignKeyCol, parentItem, parentField); err != nil {
 			return nil, err
 		}
 	}
@@ -417,11 +423,11 @@ func (w *Wrapper[T]) getWithMeta(ctx context.Context, meta *metadata.TypeMetadat
 // parentItem is the parent object from which we extract the primary key value.
 // parentPKField specifies the parent's primary key field name (from parentMeta.PKField).
 func (w *Wrapper[T]) setForeignKey(item *T, foreignKeyCol string, parentItem interface{}, parentPKField string) error {
-	// Convert column name to field name (e.g., "author_id" -> "AuthorID")
-	fieldName := fieldNameFromColumn(foreignKeyCol)
-
-	// Use reflection to set the field
 	itemValue := reflect.ValueOf(item).Elem()
+	fieldName := w.goNameFromColumn(itemValue.Type(), foreignKeyCol)
+	if fieldName == "" {
+		return fmt.Errorf("no field found for column %s", foreignKeyCol)
+	}
 	fkField := itemValue.FieldByName(fieldName)
 	if !fkField.IsValid() || !fkField.CanSet() {
 		return fmt.Errorf("cannot set foreign key field %s", fieldName)
@@ -462,31 +468,21 @@ func (w *Wrapper[T]) setForeignKey(item *T, foreignKeyCol string, parentItem int
 	return nil
 }
 
-// hasField checks if a type has a field matching the given column name
-func hasField(t reflect.Type, colName string) bool {
+// hasColumn checks if a model type has a field matching the given SQL column name.
+func (w *Wrapper[T]) hasColumn(t reflect.Type, colName string) bool {
 	if colName == "" {
 		return false
 	}
-	fieldName := fieldNameFromColumn(colName)
-	_, found := t.FieldByName(fieldName)
-	return found
+	return w.Store.GetDB().Table(t).HasField(colName)
 }
 
-// fieldNameFromColumn converts a database column name to a Go field name
-// e.g., "author_id" -> "AuthorID", "post_id" -> "PostID"
-func fieldNameFromColumn(col string) string {
-	parts := strings.Split(col, "_")
-	for i, part := range parts {
-		if len(part) > 0 {
-			// Special case for "id" -> "ID"
-			if strings.ToLower(part) == "id" {
-				parts[i] = "ID"
-			} else {
-				parts[i] = strings.ToUpper(part[:1]) + part[1:]
-			}
-		}
+// goNameFromColumn resolves a SQL column name to its Go struct field name using Bun's schema.
+func (w *Wrapper[T]) goNameFromColumn(t reflect.Type, colName string) string {
+	field := w.Store.GetDB().Table(t).LookupField(colName)
+	if field == nil {
+		return ""
 	}
-	return strings.Join(parts, "")
+	return field.GoName
 }
 
 // applyParentFiltersWithMeta applies parent ID filters and JOINs using metadata chain
@@ -513,6 +509,7 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 		childType     reflect.Type
 		childTable    string
 		childFKCol    string
+		parentJoinCol string
 		parentTable   string
 		parentURLUUID string
 		parentMeta    *metadata.TypeMetadata
@@ -524,10 +521,15 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 
 	// Walk up the chain using ParentMeta pointers
 	for parentMeta != nil {
+		parentJoinCol := childMeta.ParentJoinCol
+		if parentJoinCol == "" {
+			parentJoinCol = "id"
+		}
 		joins = append(joins, joinInfo{
 			childType:     childMeta.ModelType,
 			childTable:    childMeta.TableName,
 			childFKCol:    childMeta.ForeignKeyCol,
+			parentJoinCol: parentJoinCol,
 			parentTable:   parentMeta.TableName,
 			parentURLUUID: parentMeta.URLParamUUID,
 			parentMeta:    parentMeta,
@@ -558,38 +560,38 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 		}
 
 		// Determine if FK is on child or parent by checking if child has the FK field
-		fkOnChild := hasField(join.childType, join.childFKCol)
+		fkOnChild := w.hasColumn(join.childType, join.childFKCol)
 
 		// Check if child is the base model being queried
 		if join.childType == baseType {
 			// Child is the base model, use ?TableAlias
 			if fkOnChild {
-				// Normal case: child.FK = parent.id
+				// Normal case: child.FK = parent.joinCol
 				query = query.Join("JOIN ? ON ?TableAlias.? = ?.?",
 					bun.Ident(join.parentTable),
 					bun.Ident(join.childFKCol),
-					bun.Ident(join.parentTable), bun.Ident("id"))
+					bun.Ident(join.parentTable), bun.Ident(join.parentJoinCol))
 			} else {
-				// Inverted case: parent.FK = child.id
+				// Inverted case: parent.FK = child.joinCol
 				query = query.Join("JOIN ? ON ?.? = ?TableAlias.?",
 					bun.Ident(join.parentTable),
 					bun.Ident(join.parentTable), bun.Ident(join.childFKCol),
-					bun.Ident("id"))
+					bun.Ident(join.parentJoinCol))
 			}
 		} else {
 			// Child is a previously joined table, use table name
 			if fkOnChild {
-				// Normal case: child.FK = parent.id
+				// Normal case: child.FK = parent.joinCol
 				query = query.Join("JOIN ? ON ?.? = ?.?",
 					bun.Ident(join.parentTable),
 					bun.Ident(join.childTable), bun.Ident(join.childFKCol),
-					bun.Ident(join.parentTable), bun.Ident("id"))
+					bun.Ident(join.parentTable), bun.Ident(join.parentJoinCol))
 			} else {
-				// Inverted case: parent.FK = child.id
+				// Inverted case: parent.FK = child.joinCol
 				query = query.Join("JOIN ? ON ?.? = ?.?",
 					bun.Ident(join.parentTable),
 					bun.Ident(join.parentTable), bun.Ident(join.childFKCol),
-					bun.Ident(join.childTable), bun.Ident("id"))
+					bun.Ident(join.childTable), bun.Ident(join.parentJoinCol))
 			}
 		}
 
@@ -599,7 +601,7 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 
 		// Issue #28 fix: Apply ownership filter for this parent if needed
 		if slices.Contains(parentsNeedingOwnership, join.parentMeta) && ownershipUserID != "" {
-			query = applyParentOwnershipFilter(query, join.parentMeta, ownershipUserID)
+			query = w.applyParentOwnershipFilter(query, join.parentMeta, ownershipUserID)
 		}
 	}
 
@@ -607,7 +609,7 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 }
 
 // applyParentOwnershipFilter adds ownership WHERE clause for a parent table
-func applyParentOwnershipFilter(query *bun.SelectQuery, parentMeta *metadata.TypeMetadata, userID string) *bun.SelectQuery {
+func (w *Wrapper[T]) applyParentOwnershipFilter(query *bun.SelectQuery, parentMeta *metadata.TypeMetadata, userID string) *bun.SelectQuery {
 	if len(parentMeta.OwnershipFields) == 0 {
 		return query
 	}
@@ -621,7 +623,7 @@ func applyParentOwnershipFilter(query *bun.SelectQuery, parentMeta *metadata.Typ
 	// Build WHERE clause for ownership: parent_table.ownership_field = userID
 	// For multiple fields, use OR logic (same as applyOwnershipFilterWithMeta)
 	for i, fieldName := range parentMeta.OwnershipFields {
-		colName, err := fieldToColumnName(parentType, fieldName)
+		colName, err := w.columnFromGoName(parentType, fieldName)
 		if err != nil {
 			continue
 		}
@@ -680,7 +682,7 @@ func (w *Wrapper[T]) applyOwnershipFilterWithMeta(ctx context.Context, query *bu
 	// Use ?TableAlias to properly qualify columns when JOINs are present
 	if len(meta.OwnershipFields) == 1 {
 		// Single field - simple WHERE clause
-		colName, err := fieldToColumnName(itemType, meta.OwnershipFields[0])
+		colName, err := w.columnFromGoName(itemType, meta.OwnershipFields[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get column name for ownership field: %w", err)
 		}
@@ -688,7 +690,7 @@ func (w *Wrapper[T]) applyOwnershipFilterWithMeta(ctx context.Context, query *bu
 	} else {
 		// Multiple fields - OR logic
 		for i, fieldName := range meta.OwnershipFields {
-			colName, err := fieldToColumnName(itemType, fieldName)
+			colName, err := w.columnFromGoName(itemType, fieldName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get column name for ownership field: %w", err)
 			}
@@ -745,26 +747,15 @@ func (w *Wrapper[T]) setOwnershipField(ctx context.Context, item *T) error {
 	return nil
 }
 
-// fieldToColumnName converts a Go field name to database column name using bun tags
-// Returns error if field doesn't exist or lacks proper bun tag (required for ownership security)
-func fieldToColumnName(tType reflect.Type, fieldName string) (string, error) {
-	field, found := tType.FieldByName(fieldName)
-	if !found {
-		return "", fmt.Errorf("field %s not found on type %s", fieldName, tType.Name())
+// columnFromGoName resolves a Go field name to its SQL column name using Bun's schema.
+func (w *Wrapper[T]) columnFromGoName(tType reflect.Type, fieldName string) (string, error) {
+	table := w.Store.GetDB().Table(tType)
+	for _, field := range table.Fields {
+		if field.GoName == fieldName {
+			return field.Name, nil
+		}
 	}
-
-	// Check bun tag for column name
-	bunTag := field.Tag.Get("bun")
-	if bunTag == "" {
-		return "", fmt.Errorf("field %s on type %s must have bun tag with column name", fieldName, tType.Name())
-	}
-
-	parts := strings.Split(bunTag, ",")
-	if len(parts) == 0 || parts[0] == "" || parts[0] == "-" {
-		return "", fmt.Errorf("field %s on type %s has invalid bun tag: column name required", fieldName, tType.Name())
-	}
-
-	return parts[0], nil
+	return "", fmt.Errorf("field %s not found on type %s", fieldName, tType.Name())
 }
 
 // convertFilterValues converts a string filter value to the appropriate Go type(s)
@@ -898,7 +889,7 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 			}
 
 			// Get column name
-			colName, err := fieldToColumnName(meta.ModelType, field)
+			colName, err := w.columnFromGoName(meta.ModelType, field)
 			if err != nil {
 				slog.WarnContext(ctx, "sum requested for field with invalid column mapping", "field", field, "type", meta.TypeName, "error", err)
 				continue
@@ -1010,7 +1001,7 @@ func (w *Wrapper[T]) applyQueryFilters(ctx context.Context, query *bun.SelectQue
 			continue
 		}
 
-		colName, err := fieldToColumnName(meta.ModelType, field)
+		colName, err := w.columnFromGoName(meta.ModelType, field)
 		if err != nil {
 			continue
 		}
@@ -1089,7 +1080,7 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 				continue // skip invalid sort fields
 			}
 
-			colName, err := fieldToColumnName(meta.ModelType, sort.Field)
+			colName, err := w.columnFromGoName(meta.ModelType, sort.Field)
 			if err != nil {
 				continue
 			}
@@ -1112,7 +1103,7 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 			field = field[1:]
 		}
 
-		colName, err := fieldToColumnName(meta.ModelType, field)
+		colName, err := w.columnFromGoName(meta.ModelType, field)
 		if err == nil {
 			if desc {
 				query = query.OrderExpr("?TableAlias.? DESC", bun.Ident(colName))
@@ -1470,7 +1461,11 @@ func (w *Wrapper[T]) BatchCreate(ctx context.Context, items []T) ([]*T, error) {
 				if err != nil {
 					return err
 				}
-				if err := w.setForeignKey(item, meta.ForeignKeyCol, parentItem, parentMeta.PKField); err != nil {
+				parentField := meta.ParentJoinField
+				if parentField == "" {
+					parentField = parentMeta.PKField
+				}
+				if err := w.setForeignKey(item, meta.ForeignKeyCol, parentItem, parentField); err != nil {
 					return err
 				}
 			}
@@ -1686,7 +1681,7 @@ func (w *Wrapper[T]) applyParentFieldFilter(ctx context.Context, query *bun.Sele
 		return query
 	}
 
-	colName, err := fieldToColumnName(targetMeta.ModelType, path.field)
+	colName, err := w.columnFromGoName(targetMeta.ModelType, path.field)
 	if err != nil {
 		return query
 	}
@@ -1733,38 +1728,46 @@ func (w *Wrapper[T]) buildParentJoins(query *bun.SelectQuery, baseMeta *metadata
 	}
 
 	// First join: from base table using ?TableAlias
-	fkOnChild := hasField(baseMeta.ModelType, baseMeta.ForeignKeyCol)
+	fkOnChild := w.hasColumn(baseMeta.ModelType, baseMeta.ForeignKeyCol)
 	query = w.joinParentFromBase(query, baseMeta, chain[0], fkOnChild)
 
 	// Remaining joins: from previously joined tables
 	for i := 1; i < len(chain); i++ {
 		child, parent := chain[i-1], chain[i]
-		fkOnChild := hasField(child.ModelType, child.ForeignKeyCol)
+		fkOnChild := w.hasColumn(child.ModelType, child.ForeignKeyCol)
 		query = w.joinParentFromTable(query, child, parent, fkOnChild)
 	}
 	return query
 }
 
 func (w *Wrapper[T]) joinParentFromBase(query *bun.SelectQuery, child, parent *metadata.TypeMetadata, fkOnChild bool) *bun.SelectQuery {
+	parentJoinCol := child.ParentJoinCol
+	if parentJoinCol == "" {
+		parentJoinCol = "id"
+	}
 	if fkOnChild {
 		return query.Join("JOIN ? ON ?TableAlias.? = ?.?",
 			bun.Ident(parent.TableName), bun.Ident(child.ForeignKeyCol),
-			bun.Ident(parent.TableName), bun.Ident("id"))
+			bun.Ident(parent.TableName), bun.Ident(parentJoinCol))
 	}
 	return query.Join("JOIN ? ON ?.? = ?TableAlias.?",
 		bun.Ident(parent.TableName), bun.Ident(parent.TableName),
-		bun.Ident(child.ForeignKeyCol), bun.Ident("id"))
+		bun.Ident(child.ForeignKeyCol), bun.Ident(parentJoinCol))
 }
 
 func (w *Wrapper[T]) joinParentFromTable(query *bun.SelectQuery, child, parent *metadata.TypeMetadata, fkOnChild bool) *bun.SelectQuery {
+	parentJoinCol := child.ParentJoinCol
+	if parentJoinCol == "" {
+		parentJoinCol = "id"
+	}
 	if fkOnChild {
 		return query.Join("JOIN ? ON ?.? = ?.?",
 			bun.Ident(parent.TableName), bun.Ident(child.TableName),
-			bun.Ident(child.ForeignKeyCol), bun.Ident(parent.TableName), bun.Ident("id"))
+			bun.Ident(child.ForeignKeyCol), bun.Ident(parent.TableName), bun.Ident(parentJoinCol))
 	}
 	return query.Join("JOIN ? ON ?.? = ?.?",
 		bun.Ident(parent.TableName), bun.Ident(parent.TableName),
-		bun.Ident(child.ForeignKeyCol), bun.Ident(child.TableName), bun.Ident("id"))
+		bun.Ident(child.ForeignKeyCol), bun.Ident(child.TableName), bun.Ident(parentJoinCol))
 }
 
 // applyChildFieldFilter applies a filter on a child relation field using EXISTS subqueries
@@ -1779,7 +1782,7 @@ func (w *Wrapper[T]) applyChildFieldFilter(ctx context.Context, query *bun.Selec
 		return query
 	}
 
-	colName, err := fieldToColumnName(targetMeta.ModelType, path.field)
+	colName, err := w.columnFromGoName(targetMeta.ModelType, path.field)
 	if err != nil {
 		return query
 	}
@@ -1852,8 +1855,12 @@ func (w *Wrapper[T]) wrapInExists(baseMeta *metadata.TypeMetadata, chain []*meta
 	sql := innerCondition
 	for i := len(chain) - 1; i >= 0; i-- {
 		child := chain[i]
-		sql = fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.id AND %s)",
-			child.TableName, child.TableName, child.ForeignKeyCol, parents[i], sql)
+		parentJoinCol := child.ParentJoinCol
+		if parentJoinCol == "" {
+			parentJoinCol = "id"
+		}
+		sql = fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.%s AND %s)",
+			child.TableName, child.TableName, child.ForeignKeyCol, parents[i], parentJoinCol, sql)
 	}
 	return sql
 }

--- a/examples/actions/main.go
+++ b/examples/actions/main.go
@@ -157,7 +157,7 @@ func main() {
 	})
 
 	// Register routes with actions
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Order](b, "/orders",
 		router.AllPublic(),
 		router.WithFilters("Status", "CustomerName"),

--- a/examples/audit/main.go
+++ b/examples/audit/main.go
@@ -139,7 +139,7 @@ func main() {
 	})
 
 	// Register Job routes with audit
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Job](b, "/jobs",
 		router.AllPublic(),
 		router.WithFilters("Status", "Priority"),

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -274,7 +274,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 
 	// Article - public reads, requires "publisher" scope for writes
 	router.RegisterRoutes[Article](b, "/articles",

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Register routes with batch operations enabled
 	// AllPublicWithBatch enables all CRUD + batch operations as public
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Product](b, "/products",
 		router.AllPublicWithBatch(), // Enable batch operations
 		router.WithBatchLimit(100),  // Optional: limit batch size to 100 items

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -317,7 +317,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 
 	// /me endpoint - single route with custom Get and Update using auth token
 	// AsSingleRouteWithPut("") creates GET /me and PUT /me (no {id} parameter)

--- a/examples/custom_join/main.go
+++ b/examples/custom_join/main.go
@@ -1,0 +1,151 @@
+//nolint:gosec,gocritic,unparam // Example code - simplified for demonstration
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+	"github.com/sjgoldie/go-restgen/router"
+)
+
+type User struct {
+	bun.BaseModel `bun:"table:users"`
+	ID            int        `bun:"id,pk,autoincrement" json:"id"`
+	Name          string     `bun:"name,notnull" json:"name"`
+	Email         string     `bun:"email,unique,notnull" json:"email"`
+	Accounts      []*Account `bun:"rel:has-many,join:id=user_id" json:"-"`
+}
+
+type Account struct {
+	bun.BaseModel `bun:"table:accounts"`
+	ID            int     `bun:"id,pk,autoincrement" json:"id"`
+	UserID        int     `bun:"user_id,notnull" json:"user_id"`
+	User          *User   `bun:"rel:belongs-to,join:user_id=id" json:"-"`
+	Name          string  `bun:"name,notnull" json:"name"`
+	Sites         []*Site `bun:"rel:has-many,join:id=account_id" json:"-"`
+}
+
+type Site struct {
+	bun.BaseModel `bun:"table:sites"`
+	ID            int          `bun:"id,pk,autoincrement" json:"id"`
+	AccountID     int          `bun:"account_id,notnull" json:"account_id"`
+	Account       *Account     `bun:"rel:belongs-to,join:account_id=id" json:"-"`
+	NMI           string       `bun:"nmi,notnull" json:"nmi"`
+	Address       string       `bun:"address,notnull" json:"address"`
+	UsageData     []*UsageData `bun:"rel:has-many,join:nmi=nmi" json:"usage_data,omitempty"`
+}
+
+// UsageData is independently ingested data keyed by NMI + date.
+// There is no FK back to Site — the relationship is through the shared NMI field.
+type UsageData struct {
+	bun.BaseModel `bun:"table:usage_data"`
+	ID            int       `bun:"id,pk,autoincrement" json:"id"`
+	NMI           string    `bun:"nmi,notnull" json:"nmi"`
+	Date          time.Time `bun:"date,notnull" json:"date"`
+	KWh           float64   `bun:"kwh,notnull" json:"kwh"`
+}
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	slog.SetDefault(logger)
+
+	db, err := datastore.NewSQLite(":memory:")
+	if err != nil {
+		log.Fatal("Failed to create datastore:", err)
+	}
+	if err := datastore.Initialize(db); err != nil {
+		log.Fatal("Failed to initialize datastore:", err)
+	}
+	defer datastore.Cleanup()
+
+	ctx := context.Background()
+	for _, model := range []any{(*User)(nil), (*Account)(nil), (*Site)(nil), (*UsageData)(nil)} {
+		if _, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx); err != nil {
+			log.Fatal("Failed to create table:", err)
+		}
+	}
+
+	// Seed usage data (ingested independently, keyed by NMI)
+	seedUsageData(db, ctx)
+
+	r := chi.NewRouter()
+
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	b := router.NewBuilder(r, db.GetDB())
+	router.RegisterRoutes[User](b, "/users", router.AllPublic(), func(b *router.Builder) {
+		router.RegisterRoutes[Account](b, "/accounts", router.AllPublic(), func(b *router.Builder) {
+			router.RegisterRoutes[Site](b, "/sites", router.AllPublic(), func(b *router.Builder) {
+				router.RegisterRoutes[UsageData](b, "/usage-data",
+					router.WithRelationName("UsageData"),
+					router.WithJoinOn("NMI", "NMI"),
+					router.AllPublic(),
+					router.QueryConfig{
+						FilterableFields: []string{"Date", "KWh"},
+						SortableFields:   []string{"Date", "KWh"},
+						DefaultSort:      "Date",
+					},
+				)
+			})
+		})
+	})
+
+	// Routes created:
+	//   /users                                                     CRUD
+	//   /users/{userId}/accounts                                   CRUD
+	//   /users/{userId}/accounts/{accountId}/sites                 CRUD
+	//   /users/{userId}/accounts/{accountId}/sites/{siteId}/usage-data   list + get (joined on NMI)
+
+	fmt.Println("Server starting on :" + getPort())
+	fmt.Println("Using SQLite in-memory database")
+	fmt.Println("\nThis example demonstrates WithJoinOn for non-FK relationships.")
+	fmt.Println("Site -> UsageData is joined on NMI (shared attribute), not a foreign key.")
+	fmt.Println("\nPre-seeded usage data for NMIs: NMI001, NMI002")
+	fmt.Println("\nExample flow:")
+	fmt.Println("  POST /users                                                      {\"name\":\"Alice\",\"email\":\"alice@example.com\"}")
+	fmt.Println("  POST /users/1/accounts                                           {\"name\":\"Home Account\"}")
+	fmt.Println("  POST /users/1/accounts/1/sites                                   {\"nmi\":\"NMI001\",\"address\":\"123 Main St\"}")
+	fmt.Println("  GET  /users/1/accounts/1/sites/1/usage-data                      (returns usage for NMI001)")
+	log.Fatal(http.ListenAndServe(":"+getPort(), r))
+}
+
+func getPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	return port
+}
+
+func seedUsageData(db *datastore.SQLite, ctx context.Context) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range 5 {
+		_, _ = db.GetDB().NewInsert().Model(&UsageData{
+			NMI:  "NMI001",
+			Date: base.AddDate(0, 0, i),
+			KWh:  10.5 + float64(i)*2.0,
+		}).Exec(ctx)
+	}
+	for i := range 3 {
+		_, _ = db.GetDB().NewInsert().Model(&UsageData{
+			NMI:  "NMI002",
+			Date: base.AddDate(0, 0, i),
+			KWh:  5.0 + float64(i)*1.5,
+		}).Exec(ctx)
+	}
+}

--- a/examples/files_proxy/main.go
+++ b/examples/files_proxy/main.go
@@ -115,7 +115,7 @@ func main() {
 	})
 
 	// Register routes
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 
 	// Posts with nested images
 	router.RegisterRoutes[Post](b, "/posts",

--- a/examples/files_signed/main.go
+++ b/examples/files_signed/main.go
@@ -120,7 +120,7 @@ func main() {
 	r.Handle("/files/*", http.StripPrefix("/files/", fileServer))
 
 	// Register routes
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 
 	// Posts with nested images
 	router.RegisterRoutes[Post](b, "/posts",

--- a/examples/nested_routes/README.md
+++ b/examples/nested_routes/README.md
@@ -58,7 +58,7 @@ type Comment struct {
 Use the Builder API to register nested routes with authentication:
 
 ```go
-b := router.NewBuilder(r)
+b := router.NewBuilder(r, db.GetDB())
 router.RegisterRoutes[User](b, "/users", router.AuthConfig{
     Methods: []string{router.MethodAll},
     Scopes:  []string{router.ScopePublic},  // Public for this example

--- a/examples/nested_routes/main.go
+++ b/examples/nested_routes/main.go
@@ -135,7 +135,7 @@ func main() {
 	})
 
 	// Register nested routes using the Builder API
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[User](b, "/users", router.AllPublic(), func(b *router.Builder) {
 		router.RegisterRoutes[Post](b, "/posts", router.AllPublic(), func(b *router.Builder) {
 			router.RegisterRoutes[Comment](b, "/comments", router.AllPublic())

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -80,7 +80,7 @@ func main() {
 	})
 
 	// Register CRUD routes with comprehensive filter/sort/pagination options
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Product](b, "/products",
 		router.AllPublic(),
 		router.WithFilters("Name", "Category", "Price", "Stock", "Active"),

--- a/examples/relations/main.go
+++ b/examples/relations/main.go
@@ -193,7 +193,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 
 	// Users - public access
 	router.RegisterRoutes[User](b, "/users",

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -82,7 +82,7 @@ This example shows:
 2. **Model with timestamps** - Automatic `created_at` and `updated_at` handling via `BeforeAppendModel` hook
 3. **Builder API** - Register routes with support for nesting:
    ```go
-   b := router.NewBuilder(r)
+   b := router.NewBuilder(r, db.GetDB())
    router.RegisterRoutes[User](b, "/users",
        router.AllPublic(),
        router.WithFilters("Name", "Email"),

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	// Register CRUD routes using Builder API (public for this simple example)
 	// Configure filtering, sorting, and pagination
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[User](b, "/users",
 		router.AllPublic(),
 		router.WithFilters("Name", "Email"),            // Allow filtering by Name and Email

--- a/examples/uuid_pk/main.go
+++ b/examples/uuid_pk/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	// Register CRUD routes with UUID primary keys
 	// Blogs are the parent resource, Posts are nested under blogs
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Blog](b, "/blogs",
 		router.AllPublic(),
 		router.WithFilters("Name"),

--- a/examples/validator/main.go
+++ b/examples/validator/main.go
@@ -151,7 +151,7 @@ func main() {
 	})
 
 	// Register Task routes with validation
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, db.GetDB())
 	router.RegisterRoutes[Task](b, "/tasks",
 		router.AllPublic(),
 		router.WithFilters("Status", "Priority"),

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -108,6 +108,8 @@ type TypeMetadata struct {
 	ParentType      reflect.Type  // Go type of parent (nil if root)
 	ParentMeta      *TypeMetadata // Direct pointer to parent metadata (nil if root)
 	ForeignKeyCol   string        // Column in THIS table that references parent (e.g., "user_id")
+	ParentJoinCol   string        // Parent column for JOIN SQL (default: "id"). Overridden by WithJoinOn().
+	ParentJoinField string        // Parent Go field name for JOIN (default: "ID"). Used by setForeignKey for custom joins.
 	OwnershipFields []string      // Model field names for ownership validation (OR logic)
 	BypassScopes    []string      // Scopes that bypass ownership validation (e.g., "admin")
 
@@ -143,24 +145,26 @@ type TypeMetadata struct {
 // Slices and maps are fully copied; pointer fields (ParentMeta) reference the same object.
 func (m *TypeMetadata) Clone() *TypeMetadata {
 	result := &TypeMetadata{
-		TypeID:         m.TypeID,
-		TypeName:       m.TypeName,
-		TableName:      m.TableName,
-		URLParamUUID:   m.URLParamUUID,
-		PKField:        m.PKField,
-		ModelType:      m.ModelType,
-		ParentType:     m.ParentType,
-		ParentMeta:     m.ParentMeta, // Intentionally shared - parent is not owned by this metadata
-		ForeignKeyCol:  m.ForeignKeyCol,
-		RelationName:   m.RelationName,
-		ParentFKField:  m.ParentFKField,
-		DefaultSort:    m.DefaultSort,
-		DefaultLimit:   m.DefaultLimit,
-		MaxLimit:       m.MaxLimit,
-		Validator:      m.Validator,
-		Auditor:        m.Auditor,
-		IsFileResource: m.IsFileResource,
-		BatchLimit:     m.BatchLimit,
+		TypeID:          m.TypeID,
+		TypeName:        m.TypeName,
+		TableName:       m.TableName,
+		URLParamUUID:    m.URLParamUUID,
+		PKField:         m.PKField,
+		ModelType:       m.ModelType,
+		ParentType:      m.ParentType,
+		ParentMeta:      m.ParentMeta, // Intentionally shared - parent is not owned by this metadata
+		ForeignKeyCol:   m.ForeignKeyCol,
+		ParentJoinCol:   m.ParentJoinCol,
+		ParentJoinField: m.ParentJoinField,
+		RelationName:    m.RelationName,
+		ParentFKField:   m.ParentFKField,
+		DefaultSort:     m.DefaultSort,
+		DefaultLimit:    m.DefaultLimit,
+		MaxLimit:        m.MaxLimit,
+		Validator:       m.Validator,
+		Auditor:         m.Auditor,
+		IsFileResource:  m.IsFileResource,
+		BatchLimit:      m.BatchLimit,
 	}
 
 	// Deep copy slices

--- a/router/action_test.go
+++ b/router/action_test.go
@@ -100,7 +100,7 @@ func TestAction_Registration(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -145,7 +145,7 @@ func TestAction_MultipleActions(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -204,7 +204,7 @@ func TestAction_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -261,7 +261,7 @@ func TestAction_WithOwnership(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Ownership needs to be on the resource auth config to be stored in metadata
 	// The action inherits this from the context set by wrapWithAuth
@@ -313,7 +313,7 @@ func TestAction_BlockedByDefault(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Action with empty auth config (no scopes) - should be blocked
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
@@ -337,7 +337,7 @@ func TestAction_NotFound(t *testing.T) {
 	cleanActionTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -381,7 +381,7 @@ func TestAction_CRUDStillWorks(t *testing.T) {
 	cleanActionTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -56,7 +56,7 @@ func setupAuthTest(t *testing.T, registerFunc func(*router.Builder)) *chi.Mux {
 
 	// Create router
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerFunc(b)
 
 	return r
@@ -132,7 +132,7 @@ func TestAuth_AuthOnlyRoute(t *testing.T) {
 
 	// Test with auth (any scopes) - create new router with auth middleware
 	r2 := addAuthMiddleware(chi.NewRouter(), "user123", []string{"random_scope"})
-	b := router.NewBuilder(r2)
+	b := router.NewBuilder(r2, testDB(t))
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{router.ScopeAuthOnly},
@@ -166,7 +166,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 
 	// With auth but wrong scope - 403
 	r = addAuthMiddleware(chi.NewRouter(), "user123", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin", "moderator"},
@@ -182,7 +182,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 
 	// With correct scope - 200
 	r = addAuthMiddleware(chi.NewRouter(), "user123", []string{"admin"})
-	b = router.NewBuilder(r)
+	b = router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin", "moderator"},
@@ -200,7 +200,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 func TestAuth_MethodSpecificAuth(t *testing.T) {
 	// Public reads, authenticated writes
 	r := addAuthMiddleware(chi.NewRouter(), "user123", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// First register without auth for GET/LIST (public reads)
 	router.RegisterRoutes[AuthTestUser](b, "/users",
@@ -216,7 +216,7 @@ func TestAuth_MethodSpecificAuth(t *testing.T) {
 
 	// GET /users (list) without auth - should succeed (public)
 	r2 := chi.NewRouter()
-	b2 := router.NewBuilder(r2)
+	b2 := router.NewBuilder(r2, testDB(t))
 	router.RegisterRoutes[AuthTestUser](b2, "/users",
 		router.AuthConfig{
 			Methods: []string{router.MethodGet, router.MethodList},
@@ -263,7 +263,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 	t.Run("PublicGet_AuthenticatedList", func(t *testing.T) {
 		// List requires auth, Get is public
 		r := chi.NewRouter()
-		b := router.NewBuilder(r)
+		b := router.NewBuilder(r, testDB(t))
 
 		router.RegisterRoutes[AuthTestPost](b, "/posts",
 			router.AuthConfig{
@@ -298,7 +298,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 	t.Run("PublicList_AuthenticatedGet", func(t *testing.T) {
 		// List is public, Get requires auth
 		r := chi.NewRouter()
-		b := router.NewBuilder(r)
+		b := router.NewBuilder(r, testDB(t))
 
 		router.RegisterRoutes[AuthTestPost](b, "/posts",
 			router.AuthConfig{
@@ -334,7 +334,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 func TestAuth_MethodAllOverride(t *testing.T) {
 	// MethodAll sets default, specific method overrides
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuthTestUser](b, "/users",
 		router.AuthConfig{
@@ -370,7 +370,7 @@ func TestAuth_MethodAllOverride(t *testing.T) {
 func TestAuth_Ownership_Create(t *testing.T) {
 	// Setup with ownership on posts
 	r := addAuthMiddleware(chi.NewRouter(), "auth0|user123", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -422,7 +422,7 @@ func TestAuth_Ownership_List(t *testing.T) {
 
 	// User1 should only see their post
 	r := addAuthMiddleware(chi.NewRouter(), "user1", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -469,7 +469,7 @@ func TestAuth_Ownership_BypassScope(t *testing.T) {
 
 	// Admin with bypass scope should see all posts
 	r := addAuthMiddleware(chi.NewRouter(), "admin_user", []string{"admin"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -511,7 +511,7 @@ func TestAuth_Ownership_Get404(t *testing.T) {
 
 	// User2 tries to access user1's post - should get 404
 	r := addAuthMiddleware(chi.NewRouter(), "user2", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -723,7 +723,7 @@ func TestAuth_ChildAuthPopulated(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Register parent (public) with child (ownership-based) using WithRelationName
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -816,7 +816,7 @@ func TestAuth_ChildAuthWithBypass(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllPublic(),
@@ -874,7 +874,7 @@ func TestAuth_ChildAuthNoAuth(t *testing.T) {
 
 	// Create router WITHOUT auth middleware (unauthenticated)
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllPublic(),
@@ -1001,7 +1001,7 @@ func TestAuth_NestedChildInclude(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts.Comments"
@@ -1042,7 +1042,7 @@ func TestAuth_NestedChildInclude_DeeperLevelBlocked(t *testing.T) {
 
 	// Comments require "premium" scope; user only has "user"
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllScoped("premium"))
 
 	// Single-level Posts include should still work
@@ -1097,7 +1097,7 @@ func TestAuth_NestedParentInclude(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	// GET comment with ?include=Post.Author
@@ -1140,7 +1140,7 @@ func TestAuth_ParentInclude_SingleLevel(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) +
@@ -1195,7 +1195,7 @@ func TestAuth_NestedParentInclude_DeeperLevelBlocked(t *testing.T) {
 
 	// Author requires "admin" scope; user only has "user"
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllScoped("admin"),
@@ -1268,7 +1268,7 @@ func TestAuth_SimpleChildInclude(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
@@ -1299,7 +1299,7 @@ func TestAuth_ChildInclude_NoAuth(t *testing.T) {
 
 	// No auth middleware — unauthenticated request
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
@@ -1329,7 +1329,7 @@ func TestAuth_ChildInclude_WrongScope(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1369,7 +1369,7 @@ func TestAuth_ChildInclude_ScopeGrantsAccess(t *testing.T) {
 
 	// User has "premium" scope which matches the child's requirement
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user", "premium"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Author is public, Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1409,7 +1409,7 @@ func TestAuth_ParentInclude_NoAuth(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Author requires "admin" scope, Post requires "editor" scope, Comment is public.
 	// No ownership at any level — avoids issue #28 parent ownership check blocking the request.
@@ -1460,7 +1460,7 @@ func TestAuth_ParentInclude_WrongScope(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Author requires "admin", Post is ownership, Comment is public
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1515,7 +1515,7 @@ func TestAuth_MixedPublicParent_ScopedChildInclude(t *testing.T) {
 
 	// No auth — unauthenticated request
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Author is public, Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1562,7 +1562,7 @@ func TestAuth_NestedChildInclude_MiddleLevelBlocked(t *testing.T) {
 
 	// User has "user" scope only
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Author is public, Posts require "editor" scope, Comments are public
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1662,7 +1662,7 @@ func TestAuth_Issue24_OwnershipWithEmptyUserID(t *testing.T) {
 
 	// Create router with middleware that sets empty UserID (simulating dhe pattern)
 	r := addAuthMiddlewareEmptyUserID(chi.NewRouter())
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Register route with ownership but no explicit scopes (the problematic pattern)
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
@@ -1702,7 +1702,7 @@ func TestAuth_Issue24_ScopeAuthOnlyWithEmptyUserID(t *testing.T) {
 
 	// Create router with middleware that sets empty UserID
 	r := addAuthMiddlewareEmptyUserID(chi.NewRouter())
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Register route with ScopeAuthOnly
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
@@ -1772,7 +1772,7 @@ func TestAuth_Issue28_ParentOwnershipNoAuth(t *testing.T) {
 
 	// Create router WITHOUT auth (simulating public child under owned parent)
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 		router.AuthConfig{
@@ -1835,7 +1835,7 @@ func TestAuth_Issue28_ParentOwnershipFiltering(t *testing.T) {
 			}
 
 			r := addAuthMiddleware(chi.NewRouter(), tt.authUser, []string{"user"})
-			b := router.NewBuilder(r)
+			b := router.NewBuilder(r, testDB(t))
 
 			router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 				router.AuthConfig{
@@ -1895,7 +1895,7 @@ func TestAuth_Issue28_ParentOwnershipBypass(t *testing.T) {
 
 	// Create router with Admin (has bypass scope)
 	r := addAuthMiddleware(chi.NewRouter(), "admin", []string{"user", "admin"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 		router.AuthConfig{

--- a/router/batch_test.go
+++ b/router/batch_test.go
@@ -46,7 +46,7 @@ func TestBatch_AllPublicWithBatch(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 	)
@@ -66,7 +66,7 @@ func TestBatch_AllScopedWithBatch(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllScopedWithBatch("admin"),
 	)
@@ -101,7 +101,7 @@ func TestBatch_WithBatchLimit(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithBatchLimit(2),
@@ -142,7 +142,7 @@ func TestBatch_CustomBatchCreate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchCreate(customFn),
@@ -178,7 +178,7 @@ func TestBatch_CustomBatchUpdate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchUpdate(customFn),
@@ -227,7 +227,7 @@ func TestBatch_CustomBatchDelete(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchDelete(customFn),
@@ -270,7 +270,7 @@ func TestBatch_NoBatchMethodsNoRoutes(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	// Only AllPublic, no batch methods
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublic(),
@@ -293,7 +293,7 @@ func TestBatch_PartialBatchMethods(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	// Only batch create, not update or delete
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublic(),

--- a/router/builder.go
+++ b/router/builder.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"reflect"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/schema"
 
 	"github.com/sjgoldie/go-restgen/handler"
 	"github.com/sjgoldie/go-restgen/metadata"
@@ -20,6 +21,7 @@ type NestedFunc func(b *Builder)
 // Builder provides context for registering nested routes and manages the chi router
 type Builder struct {
 	router                  chi.Router             // Chi router being configured
+	db                      *bun.DB                // Database connection for schema introspection
 	parentMeta              *metadata.TypeMetadata // Metadata of the immediate parent (nil for root)
 	parentChildRelationAuth map[string]*AuthConfig // Parent's shared child relation auth map (children add to this via registerChildAuthConfig)
 	parentGetAuth           *AuthConfig            // Parent's GET auth config (for ParentAuth chain on child configs)
@@ -59,10 +61,13 @@ type metadataSetup struct {
 	metadataMiddleware func(http.Handler) http.Handler
 }
 
-// NewBuilder creates a new Builder for registering routes
-func NewBuilder(r chi.Router) *Builder {
+// NewBuilder creates a new Builder for registering routes.
+// The db parameter provides access to Bun's schema introspection for resolving
+// field names, column names, table names, and relationships from model types.
+func NewBuilder(r chi.Router, db *bun.DB) *Builder {
 	return &Builder{
 		router:     r,
+		db:         db,
 		parentMeta: nil,
 	}
 }
@@ -92,6 +97,7 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 	var singleRoute *SingleRouteConfig
 	var isFileResource bool
 	var pkField string
+	var joinOn *JoinOnConfig
 
 	for _, opt := range options {
 		switch v := opt.(type) {
@@ -131,17 +137,19 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 			isFileResource = true
 		case PKFieldConfig:
 			pkField = v.FieldName
+		case JoinOnConfig:
+			joinOn = &v
 		case func(*Builder):
 			nested = v
 		}
 	}
 
-	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, relationName, singleRoute, isFileResource, pkField)
+	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, relationName, singleRoute, isFileResource, pkField, joinOn)
 }
 
 // prepareMetadata assembles type metadata and auth configuration before route registration.
 // This extracts the setup phase from registerRoutesWithBuilder to reduce cyclomatic complexity.
-func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string) (string, *metadataSetup) {
+func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string, joinOn *JoinOnConfig) (string, *metadataSetup) {
 	// Ensure path starts with /
 	if len(path) > 0 && path[0] != '/' {
 		path = "/" + path
@@ -162,19 +170,54 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	// This avoids chi routing conflicts with nested routes
 	urlParamUUID := metadata.GenerateTypeID()
 
-	// Get table name from bun tag
-	tableName := getTableName(tType)
+	// Get table name from Bun schema
+	tableName := getTableName(b.db, tType)
 
 	// Check if this type has a parent relationship
 	var parentType reflect.Type
 	if b.parentMeta != nil {
 		parentType = b.parentMeta.ModelType
 	}
-	parentRel, err := findParentRelationshipFromType(tType, parentType)
-	if err != nil {
-		slog.WarnContext(context.Background(), "could not find parent relationship",
-			"type", typeName,
-			"error", err)
+
+	var parentRel parentRelation
+	var parentJoinCol string
+	var parentJoinField string
+	if joinOn != nil && b.parentMeta != nil {
+		// WithJoinOn provided — resolve Go field names to column names via Bun schema.
+		childCol, err := columnFromGoName(b.db, tType, joinOn.ChildCol)
+		if err != nil {
+			slog.WarnContext(context.Background(), "WithJoinOn: invalid child field",
+				"type", typeName,
+				"field", joinOn.ChildCol,
+				"error", err)
+		}
+		parentCol, err := columnFromGoName(b.db, b.parentMeta.ModelType, joinOn.ParentCol)
+		if err != nil {
+			slog.WarnContext(context.Background(), "WithJoinOn: invalid parent field",
+				"type", typeName,
+				"field", joinOn.ParentCol,
+				"error", err)
+		}
+		parentRel = parentRelation{foreignKeyCol: childCol, parentJoinCol: parentCol}
+		parentJoinCol = parentCol
+		parentJoinField = joinOn.ParentCol
+	} else {
+		var err error
+		parentRel, err = findParentRelationshipFromType(b.db, tType, parentType)
+		if err != nil {
+			slog.WarnContext(context.Background(), "could not find parent relationship",
+				"type", typeName,
+				"error", err)
+		}
+		parentJoinCol = parentRel.parentJoinCol
+	}
+
+	// Default parent join column/field to "id"/"ID" for standard FK relationships
+	if parentJoinCol == "" {
+		parentJoinCol = "id"
+	}
+	if parentJoinField == "" {
+		parentJoinField = "ID"
 	}
 
 	// Validate parent relationship
@@ -187,17 +230,19 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 
 	// Create metadata with all configuration
 	meta := &metadata.TypeMetadata{
-		TypeID:         typeID,
-		TypeName:       typeName,
-		TableName:      tableName,
-		URLParamUUID:   urlParamUUID,
-		PKField:        pkField,
-		ModelType:      tType,
-		ParentType:     parentType,
-		ParentMeta:     b.parentMeta,
-		ForeignKeyCol:  parentRel.foreignKeyCol,
-		ChildMeta:      make(map[string]*metadata.TypeMetadata),
-		IsFileResource: isFileResource,
+		TypeID:          typeID,
+		TypeName:        typeName,
+		TableName:       tableName,
+		URLParamUUID:    urlParamUUID,
+		PKField:         pkField,
+		ModelType:       tType,
+		ParentType:      parentType,
+		ParentMeta:      b.parentMeta,
+		ForeignKeyCol:   parentRel.foreignKeyCol,
+		ParentJoinCol:   parentJoinCol,
+		ParentJoinField: parentJoinField,
+		ChildMeta:       make(map[string]*metadata.TypeMetadata),
+		IsFileResource:  isFileResource,
 	}
 
 	// Merge auth configs (last wins for each method)
@@ -281,8 +326,8 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 }
 
 // registerRoutesWithBuilder is the internal implementation
-func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string) {
-	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField)
+func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string, joinOn *JoinOnConfig) {
+	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField, joinOn)
 	meta := setup.meta
 	authMap := setup.authMap
 	metadataMiddleware := setup.metadataMiddleware
@@ -428,6 +473,7 @@ func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc
 		if nested != nil && nestedRouter != nil {
 			childBuilder := &Builder{
 				router:                  nestedRouter,
+				db:                      b.db,
 				parentMeta:              meta,
 				parentChildRelationAuth: setup.childRelationAuth,
 				parentGetAuth:           setup.authMap[MethodGet],
@@ -497,81 +543,80 @@ func createParentIDMiddleware(paramUUID string) func(http.Handler) http.Handler 
 // parentRelation holds the results of finding a parent relationship
 type parentRelation struct {
 	foreignKeyCol string // FK column name (e.g., "author_id")
+	parentJoinCol string // Parent join column name (e.g., "id") — right side of join: tag
 	fieldName     string // Struct field name for belongs-to (e.g., "Author")
 }
 
-// findParentRelationshipFromType looks for a belongs-to relationship between child and parent types
-// and extracts the foreign key from the bun relation tag. Returns the foreign key column name
-// and the belongs-to field name.
-// Handles two cases:
-// 1. Child has belongs-to Parent (e.g., Comment belongs-to Post) - FK is on child
-// 2. Parent has belongs-to Child (e.g., Post belongs-to User/Author) - FK is on parent
-func findParentRelationshipFromType(childType reflect.Type, parentType reflect.Type) (parentRelation, error) {
+// findParentRelationshipFromType uses Bun's schema to find the relationship between child and parent.
+// Checks for:
+// 1. Child has belongs-to Parent (e.g., Article belongs-to User) — FK is on child
+// 2. Parent has has-many/has-one Child — extract join columns from parent's relation
+func findParentRelationshipFromType(db *bun.DB, childType reflect.Type, parentType reflect.Type) (parentRelation, error) {
 	if parentType == nil {
 		return parentRelation{}, nil
 	}
-	// Case 1: child belongs-to parent
-	if rel := parseBelongsToRelation(childType, parentType); rel.foreignKeyCol != "" {
-		return rel, nil
+
+	childTable := db.Table(childType)
+
+	// Case 1: child has a belongs-to relation pointing to parent
+	for _, rel := range childTable.Relations {
+		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == parentType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return parentRelation{
+					foreignKeyCol: rel.BasePKs[0].Name,
+					parentJoinCol: rel.JoinPKs[0].Name,
+					fieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
 	}
-	// Case 2: parent belongs-to child (inverted)
-	if rel := parseBelongsToRelation(parentType, childType); rel.foreignKeyCol != "" {
-		return rel, nil
+
+	// Case 2: parent has has-many or has-one pointing to child
+	parentTable := db.Table(parentType)
+	for _, rel := range parentTable.Relations {
+		if (rel.Type == schema.HasManyRelation || rel.Type == schema.HasOneRelation) && rel.JoinTable.Type == childType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return parentRelation{
+					foreignKeyCol: rel.JoinPKs[0].Name,
+					parentJoinCol: rel.BasePKs[0].Name,
+					fieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
 	}
+
+	// Case 3: parent has belongs-to pointing to child (inverted belongs-to,
+	// e.g., Post.Author belongs-to User — FK author_id is on the parent)
+	for _, rel := range parentTable.Relations {
+		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == childType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return parentRelation{
+					foreignKeyCol: rel.BasePKs[0].Name,
+					parentJoinCol: rel.JoinPKs[0].Name,
+					fieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
+	}
+
 	return parentRelation{}, fmt.Errorf("no relationship between %s and %s found", childType.Name(), parentType.Name())
 }
 
-// parseBelongsToRelation looks for a belongs-to field on sourceType pointing to targetType.
-// Returns the FK column name and the struct field name.
-func parseBelongsToRelation(sourceType, targetType reflect.Type) parentRelation {
-	for i := 0; i < sourceType.NumField(); i++ {
-		field := sourceType.Field(i)
-
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-
-		if fieldType == targetType {
-			bunTag := field.Tag.Get("bun")
-			if bunTag == "" {
-				continue
-			}
-			// Parse bun tag for join clause: "rel:belongs-to,join:post_id=id"
-			for _, part := range strings.Split(bunTag, ",") {
-				part = strings.TrimSpace(part)
-				if strings.HasPrefix(part, "join:") {
-					joinClause := strings.TrimPrefix(part, "join:")
-					if idx := strings.Index(joinClause, "="); idx != -1 {
-						return parentRelation{
-							foreignKeyCol: strings.TrimSpace(joinClause[:idx]),
-							fieldName:     field.Name,
-						}
-					}
-				}
-			}
+// columnFromGoName resolves a Go field name to its SQL column name using Bun's schema.
+func columnFromGoName(db *bun.DB, tType reflect.Type, goName string) (string, error) {
+	table := db.Table(tType)
+	for _, field := range table.Fields {
+		if field.GoName == goName {
+			return field.Name, nil
 		}
 	}
-	return parentRelation{}
+	return "", fmt.Errorf("field %s not found on type %s", goName, tType.Name())
 }
 
-// getTableName extracts table name from bun tag on the struct
-func getTableName(tType reflect.Type) string {
-	// Look for bun.BaseModel field
-	for i := 0; i < tType.NumField(); i++ {
-		field := tType.Field(i)
-		bunTag := field.Tag.Get("bun")
-		if strings.HasPrefix(bunTag, "table:") {
-			parts := strings.Split(bunTag, ",")
-			for _, part := range parts {
-				if strings.HasPrefix(part, "table:") {
-					return strings.TrimPrefix(part, "table:")
-				}
-			}
-		}
-	}
-	// Fallback: pluralize type name and lowercase
-	return strings.ToLower(tType.Name()) + "s"
+// getTableName returns the SQL table name for a model type using Bun's schema.
+func getTableName(db *bun.DB, tType reflect.Type) string {
+	table := db.Table(tType)
+	return table.Name
 }
 
 // mergeQueryConfigs applies query configurations to metadata and returns a new copy.

--- a/router/builder_internal_test.go
+++ b/router/builder_internal_test.go
@@ -2,17 +2,32 @@ package router
 
 import (
 	"context"
+	"database/sql"
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	_ "github.com/uptrace/bun/driver/sqliteshim"
 
 	"github.com/sjgoldie/go-restgen/filestore"
 	"github.com/sjgoldie/go-restgen/metadata"
 )
 
+func testDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return bun.NewDB(sqlDB, sqlitedialect.New())
+}
+
 const testFieldName = "Name"
+const testAuthorIDCol = "author_id"
 
 // testModel is a simple model for testing route registration
 type testModel struct {
@@ -162,6 +177,130 @@ func TestMergeQueryConfigs(t *testing.T) {
 	})
 }
 
+type columnFromGoNameTestModel struct {
+	bun.BaseModel `bun:"table:test_ftc"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	NMI           string `bun:"nmi,notnull"`
+	AuthorID      int    `bun:"author_id,notnull"`
+}
+
+func TestColumnFromGoName(t *testing.T) {
+	db := testDB(t)
+	tType := reflect.TypeOf(columnFromGoNameTestModel{})
+
+	t.Run("standard field", func(t *testing.T) {
+		col, err := columnFromGoName(db, tType, "AuthorID")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != testAuthorIDCol {
+			t.Errorf("expected 'author_id', got '%s'", col)
+		}
+	})
+
+	t.Run("acronym field", func(t *testing.T) {
+		col, err := columnFromGoName(db, tType, "NMI")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != "nmi" {
+			t.Errorf("expected 'nmi', got '%s'", col)
+		}
+	})
+
+	t.Run("pk field", func(t *testing.T) {
+		col, err := columnFromGoName(db, tType, "ID")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != "id" {
+			t.Errorf("expected 'id', got '%s'", col)
+		}
+	})
+
+	t.Run("field not found", func(t *testing.T) {
+		_, err := columnFromGoName(db, tType, "Nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent field")
+		}
+	})
+}
+
+// Models for testing findParentRelationshipFromType — inverted belongs-to case
+// (parent has belongs-to pointing to child, e.g., Post.Author belongs-to User)
+type parentRelUser struct {
+	bun.BaseModel `bun:"table:parent_rel_users"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+}
+
+type parentRelPost struct {
+	bun.BaseModel `bun:"table:parent_rel_posts"`
+	ID            int            `bun:"id,pk,autoincrement"`
+	AuthorID      int            `bun:"author_id,notnull"`
+	Author        *parentRelUser `bun:"rel:belongs-to,join:author_id=id"`
+	Title         string         `bun:"title"`
+}
+
+func TestFindParentRelationshipFromType(t *testing.T) {
+	db := testDB(t)
+	userType := reflect.TypeOf(parentRelUser{})
+	postType := reflect.TypeOf(parentRelPost{})
+
+	t.Run("child belongs-to parent", func(t *testing.T) {
+		// Post belongs-to User (standard case: FK author_id is on Post)
+		rel, err := findParentRelationshipFromType(db, postType, userType)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.foreignKeyCol != testAuthorIDCol {
+			t.Errorf("expected foreignKeyCol 'author_id', got %q", rel.foreignKeyCol)
+		}
+		if rel.parentJoinCol != "id" {
+			t.Errorf("expected parentJoinCol 'id', got %q", rel.parentJoinCol)
+		}
+		if rel.fieldName != "Author" {
+			t.Errorf("expected fieldName 'Author', got %q", rel.fieldName)
+		}
+	})
+
+	t.Run("parent belongs-to child (inverted)", func(t *testing.T) {
+		// User registered as child of Post — Post.Author belongs-to User
+		// FK author_id is on the parent (Post), not on the child (User)
+		rel, err := findParentRelationshipFromType(db, userType, postType)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.foreignKeyCol != testAuthorIDCol {
+			t.Errorf("expected foreignKeyCol 'author_id', got %q", rel.foreignKeyCol)
+		}
+		if rel.parentJoinCol != "id" {
+			t.Errorf("expected parentJoinCol 'id', got %q", rel.parentJoinCol)
+		}
+		if rel.fieldName != "Author" {
+			t.Errorf("expected fieldName 'Author', got %q", rel.fieldName)
+		}
+	})
+
+	t.Run("no relationship", func(t *testing.T) {
+		unrelatedType := reflect.TypeOf(testModel{})
+		_, err := findParentRelationshipFromType(db, unrelatedType, userType)
+		if err == nil {
+			t.Fatal("expected error for unrelated types")
+		}
+	})
+
+	t.Run("nil parent returns empty", func(t *testing.T) {
+		rel, err := findParentRelationshipFromType(db, postType, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.foreignKeyCol != "" {
+			t.Errorf("expected empty foreignKeyCol, got %q", rel.foreignKeyCol)
+		}
+	})
+}
+
 func TestRegisterChildAuthConfig(t *testing.T) {
 	t.Run("empty relationName does nothing", func(t *testing.T) {
 		sharedMap := make(map[string]*AuthConfig)
@@ -259,7 +398,7 @@ func TestSharedChildRelationAuth(t *testing.T) {
 		// This test verifies that when we use AllPublicWithBatch and register child routes,
 		// the batch auth configs have access to the same ChildAuth map as regular GET/LIST configs
 		r := chi.NewRouter()
-		b := NewBuilder(r)
+		b := NewBuilder(r, testDB(t))
 
 		// We need to capture the auth configs to verify they share the same ChildAuth
 		// Since we can't easily access them after registration, we'll verify the behavior
@@ -350,7 +489,7 @@ func TestFileResourceRegistration(t *testing.T) {
 		}
 
 		r := chi.NewRouter()
-		b := NewBuilder(r)
+		b := NewBuilder(r, testDB(t))
 		RegisterRoutes[testModel](b, "/test", AsFileResource())
 	})
 }

--- a/router/builder_test.go
+++ b/router/builder_test.go
@@ -4,6 +4,7 @@ package router_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	_ "github.com/uptrace/bun/driver/sqliteshim"
 
 	"github.com/sjgoldie/go-restgen/datastore"
 	"github.com/sjgoldie/go-restgen/filestore"
@@ -24,6 +27,16 @@ import (
 	"github.com/sjgoldie/go-restgen/router"
 	"github.com/sjgoldie/go-restgen/service"
 )
+
+func testDB(t *testing.T) *bun.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { sqlDB.Close() })
+	return bun.NewDB(sqlDB, sqlitedialect.New())
+}
 
 func TestMain(m *testing.M) {
 	// Initialize datastore for all tests
@@ -122,7 +135,7 @@ func setupBuilderTest(t *testing.T) (*chi.Mux, *bun.DB) {
 
 	// Create router with nested routes using Builder API
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 	router.RegisterRoutes[TestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{router.ScopePublic},
@@ -469,7 +482,7 @@ func TestMultiReg_SameModelRootAndNested(t *testing.T) {
 
 	// Setup router with Item at root AND nested under Project
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Root registration: /items (all items)
 	router.RegisterRoutes[MultiRegItem](b, "/items", router.AuthConfig{
@@ -574,7 +587,7 @@ func TestMultiReg_SameModelDifferentParents(t *testing.T) {
 
 	// Setup router with Item under both Project and User
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[MultiRegProject](b, "/projects", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -671,7 +684,7 @@ func TestMultiReg_DifferentOwnershipPerRegistration(t *testing.T) {
 	// - /projects/{id}/items: ownership enforced (sees only own items)
 	r := chi.NewRouter()
 	addMultiRegAuthMiddleware(r, "alice", []string{"user"})
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Root: public, no ownership
 	router.RegisterRoutes[MultiRegItem](b, "/items", router.AuthConfig{
@@ -764,7 +777,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Admin can see all project items (bypass)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "admin_user", []string{"admin"})
-		b := router.NewBuilder(r)
+		b := router.NewBuilder(r, testDB(t))
 
 		router.RegisterRoutes[MultiRegProject](b, "/projects", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -800,7 +813,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Admin does NOT bypass user items (different bypass scope)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "admin_user", []string{"admin"})
-		b := router.NewBuilder(r)
+		b := router.NewBuilder(r, testDB(t))
 
 		router.RegisterRoutes[MultiRegUser](b, "/users", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -837,7 +850,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Moderator can see all user items (bypass)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "mod_user", []string{"moderator"})
-		b := router.NewBuilder(r)
+		b := router.NewBuilder(r, testDB(t))
 
 		router.RegisterRoutes[MultiRegUser](b, "/users", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -891,7 +904,7 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 
 	// Setup router with query config options
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[MultiRegItem](b, "/items",
 		router.AuthConfig{
@@ -1071,7 +1084,7 @@ func TestBuilder_ValidationCreate(t *testing.T) {
 	setupJobTable()
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Register with validator: new jobs must have status "pending" and priority 1-5
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1149,7 +1162,7 @@ func TestBuilder_ValidationUpdate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Validator: can only move to "in_progress" from "pending", and to "complete" from "in_progress"
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1229,7 +1242,7 @@ func TestBuilder_ValidationDelete(t *testing.T) {
 	_, _ = db.NewInsert().Model(inProgressJob).Returning("*").Exec(context.Background())
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	// Validator: can't delete jobs that are in_progress
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1286,7 +1299,7 @@ func TestBuilder_CustomHandlers(t *testing.T) {
 
 	// Setup router with ALL custom handler options
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	customGetCalled := false
 	customGetAllCalled := false
@@ -1437,7 +1450,7 @@ func TestWithAudit(t *testing.T) {
 
 	// Setup router with audit
 	r := chi.NewRouter()
-	b := router.NewBuilder(r)
+	b := router.NewBuilder(r, testDB(t))
 
 	router.RegisterRoutes[AuditedTask](b, "/tasks",
 		router.AuthConfig{

--- a/router/relation.go
+++ b/router/relation.go
@@ -14,6 +14,21 @@ func WithRelationName(name string) RelationConfig {
 	}
 }
 
+// JoinOnConfig specifies custom join columns for non-FK relationships.
+// Use this when the child has no belongs-to tag pointing to the parent
+// and the join is on a shared attribute (e.g., NMI) rather than the parent's PK.
+type JoinOnConfig struct {
+	ChildCol  string // Column on child table (e.g., "nmi")
+	ParentCol string // Column on parent table (e.g., "nmi")
+}
+
+// WithJoinOn configures custom join columns for this child route.
+// Used when the relationship is through a shared attribute rather than a foreign key.
+// Example: WithJoinOn("NMI", "NMI") joins usage_data.nmi = sites.nmi
+func WithJoinOn(childCol, parentCol string) JoinOnConfig {
+	return JoinOnConfig{ChildCol: childCol, ParentCol: parentCol}
+}
+
 // SingleRouteConfig marks this route as a single-object route (not a collection)
 // Used for belongs-to relations like /posts/{id}/author
 // Only GET is registered; the ID is resolved from the parent's FK field

--- a/router/relation_test.go
+++ b/router/relation_test.go
@@ -4,12 +4,38 @@ import (
 	"testing"
 )
 
+const testNMIField = "NMI"
+
 func TestWithRelationName(t *testing.T) {
 	config := WithRelationName("Posts")
 
 	if config.Name != "Posts" {
 		t.Errorf("expected relation name 'Posts', got '%s'", config.Name)
 	}
+}
+
+func TestWithJoinOn(t *testing.T) {
+	t.Run("sets both columns", func(t *testing.T) {
+		config := WithJoinOn(testNMIField, testNMIField)
+
+		if config.ChildCol != testNMIField {
+			t.Errorf("expected ChildCol 'NMI', got '%s'", config.ChildCol)
+		}
+		if config.ParentCol != testNMIField {
+			t.Errorf("expected ParentCol 'NMI', got '%s'", config.ParentCol)
+		}
+	})
+
+	t.Run("different child and parent columns", func(t *testing.T) {
+		config := WithJoinOn("SiteNMI", testNMIField)
+
+		if config.ChildCol != "SiteNMI" {
+			t.Errorf("expected ChildCol 'SiteNMI', got '%s'", config.ChildCol)
+		}
+		if config.ParentCol != testNMIField {
+			t.Errorf("expected ParentCol 'NMI', got '%s'", config.ParentCol)
+		}
+	})
 }
 
 func TestAsSingleRoute(t *testing.T) {

--- a/scripts/run-bruno-tests.sh
+++ b/scripts/run-bruno-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Bruno API test runner for go-restgen examples
-# Usage: ./scripts/run-bruno-tests.sh [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|all]
+# Usage: ./scripts/run-bruno-tests.sh [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|custom-join|all]
 # Set PORT env var to override the default port (8080), e.g.: PORT=9090 ./scripts/run-bruno-tests.sh all
 
 set -e
@@ -178,6 +178,9 @@ case "$TEST_SUITE" in
     query)
         run_tests "Query Example" "examples/query" "query-example" || FAILED=1
         ;;
+    custom-join)
+        run_tests "Custom Join Example" "examples/custom_join" "custom-join-example" || FAILED=1
+        ;;
     all)
         run_tests "Simple Example" "examples/simple" "simple-example" || FAILED=1
         run_tests "Nested Example" "examples/nested_routes" "nested-example" || FAILED=1
@@ -192,9 +195,10 @@ case "$TEST_SUITE" in
         run_tests "Actions Example" "examples/actions" "actions-example" || FAILED=1
         run_tests "Batch Example" "examples/batch" "batch-example" || FAILED=1
         run_tests "Query Example" "examples/query" "query-example" || FAILED=1
+        run_tests "Custom Join Example" "examples/custom_join" "custom-join-example" || FAILED=1
         ;;
     *)
-        echo "Usage: $0 [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|all]"
+        echo "Usage: $0 [simple|nested|auth|validator|audit|uuid|custom|relations|files-proxy|files-signed|actions|batch|query|custom-join|all]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Add `WithJoinOn(childField, parentField)` router option for custom join columns (e.g., `Site.NMI = UsageData.NMI`)
- Replace all manual bun struct tag parsing with Bun's schema introspection API (`db.Table()`)
- `NewBuilder` now requires `*bun.DB` parameter for schema access
- Handle inverted belongs-to relationships (parent belongs-to child, e.g., `Post.Author`)

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] All Bruno integration tests pass (13/14, Files Signed is a known issue)
- [x] New unit tests for `findParentRelationshipFromType` (standard, inverted, unrelated, nil parent)
- [x] New unit tests for `WithJoinOn` and `columnFromGoName`
- [x] New datastore tests for non-FK join relationships
- [x] New `custom_join` example with Bruno tests and CI workflow job
- [x] Verify existing relationships unchanged (backwards compatible via `ParentJoinCol` defaulting to `"id"`)

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)