### PR TITLE
Fix WithSums for decimal.Decimal and struct-based numeric types

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -123,7 +123,7 @@ router.RegisterRoutes[Model](builder, "/path",
     router.WithDefaultSort("-CreatedAt"),
     router.WithRelationName("Posts"),  // enables ?include=Posts on parent
     router.WithJoinOn("NMI", "NMI"),  // custom join: child.NMI = parent.NMI (no belongs-to tag needed)
-    router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock with X-Sum-* headers
+    router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock with X-Sum-* headers (works with any DB-numeric type including decimal.Decimal)
     router.WithAlternatePK("MyPK"),     // when PK field isn't named "ID"
 
     // Custom handlers
@@ -358,7 +358,7 @@ Built-in support on GetAll endpoints:
 | Offset | `?offset=20` | Skip results |
 | Count | `?count=true` | Include X-Total-Count header |
 | Include | `?include=Posts` or `?include=Posts.Comments` | Load relations (requires WithRelationName on child route). Dot notation for nested. |
-| Sum | `?sum=Price,Stock` | Sum numeric fields, returns X-Sum-Price, X-Sum-Stock headers (requires WithSums) |
+| Sum | `?sum=Price,Stock` | Sum fields, returns X-Sum-Price, X-Sum-Stock headers (requires WithSums). Works with any DB-numeric type including `decimal.Decimal`. Bool fields return count of `true` values. DB validates types — non-numeric columns return a database error. |
 
 **Filter operator details:**
 - `in` - In list: `?filter[Status][in]=active,pending`

--- a/README.md
+++ b/README.md
@@ -755,13 +755,13 @@ GET /users?limit=10&offset=20&count=true
 
 ### Sum Aggregation
 
-Request sum totals for numeric fields using the `sum` query parameter:
+Request sum totals using the `sum` query parameter. Any field with a numeric database column type can be summed, including struct-based types like `decimal.Decimal`:
 
 ```go
 router.RegisterRoutes[Product](b, "/products",
     router.AllPublic(),
     router.WithFilters("Category", "Price"),
-    router.WithSums("Price", "Stock"),  // Allow summing these fields
+    router.WithSums("Price", "Stock", "TotalAmount"),  // Allow summing these fields
 )
 ```
 
@@ -780,7 +780,7 @@ GET /products?filter[Category]=Electronics&sum=Price,Stock&count=true
 - `X-Sum-Price` - Sum of the Price field across matching records
 - `X-Sum-Stock` - Sum of the Stock field across matching records
 
-Non-numeric fields (strings, bools) return 0 in the sum header. Fields not listed in `WithSums` are silently ignored.
+Fields not listed in `WithSums` are silently ignored (returns 0). Bool fields return the count of `true` values. The database validates types — summing a non-numeric column (e.g. a string) returns a database error.
 
 See the [query example](./examples/query) for a complete working example with all filter operators, sorting, pagination, and sum aggregation.
 

--- a/bruno/query-example/44-sum-string-field.bru
+++ b/bruno/query-example/44-sum-string-field.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Sum String Field - Returns 0
+  name: Sum String Field - Database Handles Type
   type: http
   seq: 44
 }
