### PR TITLE
Fix files-signed Bruno test download redirect

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,48 +336,47 @@ jobs:
         working-directory: bruno
         run: bru run files-proxy-example --env local --format json --sandbox=developer
 
-  # TODO: Re-enable when Bruno CLI issue is resolved
-  # files-signed-example-test:
-  #   name: Files Signed Example Test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
+  files-signed-example-test:
+    name: Files Signed Example Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v6
-  #       with:
-  #         go-version: '1.24.13'
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24.13'
 
-  #     - name: Set up Node
-  #       uses: actions/setup-node@v6
-  #       with:
-  #         node-version: '20'
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
 
-  #     - name: Build Server
-  #       working-directory: examples/files_signed
-  #       run: go build -o /tmp/files-signed-server .
+      - name: Build Server
+        working-directory: examples/files_signed
+        run: go build -o /tmp/files-signed-server .
 
-  #     - name: Start Server
-  #       run: /tmp/files-signed-server &
+      - name: Start Server
+        run: /tmp/files-signed-server &
 
-  #     - name: Wait for Server
-  #       run: |
-  #         for i in {1..30}; do
-  #           if curl -f http://localhost:8080/health > /dev/null 2>&1; then
-  #             echo "Server is ready!"
-  #             exit 0
-  #           fi
-  #           sleep 1
-  #         done
-  #         echo "Server failed to start"
-  #         exit 1
+      - name: Wait for Server
+        run: |
+          for i in {1..30}; do
+            if curl -f http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start"
+          exit 1
 
-  #     - name: Install Bruno CLI
-  #       run: npm install -g @usebruno/cli
+      - name: Install Bruno CLI
+        run: npm install -g @usebruno/cli
 
-  #     - name: Run Tests
-  #       working-directory: bruno
-  #       run: bru run files-signed-example --env local --format json --sandbox=developer
+      - name: Run Tests
+        working-directory: bruno
+        run: bru run files-signed-example --env local --format json --sandbox=developer
 
   batch-example-test:
     name: Batch Example Test

--- a/examples/files_signed/main.go
+++ b/examples/files_signed/main.go
@@ -68,9 +68,14 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
 	// Create local file storage
 	uploadDir := "./uploads"
-	storage, err := NewLocalStorage(uploadDir, "http://localhost:8080/files")
+	storage, err := NewLocalStorage(uploadDir, "http://localhost:"+port+"/files")
 	if err != nil {
 		log.Fatal("Failed to create storage:", err)
 	}
@@ -140,29 +145,26 @@ func main() {
 	)
 
 	// Start server
-	fmt.Println("Server starting on :8080")
+	base := "http://localhost:" + port
+	fmt.Println("Server starting on :" + port)
 	fmt.Println("Using SQLite in-memory database")
 	fmt.Println("Using local file storage:", uploadDir)
 	fmt.Println("\nFile download mode: SIGNED URL (direct access via /files)")
 	fmt.Println("\nAvailable endpoints:")
-	fmt.Println("  POST   http://localhost:8080/posts")
-	fmt.Println("  GET    http://localhost:8080/posts")
-	fmt.Println("  GET    http://localhost:8080/posts/{id}")
-	fmt.Println("  PUT    http://localhost:8080/posts/{id}")
-	fmt.Println("  DELETE http://localhost:8080/posts/{id}")
+	fmt.Println("  POST   " + base + "/posts")
+	fmt.Println("  GET    " + base + "/posts")
+	fmt.Println("  GET    " + base + "/posts/{id}")
+	fmt.Println("  PUT    " + base + "/posts/{id}")
+	fmt.Println("  DELETE " + base + "/posts/{id}")
 	fmt.Println("")
-	fmt.Println("  POST   http://localhost:8080/posts/{id}/images  (multipart upload)")
-	fmt.Println("  GET    http://localhost:8080/posts/{id}/images")
-	fmt.Println("  GET    http://localhost:8080/posts/{id}/images/{id}")
-	fmt.Println("  DELETE http://localhost:8080/posts/{id}/images/{id}")
+	fmt.Println("  POST   " + base + "/posts/{id}/images  (multipart upload)")
+	fmt.Println("  GET    " + base + "/posts/{id}/images")
+	fmt.Println("  GET    " + base + "/posts/{id}/images/{id}")
+	fmt.Println("  DELETE " + base + "/posts/{id}/images/{id}")
 	fmt.Println("\n  NOTE: No /download endpoint - download_url points to /files/{key}")
 	fmt.Println("\nUpload example:")
-	fmt.Println(`  curl -X POST http://localhost:8080/posts/1/images \`)
+	fmt.Printf("  curl -X POST %s/posts/1/images \\\n", base)
 	fmt.Println(`    -F "file=@image.png" \`)
 	fmt.Println(`    -F 'metadata={"alt_text":"My image"}'`)
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
 	log.Fatal(http.ListenAndServe(":"+port, r))
 }


### PR DESCRIPTION
## Summary
- Fixed signed URL prefix using hardcoded port 8080 instead of the actual server port, causing 404 on download redirect
- Re-enabled files-signed-example-test CI job

Fixes #45

## Test plan
- [x] Unit tests pass (all 7 packages)
- [x] All 14 Bruno test suites pass (including files-signed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)