@@ -16,8 +16,9 @@ assert {
 }
 
 tests {
-  test("X-Sum-Name header returns 0 for non-numeric field", function() {
-    // String fields cannot be summed, should return 0
-    expect(res.headers['x-sum-name']).to.equal('0');
+  test("X-Sum-Name header returns database SUM of varchar field", function() {
+    // SQLite coerces numeric-looking text to numbers: "123" → 123, "Apple" → 0
+    // Product "123" contributes 123, all others contribute 0 → SUM = 123
+    expect(res.headers['x-sum-name']).to.equal('123');
   });
 }

--- a/bruno/query-example/45-sum-bool-field.bru
+++ b/bruno/query-example/45-sum-bool-field.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Sum Bool Field - Returns 0
+  name: Sum Bool Field - Counts True Values
   type: http
   seq: 45
 }
@@ -16,8 +16,9 @@ assert {
 }
 
 tests {
-  test("X-Sum-Active header returns 0 for bool field", function() {
-    // Bool fields cannot be summed, should return 0
-    expect(res.headers['x-sum-active']).to.equal('0');
+  test("X-Sum-Active header returns count of true values", function() {
+    // Bool fields are passed to the database — SUM counts true values (stored as 1)
+    // 5 products with active=true, 2 with active=false → SUM = 5
+    expect(res.headers['x-sum-active']).to.equal('5');
   });
 }

--- a/bruno/query-example/47-sum-mixed-valid-invalid.bru
+++ b/bruno/query-example/47-sum-mixed-valid-invalid.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Sum Mixed Valid and Invalid Fields
+  name: Sum Mixed Numeric and Non-Numeric Fields
   type: http
   seq: 47
 }
@@ -17,12 +17,11 @@ assert {
 
 tests {
   test("X-Sum-Price header contains valid sum", function() {
-    // Price is numeric and allowed, should return actual sum
     expect(res.headers['x-sum-price']).to.equal('2297');
   });
 
-  test("X-Sum-Name header returns 0 for invalid field", function() {
-    // Name is string, should return 0 but still be present
-    expect(res.headers['x-sum-name']).to.equal('0');
+  test("X-Sum-Name header returns database SUM of varchar field", function() {
+    // SQLite coerces numeric-looking text: "123" → 123, others → 0
+    expect(res.headers['x-sum-name']).to.equal('123');
   });
 }

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -2,10 +2,12 @@ package datastore_test
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"github.com/uptrace/bun"
 
 	"github.com/sjgoldie/go-restgen/datastore"
@@ -1429,7 +1431,7 @@ var testQueryProductMetaWithSums = &metadata.TypeMetadata{
 	ModelType:        reflect.TypeOf(TestQueryProduct{}),
 	FilterableFields: []string{"Name", "Category", "Price", "InStock"},
 	SortableFields:   []string{"Name", "Price", "CreatedAt"},
-	SummableFields:   []string{"Price", "Name", "InStock"}, // Price is numeric, Name is string, InStock is bool
+	SummableFields:   []string{"Price", "Name", "InStock"},
 	DefaultLimit:     10,
 	MaxLimit:         100,
 }
@@ -1468,7 +1470,7 @@ func TestQuery_Sum_MultipleFields(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Request sum of Price (numeric) and Name (string - should return 0)
+	// Request sum of Price (int) and Name (varchar — SQLite returns 0 for non-numeric text)
 	opts := &metadata.QueryOptions{
 		Sums: []string{"Price", "Name"},
 	}
@@ -1479,15 +1481,14 @@ func TestQuery_Sum_MultipleFields(t *testing.T) {
 		t.Fatal("GetAll failed:", err)
 	}
 
-	// Price sum should be 410
 	expectedPriceSum := 410.0
 	if sums["Price"] != expectedPriceSum {
 		t.Errorf("Expected sum of Price to be %v, got %v", expectedPriceSum, sums["Price"])
 	}
 
-	// Name (string) sum should be 0 (non-numeric)
+	// SQLite: non-numeric text sums to 0
 	if sums["Name"] != 0 {
-		t.Errorf("Expected sum of Name (string) to be 0, got %v", sums["Name"])
+		t.Errorf("Expected sum of Name (varchar) to be 0, got %v", sums["Name"])
 	}
 }
 
@@ -1558,7 +1559,7 @@ func TestQuery_Sum_WithCount(t *testing.T) {
 	}
 }
 
-func TestQuery_Sum_NonNumericField(t *testing.T) {
+func TestQuery_Sum_VarcharField_NoPanic(t *testing.T) {
 	db, cleanup := setupQueryTestDB(t)
 	defer cleanup()
 
@@ -1566,7 +1567,8 @@ func TestQuery_Sum_NonNumericField(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Request sum of Name (string field in allowlist)
+	// Summing a varchar field should not panic.
+	// SQLite returns 0 for non-numeric text; PostgreSQL would return a database error.
 	opts := &metadata.QueryOptions{
 		Sums: []string{"Name"},
 	}
@@ -1574,12 +1576,13 @@ func TestQuery_Sum_NonNumericField(t *testing.T) {
 
 	_, _, sums, err := wrapper.GetAll(ctx)
 	if err != nil {
-		t.Fatal("GetAll failed:", err)
+		// Database error is acceptable (PostgreSQL rejects SUM on text)
+		return
 	}
 
-	// String field should return 0 (with slog warning)
+	// SQLite: non-numeric text values sum to 0
 	if sums["Name"] != 0 {
-		t.Errorf("Expected sum of Name (string) to be 0, got %v", sums["Name"])
+		t.Errorf("Expected sum of Name (varchar) to be 0, got %v", sums["Name"])
 	}
 }
 
@@ -1591,7 +1594,7 @@ func TestQuery_Sum_BoolField(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Request sum of InStock (bool field in allowlist)
+	// Bool fields are now passed to the database — SUM counts true values (stored as 1)
 	opts := &metadata.QueryOptions{
 		Sums: []string{"InStock"},
 	}
@@ -1602,9 +1605,10 @@ func TestQuery_Sum_BoolField(t *testing.T) {
 		t.Fatal("GetAll failed:", err)
 	}
 
-	// Bool field should return 0 (with slog warning)
-	if sums["InStock"] != 0 {
-		t.Errorf("Expected sum of InStock (bool) to be 0, got %v", sums["InStock"])
+	// 4 products with InStock=true, 1 with false → SUM = 4
+	expectedSum := 4.0
+	if sums["InStock"] != expectedSum {
+		t.Errorf("Expected sum of InStock (bool) to be %v, got %v", expectedSum, sums["InStock"])
 	}
 }
 
@@ -1666,7 +1670,7 @@ func TestQuery_Sum_MixedValidAndInvalid(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMetaWithSums)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Request sum of Price (valid numeric) and Name (invalid string in allowlist)
+	// Price (int) and Name (varchar) — both pass to DB; Name sums to 0 in SQLite
 	opts := &metadata.QueryOptions{
 		Sums: []string{"Price", "Name"},
 	}
@@ -1677,15 +1681,13 @@ func TestQuery_Sum_MixedValidAndInvalid(t *testing.T) {
 		t.Fatal("GetAll failed:", err)
 	}
 
-	// Price should have valid sum
 	expectedPriceSum := 410.0
 	if sums["Price"] != expectedPriceSum {
 		t.Errorf("Expected sum of Price to be %v, got %v", expectedPriceSum, sums["Price"])
 	}
 
-	// Name should be 0 but still present in response
 	if sums["Name"] != 0 {
-		t.Errorf("Expected sum of Name to be 0, got %v", sums["Name"])
+		t.Errorf("Expected sum of Name (varchar) to be 0, got %v", sums["Name"])
 	}
 }
 
@@ -1709,5 +1711,169 @@ func TestQuery_Sum_NoSumsRequested(t *testing.T) {
 	// Should return nil or empty map when no sums requested
 	if len(sums) > 0 {
 		t.Errorf("Expected nil or empty sums map when no sums requested, got %v", sums)
+	}
+}
+
+// TestDecimalProduct is a test model with shopspring/decimal fields to verify
+// that struct-based numeric types work with WithSums (issue #50)
+type TestDecimalProduct struct {
+	bun.BaseModel `bun:"table:decimal_products"`
+	ID            int             `bun:"id,pk,autoincrement" json:"id"`
+	Name          string          `bun:"name,notnull" json:"name"`
+	Category      string          `bun:"category,notnull" json:"category"`
+	UnitPrice     decimal.Decimal `bun:"unit_price,notnull,type:decimal(10,2)" json:"unitPrice"`
+	TaxAmount     decimal.Decimal `bun:"tax_amount,notnull,type:decimal(10,2)" json:"taxAmount"`
+}
+
+var testDecimalProductMeta = &metadata.TypeMetadata{
+	TypeID:           "decimal_product_id",
+	TypeName:         "TestDecimalProduct",
+	TableName:        "decimal_products",
+	URLParamUUID:     "productId",
+	ModelType:        reflect.TypeOf(TestDecimalProduct{}),
+	FilterableFields: []string{"Name", "Category"},
+	SortableFields:   []string{"Name", "UnitPrice"},
+	SummableFields:   []string{"UnitPrice", "TaxAmount"},
+	DefaultLimit:     10,
+	MaxLimit:         100,
+}
+
+func setupDecimalTestDB(t *testing.T) (*datastore.SQLite, func()) {
+	return setupTestDBWithModel(t, (*TestDecimalProduct)(nil), (*TestDecimalProduct)(nil))
+}
+
+func seedDecimalProducts(t *testing.T, wrapper *datastore.Wrapper[TestDecimalProduct], ctx context.Context) {
+	t.Helper()
+
+	products := []TestDecimalProduct{
+		{Name: "Widget", Category: "Hardware", UnitPrice: decimal.NewFromFloat(29.99), TaxAmount: decimal.NewFromFloat(3.00)},
+		{Name: "Gadget", Category: "Hardware", UnitPrice: decimal.NewFromFloat(49.95), TaxAmount: decimal.NewFromFloat(5.00)},
+		{Name: "Service", Category: "Software", UnitPrice: decimal.NewFromFloat(199.00), TaxAmount: decimal.NewFromFloat(19.90)},
+		{Name: "License", Category: "Software", UnitPrice: decimal.NewFromFloat(99.50), TaxAmount: decimal.NewFromFloat(9.95)},
+	}
+
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed decimal product:", err)
+		}
+	}
+}
+
+func TestQuery_Sum_DecimalField(t *testing.T) {
+	db, cleanup := setupDecimalTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestDecimalProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testDecimalProductMeta)
+	seedDecimalProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{
+		Sums: []string{"UnitPrice"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// 29.99 + 49.95 + 199.00 + 99.50 = 378.44
+	expectedSum := 378.44
+	if sums["UnitPrice"] != expectedSum {
+		t.Errorf("Expected sum of UnitPrice to be %v, got %v", expectedSum, sums["UnitPrice"])
+	}
+}
+
+func TestQuery_Sum_MultipleDecimalFields(t *testing.T) {
+	db, cleanup := setupDecimalTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestDecimalProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testDecimalProductMeta)
+	seedDecimalProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{
+		Sums: []string{"UnitPrice", "TaxAmount"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	expectedPrice := 378.44
+	if sums["UnitPrice"] != expectedPrice {
+		t.Errorf("Expected sum of UnitPrice to be %v, got %v", expectedPrice, sums["UnitPrice"])
+	}
+
+	// 3.00 + 5.00 + 19.90 + 9.95 = 37.85
+	expectedTax := 37.85
+	if math.Abs(sums["TaxAmount"]-expectedTax) > 0.001 {
+		t.Errorf("Expected sum of TaxAmount to be %v, got %v", expectedTax, sums["TaxAmount"])
+	}
+}
+
+func TestQuery_Sum_DecimalField_WithFilter(t *testing.T) {
+	db, cleanup := setupDecimalTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestDecimalProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testDecimalProductMeta)
+	seedDecimalProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: "Software", Operator: metadata.OpEq},
+		},
+		Sums: []string{"UnitPrice"},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	_, _, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Software only: Service=199.00 + License=99.50 = 298.50
+	expectedSum := 298.50
+	if sums["UnitPrice"] != expectedSum {
+		t.Errorf("Expected sum of UnitPrice (filtered) to be %v, got %v", expectedSum, sums["UnitPrice"])
+	}
+}
+
+func TestQuery_Sum_DecimalField_WithCount(t *testing.T) {
+	db, cleanup := setupDecimalTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestDecimalProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testDecimalProductMeta)
+	seedDecimalProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{
+		CountTotal: true,
+		Sums:       []string{"UnitPrice"},
+		Limit:      2,
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, count, sums, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	if count != 4 {
+		t.Errorf("Expected count of 4, got %d", count)
+	}
+
+	// Sum should be for all items, not just paginated
+	expectedSum := 378.44
+	if sums["UnitPrice"] != expectedSum {
+		t.Errorf("Expected sum of UnitPrice to be %v, got %v", expectedSum, sums["UnitPrice"])
 	}
 }

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -839,24 +839,10 @@ func splitStringValues(vals []any) []any {
 	return result
 }
 
-// isNumericField checks if a field on the model type is a numeric type (int, uint, float)
-func isNumericField(modelType reflect.Type, fieldName string) bool {
-	field, found := modelType.FieldByName(fieldName)
-	if !found {
-		return false
-	}
-	switch field.Type.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64:
-		return true
-	}
-	return false
-}
-
 // computeAggregates computes count and/or sum aggregates for the query.
 // When both count and sums are requested, they're combined into a single query.
-// Invalid sum fields (not in allowlist, non-numeric, or non-existent) return 0 with slog warning.
+// Fields not in the SummableFields allowlist or without a valid column mapping return 0 with slog warning.
+// The database handles type validation — SUM on non-numeric columns will return a database error.
 func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) (int, map[string]float64, error) {
 	var totalCount int
 	var sums map[string]float64
@@ -879,12 +865,6 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 			// Check if field is in allowlist
 			if !slices.Contains(meta.SummableFields, field) {
 				slog.WarnContext(ctx, "sum requested for field not in SummableFields", "field", field, "type", meta.TypeName)
-				continue
-			}
-
-			// Check if field exists and is numeric
-			if !isNumericField(meta.ModelType, field) {
-				slog.WarnContext(ctx, "sum requested for non-numeric field", "field", field, "type", meta.TypeName)
 				continue
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
+	github.com/shopspring/decimal v1.4.0
 	github.com/uptrace/bun v1.2.15
 	github.com/uptrace/bun/dialect/pgdialect v1.2.15
 	github.com/uptrace/bun/dialect/sqlitedialect v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2774,10 +2774,10 @@ func TestHandler_GetAll_SumHeaders(t *testing.T) {
 			},
 		},
 		{
-			name:        "bool field returns 0",
+			name:        "bool field sums true values",
 			queryString: "sum=InStock",
 			expectedHeaders: map[string]string{
-				"X-Sum-InStock": "0",
+				"X-Sum-InStock": "2", // Apple=true(1) + Banana=true(1) + Carrot=false(0) = 2
 			},
 		},
 		{

--- a/router/query.go
+++ b/router/query.go
@@ -45,8 +45,9 @@ func WithDefaultSort(field string) QueryConfig {
 	}
 }
 
-// WithSums returns a QueryConfig that enables sum aggregation on the specified fields
-// Only numeric fields (int, float, uint) can be summed; non-numeric fields return 0
+// WithSums returns a QueryConfig that enables sum aggregation on the specified fields.
+// Any field with a numeric database column type (including struct-based types like decimal.Decimal)
+// can be summed. The database validates the type — summing a non-numeric column returns a database error.
 func WithSums(fields ...string) QueryConfig {
 	return QueryConfig{
 		SummableFields: fields,


### PR DESCRIPTION
## Summary
- Removes `isNumericField` Go-side reflect.Kind check that rejected struct-based numeric types like `decimal.Decimal`
- `SummableFields` allowlist is now the sole validation gate — the database handles type validation for SUM operations
- Bool fields now return count of `true` values instead of 0

## Test plan
- [x] Unit tests for `decimal.Decimal` fields (single, multiple, filtered, with count)
- [x] Unit test for varchar field sum (no panic, SQLite returns 0)
- [x] Unit test for bool field sum (returns count of true values)
- [x] Handler test updated for bool sum behavior
- [x] Bruno tests updated for SQLite type coercion behavior (tests 44, 45, 47)
- [x] All pre-commit hooks pass (fmt, vet, lint, tests)
- [x] Full Bruno test suite passes

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)