### PR TITLE
fix: Resolve AsSingleRouteWithPut using parent URL ID as child PK

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install golangci-lint v2
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Run golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Install golangci-lint v2
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Check formatting
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Run go vet
         run: go vet ./...
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Install golangci-lint v2
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Check formatting
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Run go vet
         run: go vet ./...
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Run tests
         run: go test ./metadata ./datastore ./router ./service ./handler ./errors -race -coverprofile=coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Run tests
         run: go test ./metadata ./datastore ./router ./service ./handler ./errors -race -coverprofile=coverage.out

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -261,7 +261,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -303,7 +303,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -345,7 +345,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -387,7 +387,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -429,7 +429,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -471,7 +471,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -513,7 +513,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -555,7 +555,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -597,7 +597,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.1'
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -261,7 +261,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -303,7 +303,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -345,7 +345,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -387,7 +387,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -429,7 +429,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -471,7 +471,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -513,7 +513,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -555,7 +555,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -597,7 +597,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.8'
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
 
       - id: go-licence-detector
         name: go licence detector
-        entry: bash -c 'go list -m -json all | go-licence-detector -rules=scripts/licence-rules.json -noticeTemplate=scripts/templates/NOTICE.txt.tmpl -noticeOut=THIRD_PARTY_NOTICES -includeIndirect && git add THIRD_PARTY_NOTICES'
+        entry: bash -c 'export PATH="$HOME/go/bin:$(go env GOPATH)/bin:$PATH" && go list -m -json all | go-licence-detector -rules=scripts/licence-rules.json -noticeTemplate=scripts/templates/NOTICE.txt.tmpl -noticeOut=THIRD_PARTY_NOTICES -includeIndirect && git add THIRD_PARTY_NOTICES'
         language: system
         files: go\.(mod|sum)$
         pass_filenames: false

--- a/AGENT.md
+++ b/AGENT.md
@@ -63,7 +63,7 @@ func main() {
         w.Write([]byte("OK"))
     })
 
-    b := router.NewBuilder(r, db.GetDB())
+    b := router.NewBuilder(r)
     router.RegisterRoutes[User](b, "/users", router.AllPublic())
 
     log.Fatal(http.ListenAndServe(":8080", r))
@@ -165,7 +165,7 @@ type Post struct {
     Title         string `bun:"title,notnull" json:"title"`
 }
 
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 router.RegisterRoutes[Blog](b, "/blogs", router.AllPublic(), func(b *router.Builder) {
     router.RegisterRoutes[Post](b, "/posts", router.AllPublic())
 })

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ type UsageData struct {
     Reading       int    `bun:"reading" json:"reading"`
 }
 
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 router.RegisterRoutes[Site](b, "/sites", router.AllPublic(), func(b *router.Builder) {
     router.RegisterRoutes[UsageData](b, "/usage",
         router.AllPublic(),
@@ -711,7 +711,7 @@ type Task struct {
 ### Registering Routes
 
 ```go
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 
 // Tenant entity: PK = tenant ID, filtered by WHERE id = tenantID
 router.RegisterRoutes[Organization](b, "/organizations",
@@ -935,7 +935,7 @@ type Item struct {
     Name          string `bun:"name" json:"name"`
 }
 
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 
 // Root registration - public read, admin write
 router.RegisterRoutes[Item](b, "/items",
@@ -1696,7 +1696,7 @@ if err := filestore.Initialize(storage); err != nil {
 }
 
 // Register parent with nested file resource
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 router.RegisterRoutes[Post](b, "/posts",
     router.AllPublic(),
     func(b *router.Builder) {
@@ -1950,7 +1950,7 @@ If OTEL is not configured, metrics are no-ops with negligible overhead.
 
 ```go
 // Register standard CRUD
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 router.RegisterRoutes[User](b, "/users", router.AllPublic())
 
 // Add custom endpoints

--- a/bruno/relations-example/00-create-dummy-user.bru
+++ b/bruno/relations-example/00-create-dummy-user.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Create Dummy User (offset auto-increment)
+  type: http
+  seq: 0
+}
+
+post {
+  url: {{baseUrl}}/users
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "external_id": "dummy",
+    "name": "Dummy User",
+    "email": "dummy@example.com"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+}
+
+docs {
+  Creates a dummy user so auto-increment user IDs diverge from post IDs.
+  This exposes bugs where parent URL IDs are incorrectly used as child PKs.
+}

--- a/datastore/postgres_test.go
+++ b/datastore/postgres_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sjgoldie/go-restgen/datastore"
 )
 
+const testDSN = "postgres://user:pass@localhost:5432/testdb?sslmode=disable" // #nosec G101 -- test DSN, not real credentials
+
 func TestNewPostgres(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -17,7 +19,7 @@ func TestNewPostgres(t *testing.T) {
 	}{
 		{
 			name:    "creates postgres instance",
-			dsn:     "postgres://user:pass@localhost:5432/testdb?sslmode=disable",
+			dsn:     testDSN,
 			wantErr: false,
 		},
 	}
@@ -48,7 +50,7 @@ func TestNewPostgres(t *testing.T) {
 func TestPostgreSQL_GetDB(t *testing.T) {
 	// Note: This test creates a PostgreSQL instance but doesn't require a running server
 	// It only tests that GetDB() returns a non-nil bun.DB instance
-	db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/testdb?sslmode=disable")
+	db, err := datastore.NewPostgres(testDSN)
 	if err != nil {
 		t.Fatal("Failed to create PostgreSQL instance:", err)
 	}
@@ -61,7 +63,7 @@ func TestPostgreSQL_GetDB(t *testing.T) {
 }
 
 func TestPostgreSQL_GetTimeout(t *testing.T) {
-	db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/testdb?sslmode=disable")
+	db, err := datastore.NewPostgres(testDSN)
 	if err != nil {
 		t.Fatal("Failed to create PostgreSQL instance:", err)
 	}
@@ -89,7 +91,7 @@ func TestPostgreSQL_Cleanup(t *testing.T) {
 		{
 			name: "cleanup doesn't panic",
 			test: func(t *testing.T) {
-				db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/testdb?sslmode=disable")
+				db, err := datastore.NewPostgres(testDSN)
 				if err != nil {
 					t.Fatal("Failed to create PostgreSQL instance:", err)
 				}
@@ -101,7 +103,7 @@ func TestPostgreSQL_Cleanup(t *testing.T) {
 		{
 			name: "multiple cleanup calls don't panic",
 			test: func(t *testing.T) {
-				db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/testdb?sslmode=disable")
+				db, err := datastore.NewPostgres(testDSN)
 				if err != nil {
 					t.Fatal("Failed to create PostgreSQL instance:", err)
 				}
@@ -124,7 +126,7 @@ func TestPostgreSQL_StoreInterface(t *testing.T) {
 	// Verify PostgreSQL implements Store interface
 	var _ datastore.Store = (*datastore.PostgreSQL)(nil)
 
-	db, err := datastore.NewPostgres("postgres://user:pass@localhost:5432/testdb?sslmode=disable")
+	db, err := datastore.NewPostgres(testDSN)
 	if err != nil {
 		t.Fatal("Failed to create PostgreSQL instance:", err)
 	}
@@ -147,7 +149,7 @@ func TestPostgreSQL_StoreInterface(t *testing.T) {
 
 func TestNewPostgresWithDB(t *testing.T) {
 	// Create external sql.DB using pgdriver
-	connector := pgdriver.NewConnector(pgdriver.WithDSN("postgres://user:pass@localhost:5432/testdb?sslmode=disable"))
+	connector := pgdriver.NewConnector(pgdriver.WithDSN(testDSN))
 	sqlDB := sql.OpenDB(connector)
 	defer func() { _ = sqlDB.Close() }()
 
@@ -172,7 +174,7 @@ func TestNewPostgresWithDB(t *testing.T) {
 
 func TestPostgresWithDB_CleanupDoesNotCloseExternalConnection(t *testing.T) {
 	// Create external sql.DB using pgdriver
-	connector := pgdriver.NewConnector(pgdriver.WithDSN("postgres://user:pass@localhost:5432/testdb?sslmode=disable"))
+	connector := pgdriver.NewConnector(pgdriver.WithDSN(testDSN))
 	sqlDB := sql.OpenDB(connector)
 	defer func() { _ = sqlDB.Close() }()
 
@@ -190,7 +192,7 @@ func TestPostgresWithDB_CleanupDoesNotCloseExternalConnection(t *testing.T) {
 }
 
 func TestPostgresWithDB_StoreInterface(t *testing.T) {
-	connector := pgdriver.NewConnector(pgdriver.WithDSN("postgres://user:pass@localhost:5432/testdb?sslmode=disable"))
+	connector := pgdriver.NewConnector(pgdriver.WithDSN(testDSN))
 	sqlDB := sql.OpenDB(connector)
 	defer func() { _ = sqlDB.Close() }()
 

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -1,0 +1,102 @@
+package datastore
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/uptrace/bun/schema"
+)
+
+// Relation holds the result of finding a parent-child relationship via Bun schema.
+type Relation struct {
+	ForeignKeyCol string // FK column name (e.g., "author_id")
+	ParentJoinCol string // Parent join column name (e.g., "id")
+	FieldName     string // Struct field name for the relation (e.g., "Author")
+}
+
+// ColumnName resolves a Go struct field name to its SQL column name using Bun's schema.
+func ColumnName(tType reflect.Type, goName string) (string, error) {
+	store, err := Get()
+	if err != nil {
+		return "", err
+	}
+	table := store.GetDB().Table(tType)
+	for _, field := range table.Fields {
+		if field.GoName == goName {
+			return field.Name, nil
+		}
+	}
+	return "", fmt.Errorf("field %s not found on type %s", goName, tType.Name())
+}
+
+// TableName returns the SQL table name for a model type using Bun's schema.
+func TableName(tType reflect.Type) string {
+	store, err := Get()
+	if err != nil {
+		return ""
+	}
+	table := store.GetDB().Table(tType)
+	return table.Name
+}
+
+// FindRelation uses Bun's schema to find the relationship between child and parent types.
+// Checks for:
+// 1. Child has belongs-to Parent (e.g., Article belongs-to User) — FK is on child
+// 2. Parent has has-many/has-one Child — extract join columns from parent's relation
+// 3. Parent has belongs-to Child (inverted) — FK is on parent
+func FindRelation(childType, parentType reflect.Type) (Relation, error) {
+	if parentType == nil {
+		return Relation{}, nil
+	}
+
+	store, err := Get()
+	if err != nil {
+		return Relation{}, err
+	}
+	db := store.GetDB()
+
+	childTable := db.Table(childType)
+
+	// Case 1: child has a belongs-to relation pointing to parent
+	for _, rel := range childTable.Relations {
+		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == parentType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return Relation{
+					ForeignKeyCol: rel.BasePKs[0].Name,
+					ParentJoinCol: rel.JoinPKs[0].Name,
+					FieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
+	}
+
+	// Case 2: parent has has-many or has-one pointing to child
+	parentTable := db.Table(parentType)
+	for _, rel := range parentTable.Relations {
+		if (rel.Type == schema.HasManyRelation || rel.Type == schema.HasOneRelation) && rel.JoinTable.Type == childType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return Relation{
+					ForeignKeyCol: rel.JoinPKs[0].Name,
+					ParentJoinCol: rel.BasePKs[0].Name,
+					FieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
+	}
+
+	// Case 3: parent has belongs-to pointing to child (inverted belongs-to,
+	// e.g., Post.Author belongs-to User — FK author_id is on the parent)
+	for _, rel := range parentTable.Relations {
+		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == childType {
+			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
+				return Relation{
+					ForeignKeyCol: rel.BasePKs[0].Name,
+					ParentJoinCol: rel.JoinPKs[0].Name,
+					FieldName:     rel.Field.GoName,
+				}, nil
+			}
+		}
+	}
+
+	return Relation{}, fmt.Errorf("no relationship between %s and %s found", childType.Name(), parentType.Name())
+}

--- a/datastore/schema_test.go
+++ b/datastore/schema_test.go
@@ -1,0 +1,167 @@
+package datastore
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/uptrace/bun"
+)
+
+const testAuthorIDCol = "author_id"
+
+type columnNameTestModel struct {
+	bun.BaseModel `bun:"table:test_ftc"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	NMI           string `bun:"nmi,notnull"`
+	AuthorID      int    `bun:"author_id,notnull"`
+}
+
+func TestColumnName(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	if err := Initialize(db); err != nil {
+		t.Fatalf("failed to initialize datastore: %v", err)
+	}
+	defer func() { singleton = nil; once = sync.Once{} }()
+
+	tType := reflect.TypeOf(columnNameTestModel{})
+
+	t.Run("standard field", func(t *testing.T) {
+		col, err := ColumnName(tType, "AuthorID")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != testAuthorIDCol {
+			t.Errorf("expected 'author_id', got '%s'", col)
+		}
+	})
+
+	t.Run("acronym field", func(t *testing.T) {
+		col, err := ColumnName(tType, "NMI")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != "nmi" {
+			t.Errorf("expected 'nmi', got '%s'", col)
+		}
+	})
+
+	t.Run("pk field", func(t *testing.T) {
+		col, err := ColumnName(tType, "ID")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if col != "id" {
+			t.Errorf("expected 'id', got '%s'", col)
+		}
+	})
+
+	t.Run("field not found", func(t *testing.T) {
+		_, err := ColumnName(tType, "Nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent field")
+		}
+	})
+}
+
+type schemaRelUser struct {
+	bun.BaseModel `bun:"table:schema_rel_users"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+}
+
+type schemaRelPost struct {
+	bun.BaseModel `bun:"table:schema_rel_posts"`
+	ID            int            `bun:"id,pk,autoincrement"`
+	AuthorID      int            `bun:"author_id,notnull"`
+	Author        *schemaRelUser `bun:"rel:belongs-to,join:author_id=id"`
+	Title         string         `bun:"title"`
+}
+
+type schemaUnrelatedModel struct {
+	bun.BaseModel `bun:"table:schema_unrelated"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+}
+
+func TestFindRelation(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	if err := Initialize(db); err != nil {
+		t.Fatalf("failed to initialize datastore: %v", err)
+	}
+	defer func() { singleton = nil; once = sync.Once{} }()
+
+	userType := reflect.TypeOf(schemaRelUser{})
+	postType := reflect.TypeOf(schemaRelPost{})
+
+	t.Run("child belongs-to parent", func(t *testing.T) {
+		rel, err := FindRelation(postType, userType)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.ForeignKeyCol != testAuthorIDCol {
+			t.Errorf("expected ForeignKeyCol 'author_id', got %q", rel.ForeignKeyCol)
+		}
+		if rel.ParentJoinCol != "id" {
+			t.Errorf("expected ParentJoinCol 'id', got %q", rel.ParentJoinCol)
+		}
+		if rel.FieldName != "Author" {
+			t.Errorf("expected FieldName 'Author', got %q", rel.FieldName)
+		}
+	})
+
+	t.Run("parent belongs-to child (inverted)", func(t *testing.T) {
+		rel, err := FindRelation(userType, postType)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.ForeignKeyCol != testAuthorIDCol {
+			t.Errorf("expected ForeignKeyCol 'author_id', got %q", rel.ForeignKeyCol)
+		}
+		if rel.ParentJoinCol != "id" {
+			t.Errorf("expected ParentJoinCol 'id', got %q", rel.ParentJoinCol)
+		}
+		if rel.FieldName != "Author" {
+			t.Errorf("expected FieldName 'Author', got %q", rel.FieldName)
+		}
+	})
+
+	t.Run("no relationship", func(t *testing.T) {
+		unrelatedType := reflect.TypeOf(schemaUnrelatedModel{})
+		_, err := FindRelation(unrelatedType, userType)
+		if err == nil {
+			t.Fatal("expected error for unrelated types")
+		}
+	})
+
+	t.Run("nil parent returns empty", func(t *testing.T) {
+		rel, err := FindRelation(postType, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rel.ForeignKeyCol != "" {
+			t.Errorf("expected empty ForeignKeyCol, got %q", rel.ForeignKeyCol)
+		}
+	})
+}
+
+func TestTableName(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	if err := Initialize(db); err != nil {
+		t.Fatalf("failed to initialize datastore: %v", err)
+	}
+	defer func() { singleton = nil; once = sync.Once{} }()
+
+	t.Run("returns table name", func(t *testing.T) {
+		name := TableName(reflect.TypeOf(schemaRelUser{}))
+		if name != "schema_rel_users" {
+			t.Errorf("expected 'schema_rel_users', got %q", name)
+		}
+	})
+}

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/uptrace/bun/schema"
 
 	apperrors "github.com/sjgoldie/go-restgen/errors"
+	"github.com/sjgoldie/go-restgen/internal/common"
 	"github.com/sjgoldie/go-restgen/metadata"
 )
 
@@ -654,7 +655,7 @@ func (w *Wrapper[T]) applyParentOwnershipFilter(query *bun.SelectQuery, parentMe
 	// Build WHERE clause for ownership: parent_table.ownership_field = userID
 	// For multiple fields, use OR logic (same as applyOwnershipFilterWithMeta)
 	for i, fieldName := range parentMeta.OwnershipFields {
-		colName, err := w.columnFromGoName(parentType, fieldName)
+		colName, err := ColumnName(parentType, fieldName)
 		if err != nil {
 			continue
 		}
@@ -713,7 +714,7 @@ func (w *Wrapper[T]) applyOwnershipFilterWithMeta(ctx context.Context, query *bu
 	// Use ?TableAlias to properly qualify columns when JOINs are present
 	if len(meta.OwnershipFields) == 1 {
 		// Single field - simple WHERE clause
-		colName, err := w.columnFromGoName(itemType, meta.OwnershipFields[0])
+		colName, err := ColumnName(itemType, meta.OwnershipFields[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get column name for ownership field: %w", err)
 		}
@@ -721,7 +722,7 @@ func (w *Wrapper[T]) applyOwnershipFilterWithMeta(ctx context.Context, query *bu
 	} else {
 		// Multiple fields - OR logic
 		for i, fieldName := range meta.OwnershipFields {
-			colName, err := w.columnFromGoName(itemType, fieldName)
+			colName, err := ColumnName(itemType, fieldName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get column name for ownership field: %w", err)
 			}
@@ -778,17 +779,6 @@ func (w *Wrapper[T]) setOwnershipField(ctx context.Context, item *T) error {
 	return nil
 }
 
-// columnFromGoName resolves a Go field name to its SQL column name using Bun's schema.
-func (w *Wrapper[T]) columnFromGoName(tType reflect.Type, fieldName string) (string, error) {
-	table := w.Store.GetDB().Table(tType)
-	for _, field := range table.Fields {
-		if field.GoName == fieldName {
-			return field.Name, nil
-		}
-	}
-	return "", fmt.Errorf("field %s not found on type %s", fieldName, tType.Name())
-}
-
 // applyTenantFilter applies tenant scoping to a query if enforced in context.
 // For IsTenantTable types, filters by PK = tenantID.
 // For WithTenantScope types, filters by tenant_field = tenantID.
@@ -819,7 +809,7 @@ func (w *Wrapper[T]) applyTenantFilter(ctx context.Context, query *bun.SelectQue
 		if itemType.Kind() == reflect.Ptr {
 			itemType = itemType.Elem()
 		}
-		colName, err := w.columnFromGoName(itemType, meta.TenantField)
+		colName, err := ColumnName(itemType, meta.TenantField)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get column name for tenant field: %w", err)
 		}
@@ -840,7 +830,7 @@ func (w *Wrapper[T]) applyParentTenantFilter(query *bun.SelectQuery, parentMeta 
 		parentType = parentType.Elem()
 	}
 
-	colName, err := w.columnFromGoName(parentType, parentMeta.TenantField)
+	colName, err := ColumnName(parentType, parentMeta.TenantField)
 	if err != nil {
 		return query
 	}
@@ -996,7 +986,7 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 			}
 
 			// Get column name
-			colName, err := w.columnFromGoName(meta.ModelType, field)
+			colName, err := ColumnName(meta.ModelType, field)
 			if err != nil {
 				slog.WarnContext(ctx, "sum requested for field with invalid column mapping", "field", field, "type", meta.TypeName, "error", err)
 				continue
@@ -1108,7 +1098,7 @@ func (w *Wrapper[T]) applyQueryFilters(ctx context.Context, query *bun.SelectQue
 			continue
 		}
 
-		colName, err := w.columnFromGoName(meta.ModelType, field)
+		colName, err := ColumnName(meta.ModelType, field)
 		if err != nil {
 			continue
 		}
@@ -1187,7 +1177,7 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 				continue // skip invalid sort fields
 			}
 
-			colName, err := w.columnFromGoName(meta.ModelType, sort.Field)
+			colName, err := ColumnName(meta.ModelType, sort.Field)
 			if err != nil {
 				continue
 			}
@@ -1210,7 +1200,7 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 			field = field[1:]
 		}
 
-		colName, err := w.columnFromGoName(meta.ModelType, field)
+		colName, err := ColumnName(meta.ModelType, field)
 		if err == nil {
 			if desc {
 				query = query.OrderExpr("?TableAlias.? DESC", bun.Ident(colName))
@@ -1329,12 +1319,23 @@ func (w *Wrapper[T]) GetByParentRelation(ctx context.Context, parentID string) (
 }
 
 // UpdateByParentRelation updates a single item of type T via the parent's foreign key field
-// Fetches the parent, extracts the FK value, then calls normal Update (preserving security checks)
+// Fetches the parent, extracts the FK value, sets it on the item struct (so WherePK targets
+// the correct row), then calls normal Update (preserving security checks).
 func (w *Wrapper[T]) UpdateByParentRelation(ctx context.Context, parentID string, item T) (*T, error) {
 	childID, err := w.resolveChildIDFromParent(ctx, parentID)
 	if err != nil {
 		return nil, err
 	}
+
+	meta, err := metadata.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := common.SetFieldFromString(&item, meta.PKField, childID); err != nil {
+		return nil, fmt.Errorf("failed to set child PK: %w", err)
+	}
+
 	return w.Update(ctx, childID, item)
 }
 
@@ -1719,17 +1720,6 @@ func (w *Wrapper[T]) BatchDelete(ctx context.Context, items []T) error {
 	return err
 }
 
-// extractID extracts the primary key field value from an item as a string.
-// The pkFieldName parameter specifies which field to extract (from metadata.PKField).
-func (w *Wrapper[T]) extractID(item *T, pkFieldName string) string {
-	v := reflect.ValueOf(item).Elem()
-	idField := v.FieldByName(pkFieldName)
-	if !idField.IsValid() {
-		return ""
-	}
-	return fmt.Sprintf("%v", idField.Interface())
-}
-
 // preFetchItems validates and fetches existing items before a batch operation.
 // This validates existence, ownership, and parent chain for each item.
 // For update operations, pass the new item to validation; for delete, pass nil.
@@ -1740,7 +1730,7 @@ func (w *Wrapper[T]) preFetchItems(ctx context.Context, meta *metadata.TypeMetad
 	}
 
 	for i := range items {
-		id := w.extractID(&items[i], meta.PKField)
+		id := common.GetFieldAsString(&items[i], meta.PKField)
 		if id == "" {
 			return nil, fmt.Errorf("item at index %d missing ID", i)
 		}
@@ -1800,7 +1790,7 @@ func (w *Wrapper[T]) applyParentFieldFilter(ctx context.Context, query *bun.Sele
 		return query
 	}
 
-	colName, err := w.columnFromGoName(targetMeta.ModelType, path.field)
+	colName, err := ColumnName(targetMeta.ModelType, path.field)
 	if err != nil {
 		return query
 	}
@@ -1901,7 +1891,7 @@ func (w *Wrapper[T]) applyChildFieldFilter(ctx context.Context, query *bun.Selec
 		return query
 	}
 
-	colName, err := w.columnFromGoName(targetMeta.ModelType, path.field)
+	colName, err := ColumnName(targetMeta.ModelType, path.field)
 	if err != nil {
 		return query
 	}

--- a/datastore/wrapper_test.go
+++ b/datastore/wrapper_test.go
@@ -2464,6 +2464,7 @@ func TestWrapper_UpdateByParentRelation(t *testing.T) {
 		TypeName:      "TestIncludeAuthor",
 		TableName:     "include_authors",
 		URLParamUUID:  postMeta.URLParamUUID,
+		PKField:       "ID",
 		ModelType:     reflect.TypeOf(TestIncludeAuthor{}),
 		ParentType:    reflect.TypeOf(TestIncludePost{}),
 		ParentMeta:    postMeta,
@@ -2489,6 +2490,109 @@ func TestWrapper_UpdateByParentRelation(t *testing.T) {
 	}
 	if retrieved.Name != "Updated Name" {
 		t.Errorf("Expected persisted name 'Updated Name', got %s", retrieved.Name)
+	}
+}
+
+// TestWrapper_UpdateByParentRelation_DivergentIDs tests the fix for issue #70:
+// When parent ID != child ID, UpdateByParentRelation must set the resolved child ID
+// on the item struct so WherePK() targets the correct row.
+func TestWrapper_UpdateByParentRelation_DivergentIDs(t *testing.T) {
+	db, cleanup := setupIncludeTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	authorWrapper := &datastore.Wrapper[TestIncludeAuthor]{Store: db}
+	authorMeta := &metadata.TypeMetadata{
+		TypeID:       "test_author_id",
+		TypeName:     "TestIncludeAuthor",
+		TableName:    "include_authors",
+		URLParamUUID: "author_id",
+		PKField:      "ID",
+		ModelType:    reflect.TypeOf(TestIncludeAuthor{}),
+	}
+	authorCtx := context.WithValue(ctx, metadata.MetadataKey, authorMeta)
+
+	// Create a dummy author to offset auto-increment (ID=1)
+	_, err := authorWrapper.Create(authorCtx, TestIncludeAuthor{Name: "Dummy"})
+	if err != nil {
+		t.Fatal("Failed to create dummy author:", err)
+	}
+
+	// Create the real author (ID=2)
+	author, err := authorWrapper.Create(authorCtx, TestIncludeAuthor{Name: "Real Author"})
+	if err != nil {
+		t.Fatal("Failed to create author:", err)
+	}
+	if author.ID == 1 {
+		t.Fatal("Expected author ID != 1, got 1 — dummy offset failed")
+	}
+
+	// Create a post (ID=1) pointing to author (ID=2)
+	postWrapper := &datastore.Wrapper[TestIncludePost]{Store: db}
+	postMeta := &metadata.TypeMetadata{
+		TypeID:       "test_post_id",
+		TypeName:     "TestIncludePost",
+		TableName:    "include_posts",
+		URLParamUUID: "post_id",
+		PKField:      "ID",
+		ModelType:    reflect.TypeOf(TestIncludePost{}),
+	}
+	postCtx := context.WithValue(ctx, metadata.MetadataKey, postMeta)
+	post, err := postWrapper.Create(postCtx, TestIncludePost{AuthorID: author.ID, OwnerID: "alice", Title: "Test Post"})
+	if err != nil {
+		t.Fatal("Failed to create post:", err)
+	}
+	if post.ID == author.ID {
+		t.Fatalf("Test requires post.ID (%d) != author.ID (%d)", post.ID, author.ID)
+	}
+
+	// Simulate what the handler does: stamp the parent (post) ID onto the child struct's PK.
+	// This is the bug — the handler sets item.ID = postID instead of authorID.
+	authorFromPostMeta := &metadata.TypeMetadata{
+		TypeID:        "test_author_from_post_id",
+		TypeName:      "TestIncludeAuthor",
+		TableName:     "include_authors",
+		URLParamUUID:  postMeta.URLParamUUID,
+		PKField:       "ID",
+		ModelType:     reflect.TypeOf(TestIncludeAuthor{}),
+		ParentType:    reflect.TypeOf(TestIncludePost{}),
+		ParentMeta:    postMeta,
+		ParentFKField: "AuthorID",
+	}
+	authorFromPostCtx := context.WithValue(ctx, metadata.MetadataKey, authorFromPostMeta)
+
+	// Item struct has WRONG PK (post.ID instead of author.ID) — simulates handler setIDField bug
+	updatedAuthor := TestIncludeAuthor{ID: post.ID, Name: "Updated Via Parent", CreatedAt: author.CreatedAt}
+	updated, err := authorWrapper.UpdateByParentRelation(authorFromPostCtx, strconv.Itoa(post.ID), updatedAuthor)
+	if err != nil {
+		t.Fatal("UpdateByParentRelation failed:", err)
+	}
+
+	// The returned item should have the correct author ID, not the post ID
+	if updated.ID != author.ID {
+		t.Errorf("Expected returned author ID %d, got %d", author.ID, updated.ID)
+	}
+	if updated.Name != "Updated Via Parent" {
+		t.Errorf("Expected name 'Updated Via Parent', got %q", updated.Name)
+	}
+
+	// Verify the correct author was updated in the database
+	retrieved, err := authorWrapper.Get(authorCtx, strconv.Itoa(author.ID))
+	if err != nil {
+		t.Fatal("Failed to get author:", err)
+	}
+	if retrieved.Name != "Updated Via Parent" {
+		t.Errorf("Expected persisted name 'Updated Via Parent', got %q", retrieved.Name)
+	}
+
+	// Verify the dummy author was NOT modified
+	dummy, err := authorWrapper.Get(authorCtx, "1")
+	if err != nil {
+		t.Fatal("Failed to get dummy author:", err)
+	}
+	if dummy.Name != "Dummy" {
+		t.Errorf("Dummy author was incorrectly modified: got name %q", dummy.Name)
 	}
 }
 

--- a/examples/actions/go.mod
+++ b/examples/actions/go.mod
@@ -1,6 +1,6 @@
 module example/actions
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/actions/main.go
+++ b/examples/actions/main.go
@@ -157,7 +157,7 @@ func main() {
 	})
 
 	// Register routes with actions
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Order](b, "/orders",
 		router.AllPublic(),
 		router.WithFilters("Status", "CustomerName"),

--- a/examples/anything/go.mod
+++ b/examples/anything/go.mod
@@ -1,6 +1,6 @@
 module example/anything
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/anything/main.go
+++ b/examples/anything/main.go
@@ -207,7 +207,7 @@ func main() {
 		w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Item-level endpoints and SSE on orders
 	router.RegisterRoutes[Order](b, "/orders",

--- a/examples/audit/go.mod
+++ b/examples/audit/go.mod
@@ -1,6 +1,6 @@
 module example/audit
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/audit/main.go
+++ b/examples/audit/main.go
@@ -139,7 +139,7 @@ func main() {
 	})
 
 	// Register Job routes with audit
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Job](b, "/jobs",
 		router.AllPublic(),
 		router.WithFilters("Status", "Priority"),

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -1,6 +1,6 @@
 module example/auth
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -274,7 +274,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Article - public reads, requires "publisher" scope for writes
 	router.RegisterRoutes[Article](b, "/articles",

--- a/examples/batch/go.mod
+++ b/examples/batch/go.mod
@@ -1,6 +1,6 @@
 module example/batch
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Register routes with batch operations enabled
 	// AllPublicWithBatch enables all CRUD + batch operations as public
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Product](b, "/products",
 		router.AllPublicWithBatch(), // Enable batch operations
 		router.WithBatchLimit(100),  // Optional: limit batch size to 100 items

--- a/examples/custom/go.mod
+++ b/examples/custom/go.mod
@@ -1,6 +1,6 @@
 module example/custom
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -317,7 +317,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// /me endpoint - single route with custom Get and Update using auth token
 	// AsSingleRouteWithPut("") creates GET /me and PUT /me (no {id} parameter)

--- a/examples/custom_join/main.go
+++ b/examples/custom_join/main.go
@@ -87,7 +87,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[User](b, "/users", router.AllPublic(), func(b *router.Builder) {
 		router.RegisterRoutes[Account](b, "/accounts", router.AllPublic(), func(b *router.Builder) {
 			router.RegisterRoutes[Site](b, "/sites", router.AllPublic(), func(b *router.Builder) {

--- a/examples/files_proxy/go.mod
+++ b/examples/files_proxy/go.mod
@@ -1,6 +1,6 @@
 module example/files_proxy
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/files_proxy/main.go
+++ b/examples/files_proxy/main.go
@@ -115,7 +115,7 @@ func main() {
 	})
 
 	// Register routes
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Posts with nested images
 	router.RegisterRoutes[Post](b, "/posts",

--- a/examples/files_signed/go.mod
+++ b/examples/files_signed/go.mod
@@ -1,6 +1,6 @@
 module example/files_signed
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/files_signed/main.go
+++ b/examples/files_signed/main.go
@@ -125,7 +125,7 @@ func main() {
 	r.Handle("/files/*", http.StripPrefix("/files/", fileServer))
 
 	// Register routes
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Posts with nested images
 	router.RegisterRoutes[Post](b, "/posts",

--- a/examples/nested_routes/README.md
+++ b/examples/nested_routes/README.md
@@ -58,7 +58,7 @@ type Comment struct {
 Use the Builder API to register nested routes with authentication:
 
 ```go
-b := router.NewBuilder(r, db.GetDB())
+b := router.NewBuilder(r)
 router.RegisterRoutes[User](b, "/users", router.AuthConfig{
     Methods: []string{router.MethodAll},
     Scopes:  []string{router.ScopePublic},  // Public for this example

--- a/examples/nested_routes/go.mod
+++ b/examples/nested_routes/go.mod
@@ -1,6 +1,6 @@
 module example/nested_routes
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/nested_routes/main.go
+++ b/examples/nested_routes/main.go
@@ -135,7 +135,7 @@ func main() {
 	})
 
 	// Register nested routes using the Builder API
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[User](b, "/users", router.AllPublic(), func(b *router.Builder) {
 		router.RegisterRoutes[Post](b, "/posts", router.AllPublic(), func(b *router.Builder) {
 			router.RegisterRoutes[Comment](b, "/comments", router.AllPublic())

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -80,7 +80,7 @@ func main() {
 	})
 
 	// Register CRUD routes with comprehensive filter/sort/pagination options
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Product](b, "/products",
 		router.AllPublic(),
 		router.WithFilters("Name", "Category", "Price", "Stock", "Active"),

--- a/examples/relations/go.mod
+++ b/examples/relations/go.mod
@@ -1,6 +1,6 @@
 module example/relations
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/relations/main.go
+++ b/examples/relations/main.go
@@ -139,20 +139,28 @@ func authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// getMe is a custom get function that returns a hardcoded user
-// Used for /me endpoint where there's no parent FK - the ID comes from custom logic
+// getMe is a custom get function that returns the authenticated user
+// Used for /me endpoint where there's no parent FK - the ID comes from auth context
 func getMe(ctx context.Context, svc *service.Common[User], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, _ string) (*User, error) {
-	// In a real app, you'd look up the user ID from auth context
-	// For this example, we just return user with ID "1"
-	return svc.Get(ctx, "1")
+	db, _ := datastore.Get()
+	var user User
+	err := db.GetDB().NewSelect().Model(&user).Where("external_id = ?", auth.UserID).Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
 }
 
-// updateMe is a custom update function that updates the hardcoded user
+// updateMe is a custom update function that updates the authenticated user
 func updateMe(ctx context.Context, svc *service.Common[User], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, _ string, item User) (*User, error) {
-	// In a real app, you'd look up the user ID from auth context
-	// For this example, we just update user with ID 1
-	item.ID = 1
-	return svc.Update(ctx, "1", item)
+	db, _ := datastore.Get()
+	var user User
+	err := db.GetDB().NewSelect().Model(&user).Where("external_id = ?", auth.UserID).Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	item.ID = user.ID
+	return svc.Update(ctx, fmt.Sprintf("%d", user.ID), item)
 }
 
 func main() {
@@ -193,7 +201,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Users - public access
 	router.RegisterRoutes[User](b, "/users",

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -82,7 +82,7 @@ This example shows:
 2. **Model with timestamps** - Automatic `created_at` and `updated_at` handling via `BeforeAppendModel` hook
 3. **Builder API** - Register routes with support for nesting:
    ```go
-   b := router.NewBuilder(r, db.GetDB())
+   b := router.NewBuilder(r)
    router.RegisterRoutes[User](b, "/users",
        router.AllPublic(),
        router.WithFilters("Name", "Email"),

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -1,6 +1,6 @@
 module example/simple
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	// Register CRUD routes using Builder API (public for this simple example)
 	// Configure filtering, sorting, and pagination
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[User](b, "/users",
 		router.AllPublic(),
 		router.WithFilters("Name", "Email"),            // Allow filtering by Name and Email

--- a/examples/tenant/go.mod
+++ b/examples/tenant/go.mod
@@ -1,6 +1,6 @@
 module example/tenant
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/tenant/main.go
+++ b/examples/tenant/main.go
@@ -199,7 +199,7 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 
 	// Organization - the tenant entity itself
 	// IsTenantTable: PK = TenantID, so queries filter by WHERE id = tenantID

--- a/examples/uuid_pk/go.mod
+++ b/examples/uuid_pk/go.mod
@@ -1,6 +1,6 @@
 module example/uuid_pk
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/uuid_pk/main.go
+++ b/examples/uuid_pk/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	// Register CRUD routes with UUID primary keys
 	// Blogs are the parent resource, Posts are nested under blogs
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Blog](b, "/blogs",
 		router.AllPublic(),
 		router.WithFilters("Name"),

--- a/examples/validator/go.mod
+++ b/examples/validator/go.mod
@@ -1,6 +1,6 @@
 module example/validator
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/examples/validator/main.go
+++ b/examples/validator/main.go
@@ -151,7 +151,7 @@ func main() {
 	})
 
 	// Register Task routes with validation
-	b := router.NewBuilder(r, db.GetDB())
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[Task](b, "/tasks",
 		router.AllPublic(),
 		router.WithFilters("Status", "Priority"),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sjgoldie/go-restgen
 
-go 1.25.8
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sjgoldie/go-restgen
 
-go 1.24.0
+go 1.25.8
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -421,7 +421,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 			// Limit request body size to prevent memory exhaustion
 			const maxUploadSize = 32 << 20 // 32 MB
 			r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
-			if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+			if err := r.ParseMultipartForm(maxUploadSize); err != nil { // #nosec G120 -- body already bounded by MaxBytesReader above
 				slog.DebugContext(ctx, "failed to parse multipart form", "error", err)
 				http.Error(w, "bad request: failed to parse multipart form", http.StatusBadRequest)
 				return

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -13,15 +13,14 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 
 	apperrors "github.com/sjgoldie/go-restgen/errors"
 	"github.com/sjgoldie/go-restgen/filestore"
+	"github.com/sjgoldie/go-restgen/internal/common"
 	"github.com/sjgoldie/go-restgen/metadata"
 	"github.com/sjgoldie/go-restgen/service"
 )
@@ -508,7 +507,7 @@ func Update[T any](updateFunc CustomUpdateFunc[T]) http.HandlerFunc {
 		// This ensures the path ID takes precedence and is required for Bun's WherePK()
 		// Skip for single routes with no URL param - custom function handles ID
 		if rc.id != "" {
-			if err := setIDField(&item, rc.id, rc.meta.PKField); err != nil {
+			if err := common.SetFieldFromString(&item, rc.meta.PKField, rc.id); err != nil {
 				slog.ErrorContext(rc.ctx, "failed to set ID field", "error", err)
 				http.Error(w, "bad request", http.StatusBadRequest)
 				return
@@ -624,41 +623,6 @@ func Download[T any]() http.HandlerFunc {
 			slog.WarnContext(rc.ctx, "failed to stream file", "error", err)
 		}
 	}
-}
-
-// setIDField sets the primary key field on a struct from a string value.
-// The pkFieldName parameter specifies which field to set (from metadata.PKField).
-// Handles int, int64, string, and uuid.UUID field types.
-func setIDField[T any](item *T, id string, pkFieldName string) error {
-	idField := reflect.ValueOf(item).Elem().FieldByName(pkFieldName)
-	if !idField.IsValid() || !idField.CanSet() {
-		return fmt.Errorf("PK field %q not found or not settable", pkFieldName)
-	}
-
-	switch idField.Kind() {
-	case reflect.Int, reflect.Int64:
-		// Parse string to int
-		intID, err := strconv.ParseInt(id, 10, 64)
-		if err != nil {
-			return err
-		}
-		idField.SetInt(intID)
-	case reflect.String:
-		idField.SetString(id)
-	default:
-		// Check for uuid.UUID type (which is [16]byte array)
-		if idField.Type() == reflect.TypeOf(uuid.UUID{}) {
-			parsed, err := uuid.Parse(id)
-			if err != nil {
-				return err
-			}
-			idField.Set(reflect.ValueOf(parsed))
-		} else {
-			return fmt.Errorf("unsupported PK field type: %s", idField.Type().String())
-		}
-	}
-
-	return nil
 }
 
 // Action handles POST requests for custom actions on a resource.

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// SetFieldFromString sets a named struct field from a string value.
+// Handles int, int64, string, and uuid.UUID field types.
+func SetFieldFromString(item any, fieldName, value string) error {
+	field := reflect.ValueOf(item).Elem().FieldByName(fieldName)
+	if !field.IsValid() || !field.CanSet() {
+		return fmt.Errorf("field %q not found or not settable", fieldName)
+	}
+
+	switch field.Kind() {
+	case reflect.Int, reflect.Int64:
+		intVal, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		field.SetInt(intVal)
+	case reflect.String:
+		field.SetString(value)
+	default:
+		if field.Type() == reflect.TypeOf(uuid.UUID{}) {
+			parsed, err := uuid.Parse(value)
+			if err != nil {
+				return err
+			}
+			field.Set(reflect.ValueOf(parsed))
+		} else {
+			return fmt.Errorf("unsupported field type: %s", field.Type().String())
+		}
+	}
+
+	return nil
+}
+
+// GetFieldAsString reads a named struct field and returns its value as a string.
+// Returns an empty string if the field is not found.
+func GetFieldAsString(item any, fieldName string) string {
+	v := reflect.ValueOf(item)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	field := v.FieldByName(fieldName)
+	if !field.IsValid() {
+		return ""
+	}
+	return fmt.Sprintf("%v", field.Interface())
+}

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -1,0 +1,134 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sjgoldie/go-restgen/internal/common"
+)
+
+type testModel struct {
+	ID       int    `bun:"id,pk,autoincrement"`
+	Name     string `bun:"name,notnull"`
+	AuthorID int    `bun:"author_id,notnull"`
+}
+
+type testUUIDModel struct {
+	ID   uuid.UUID `bun:"id,pk"`
+	Name string    `bun:"name"`
+}
+
+type testStringModel struct {
+	ID   string `bun:"id,pk"`
+	Name string `bun:"name"`
+}
+
+type testFloatModel struct {
+	ID   float64 `bun:"id,pk"`
+	Name string  `bun:"name"`
+}
+
+func TestSetFieldFromString(t *testing.T) {
+	t.Run("int field", func(t *testing.T) {
+		item := &testModel{}
+		if err := common.SetFieldFromString(item, "ID", "42"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if item.ID != 42 {
+			t.Errorf("expected 42, got %d", item.ID)
+		}
+	})
+
+	t.Run("string field", func(t *testing.T) {
+		item := &testStringModel{}
+		if err := common.SetFieldFromString(item, "ID", "abc-123"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if item.ID != "abc-123" {
+			t.Errorf("expected 'abc-123', got %q", item.ID)
+		}
+	})
+
+	t.Run("uuid field", func(t *testing.T) {
+		item := &testUUIDModel{}
+		id := uuid.New()
+		if err := common.SetFieldFromString(item, "ID", id.String()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if item.ID != id {
+			t.Errorf("expected %s, got %s", id, item.ID)
+		}
+	})
+
+	t.Run("invalid uuid", func(t *testing.T) {
+		item := &testUUIDModel{}
+		if err := common.SetFieldFromString(item, "ID", "not-a-uuid"); err == nil {
+			t.Fatal("expected error for invalid UUID")
+		}
+	})
+
+	t.Run("invalid int", func(t *testing.T) {
+		item := &testModel{}
+		if err := common.SetFieldFromString(item, "ID", "not-a-number"); err == nil {
+			t.Fatal("expected error for invalid int")
+		}
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		item := &testFloatModel{}
+		if err := common.SetFieldFromString(item, "ID", "1.5"); err == nil {
+			t.Fatal("expected error for unsupported float type")
+		}
+	})
+
+	t.Run("nonexistent field", func(t *testing.T) {
+		item := &testModel{}
+		if err := common.SetFieldFromString(item, "Nonexistent", "value"); err == nil {
+			t.Fatal("expected error for nonexistent field")
+		}
+	})
+}
+
+func TestGetFieldAsString(t *testing.T) {
+	t.Run("int field", func(t *testing.T) {
+		item := &testModel{ID: 42}
+		result := common.GetFieldAsString(item, "ID")
+		if result != "42" {
+			t.Errorf("expected '42', got %q", result)
+		}
+	})
+
+	t.Run("string field", func(t *testing.T) {
+		item := &testStringModel{ID: "abc-123"}
+		result := common.GetFieldAsString(item, "ID")
+		if result != "abc-123" {
+			t.Errorf("expected 'abc-123', got %q", result)
+		}
+	})
+
+	t.Run("uuid field", func(t *testing.T) {
+		id := uuid.New()
+		item := &testUUIDModel{ID: id}
+		result := common.GetFieldAsString(item, "ID")
+		if result != id.String() {
+			t.Errorf("expected %q, got %q", id.String(), result)
+		}
+	})
+
+	t.Run("nonexistent field", func(t *testing.T) {
+		item := &testModel{ID: 1}
+		result := common.GetFieldAsString(item, "Nonexistent")
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("non-pointer value", func(t *testing.T) {
+		item := testModel{ID: 99}
+		result := common.GetFieldAsString(item, "ID")
+		if result != "99" {
+			t.Errorf("expected '99', got %q", result)
+		}
+	})
+}

--- a/router/action_test.go
+++ b/router/action_test.go
@@ -100,7 +100,7 @@ func TestAction_Registration(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -145,7 +145,7 @@ func TestAction_MultipleActions(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -204,7 +204,7 @@ func TestAction_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -261,7 +261,7 @@ func TestAction_WithOwnership(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Ownership needs to be on the resource auth config to be stored in metadata
 	// The action inherits this from the context set by wrapWithAuth
@@ -313,7 +313,7 @@ func TestAction_BlockedByDefault(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Action with empty auth config (no scopes) - should be blocked
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
@@ -337,7 +337,7 @@ func TestAction_NotFound(t *testing.T) {
 	cleanActionTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -381,7 +381,7 @@ func TestAction_CRUDStillWorks(t *testing.T) {
 	cleanActionTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[ActionTestOrder](b, "/orders",
 		router.AllPublic(),

--- a/router/auth.go
+++ b/router/auth.go
@@ -66,11 +66,10 @@ type OwnershipConfig struct {
 // Last config wins for each method. MethodAll expands to individual methods.
 func mergeAuthConfigs(configs []AuthConfig) map[string]*AuthConfig {
 	result := make(map[string]*AuthConfig)
-	for i := range configs {
-		methods := expandMethods(configs[i].Methods)
+	for _, cfg := range configs {
+		methods := expandMethods(cfg.Methods)
 		for _, method := range methods {
-			// Create a copy to avoid pointer issues
-			configCopy := configs[i]
+			configCopy := cfg
 			result[method] = &configCopy
 		}
 	}

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -56,7 +56,7 @@ func setupAuthTest(t *testing.T, registerFunc func(*router.Builder)) *chi.Mux {
 
 	// Create router
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerFunc(b)
 
 	return r
@@ -132,7 +132,7 @@ func TestAuth_AuthOnlyRoute(t *testing.T) {
 
 	// Test with auth (any scopes) - create new router with auth middleware
 	r2 := addAuthMiddleware(chi.NewRouter(), "user123", []string{"random_scope"})
-	b := router.NewBuilder(r2, testDB(t))
+	b := router.NewBuilder(r2)
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{router.ScopeAuthOnly},
@@ -166,7 +166,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 
 	// With auth but wrong scope - 403
 	r = addAuthMiddleware(chi.NewRouter(), "user123", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin", "moderator"},
@@ -182,7 +182,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 
 	// With correct scope - 200
 	r = addAuthMiddleware(chi.NewRouter(), "user123", []string{"admin"})
-	b = router.NewBuilder(r, testDB(t))
+	b = router.NewBuilder(r)
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin", "moderator"},
@@ -200,7 +200,7 @@ func TestAuth_ScopeRequired(t *testing.T) {
 func TestAuth_MethodSpecificAuth(t *testing.T) {
 	// Public reads, authenticated writes
 	r := addAuthMiddleware(chi.NewRouter(), "user123", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// First register without auth for GET/LIST (public reads)
 	router.RegisterRoutes[AuthTestUser](b, "/users",
@@ -216,7 +216,7 @@ func TestAuth_MethodSpecificAuth(t *testing.T) {
 
 	// GET /users (list) without auth - should succeed (public)
 	r2 := chi.NewRouter()
-	b2 := router.NewBuilder(r2, testDB(t))
+	b2 := router.NewBuilder(r2)
 	router.RegisterRoutes[AuthTestUser](b2, "/users",
 		router.AuthConfig{
 			Methods: []string{router.MethodGet, router.MethodList},
@@ -263,7 +263,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 	t.Run("PublicGet_AuthenticatedList", func(t *testing.T) {
 		// List requires auth, Get is public
 		r := chi.NewRouter()
-		b := router.NewBuilder(r, testDB(t))
+		b := router.NewBuilder(r)
 
 		router.RegisterRoutes[AuthTestPost](b, "/posts",
 			router.AuthConfig{
@@ -298,7 +298,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 	t.Run("PublicList_AuthenticatedGet", func(t *testing.T) {
 		// List is public, Get requires auth
 		r := chi.NewRouter()
-		b := router.NewBuilder(r, testDB(t))
+		b := router.NewBuilder(r)
 
 		router.RegisterRoutes[AuthTestPost](b, "/posts",
 			router.AuthConfig{
@@ -334,7 +334,7 @@ func TestAuth_MethodListVsMethodGet(t *testing.T) {
 func TestAuth_MethodAllOverride(t *testing.T) {
 	// MethodAll sets default, specific method overrides
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuthTestUser](b, "/users",
 		router.AuthConfig{
@@ -370,7 +370,7 @@ func TestAuth_MethodAllOverride(t *testing.T) {
 func TestAuth_Ownership_Create(t *testing.T) {
 	// Setup with ownership on posts
 	r := addAuthMiddleware(chi.NewRouter(), "auth0|user123", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -422,7 +422,7 @@ func TestAuth_Ownership_List(t *testing.T) {
 
 	// User1 should only see their post
 	r := addAuthMiddleware(chi.NewRouter(), "user1", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -469,7 +469,7 @@ func TestAuth_Ownership_BypassScope(t *testing.T) {
 
 	// Admin with bypass scope should see all posts
 	r := addAuthMiddleware(chi.NewRouter(), "admin_user", []string{"admin"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -511,7 +511,7 @@ func TestAuth_Ownership_Get404(t *testing.T) {
 
 	// User2 tries to access user1's post - should get 404
 	r := addAuthMiddleware(chi.NewRouter(), "user2", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -723,7 +723,7 @@ func TestAuth_ChildAuthPopulated(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Register parent (public) with child (ownership-based) using WithRelationName
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -816,7 +816,7 @@ func TestAuth_ChildAuthWithBypass(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllPublic(),
@@ -874,7 +874,7 @@ func TestAuth_ChildAuthNoAuth(t *testing.T) {
 
 	// Create router WITHOUT auth middleware (unauthenticated)
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllPublic(),
@@ -1001,7 +1001,7 @@ func TestAuth_NestedChildInclude(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts.Comments"
@@ -1042,7 +1042,7 @@ func TestAuth_NestedChildInclude_DeeperLevelBlocked(t *testing.T) {
 
 	// Comments require "premium" scope; user only has "user"
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllScoped("premium"))
 
 	// Single-level Posts include should still work
@@ -1097,7 +1097,7 @@ func TestAuth_NestedParentInclude(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	// GET comment with ?include=Post.Author
@@ -1140,7 +1140,7 @@ func TestAuth_ParentInclude_SingleLevel(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) +
@@ -1195,7 +1195,7 @@ func TestAuth_NestedParentInclude_DeeperLevelBlocked(t *testing.T) {
 
 	// Author requires "admin" scope; user only has "user"
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
 		router.AllScoped("admin"),
@@ -1268,7 +1268,7 @@ func TestAuth_SimpleChildInclude(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
@@ -1299,7 +1299,7 @@ func TestAuth_ChildInclude_NoAuth(t *testing.T) {
 
 	// No auth middleware — unauthenticated request
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	registerNestedIncludeRoutes(b, router.AllPublic())
 
 	url := "/authors/" + strconv.Itoa(author.ID) + "?include=Posts"
@@ -1329,7 +1329,7 @@ func TestAuth_ChildInclude_WrongScope(t *testing.T) {
 	author, _, _ := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1369,7 +1369,7 @@ func TestAuth_ChildInclude_ScopeGrantsAccess(t *testing.T) {
 
 	// User has "premium" scope which matches the child's requirement
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user", "premium"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Author is public, Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1409,7 +1409,7 @@ func TestAuth_ParentInclude_NoAuth(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Author requires "admin" scope, Post requires "editor" scope, Comment is public.
 	// No ownership at any level — avoids issue #28 parent ownership check blocking the request.
@@ -1460,7 +1460,7 @@ func TestAuth_ParentInclude_WrongScope(t *testing.T) {
 	author, post, comment := seedNestedIncludeData(t, db)
 
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Author requires "admin", Post is ownership, Comment is public
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1515,7 +1515,7 @@ func TestAuth_MixedPublicParent_ScopedChildInclude(t *testing.T) {
 
 	// No auth — unauthenticated request
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Author is public, Posts require "premium" scope
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1562,7 +1562,7 @@ func TestAuth_NestedChildInclude_MiddleLevelBlocked(t *testing.T) {
 
 	// User has "user" scope only
 	r := addAuthMiddleware(chi.NewRouter(), "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Author is public, Posts require "editor" scope, Comments are public
 	router.RegisterRoutes[IncludeTestAuthor](b, "/authors",
@@ -1662,7 +1662,7 @@ func TestAuth_Issue24_OwnershipWithEmptyUserID(t *testing.T) {
 
 	// Create router with middleware that sets empty UserID (simulating dhe pattern)
 	r := addAuthMiddlewareEmptyUserID(chi.NewRouter())
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Register route with ownership but no explicit scopes (the problematic pattern)
 	router.RegisterRoutes[AuthTestPost](b, "/posts", router.AuthConfig{
@@ -1702,7 +1702,7 @@ func TestAuth_Issue24_ScopeAuthOnlyWithEmptyUserID(t *testing.T) {
 
 	// Create router with middleware that sets empty UserID
 	r := addAuthMiddlewareEmptyUserID(chi.NewRouter())
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Register route with ScopeAuthOnly
 	router.RegisterRoutes[AuthTestUser](b, "/users", router.AuthConfig{
@@ -1772,7 +1772,7 @@ func TestAuth_Issue28_ParentOwnershipNoAuth(t *testing.T) {
 
 	// Create router WITHOUT auth (simulating public child under owned parent)
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 		router.AuthConfig{
@@ -1835,7 +1835,7 @@ func TestAuth_Issue28_ParentOwnershipFiltering(t *testing.T) {
 			}
 
 			r := addAuthMiddleware(chi.NewRouter(), tt.authUser, []string{"user"})
-			b := router.NewBuilder(r, testDB(t))
+			b := router.NewBuilder(r)
 
 			router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 				router.AuthConfig{
@@ -1895,7 +1895,7 @@ func TestAuth_Issue28_ParentOwnershipBypass(t *testing.T) {
 
 	// Create router with Admin (has bypass scope)
 	r := addAuthMiddleware(chi.NewRouter(), "admin", []string{"user", "admin"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[OwnershipTestProject](b, "/projects",
 		router.AuthConfig{
@@ -2000,7 +2000,7 @@ func TestTenantAuth_RequiresTenantID(t *testing.T) {
 
 	// Auth middleware with empty TenantID
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2032,7 +2032,7 @@ func TestTenantAuth_List_FiltersByTenant(t *testing.T) {
 
 	// User in org-a
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2072,7 +2072,7 @@ func crossTenantRequestReturns404(t *testing.T, method string) {
 	_, _ = db.NewInsert().Model(p).Returning("*").Exec(ctx)
 
 	r := addTenantAuthMiddleware(chi.NewRouter(), "bob", "org-b", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2096,7 +2096,7 @@ func TestTenantAuth_Create_AutoSetsTenantField(t *testing.T) {
 	setupTenantTest(t)
 
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2138,7 +2138,7 @@ func TestTenantAuth_Update_CrossTenant_404(t *testing.T) {
 
 	// org-b tries to update org-a's project
 	r := addTenantAuthMiddleware(chi.NewRouter(), "bob", "org-b", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2171,7 +2171,7 @@ func TestTenantAuth_IsTenantTable_ViewOwnOrg(t *testing.T) {
 	_, _ = db.NewInsert().Model(&TenantTestOrg{ID: "org-b", Name: "Beta"}).Exec(ctx)
 
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestOrg](b, "/organizations",
 		router.IsTenantTable(),
@@ -2211,7 +2211,7 @@ func TestTenantAuth_IsTenantTable_CrossTenant_404(t *testing.T) {
 
 	// org-b tries to GET org-a
 	r := addTenantAuthMiddleware(chi.NewRouter(), "bob", "org-b", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestOrg](b, "/organizations",
 		router.IsTenantTable(),
@@ -2248,7 +2248,7 @@ func TestTenantAuth_ChildInheritsTenantScope(t *testing.T) {
 
 	// org-a user accesses tasks under their project
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),
@@ -2311,7 +2311,7 @@ func TestTenantAuth_WithOwnership_BothEnforced(t *testing.T) {
 
 	// Alice in org-a: should only see her own project in org-a
 	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[TenantTestProject](b, "/projects",
 		router.WithTenantScope("OrgID"),

--- a/router/batch_test.go
+++ b/router/batch_test.go
@@ -46,7 +46,7 @@ func TestBatch_AllPublicWithBatch(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 	)
@@ -66,7 +66,7 @@ func TestBatch_AllScopedWithBatch(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllScopedWithBatch("admin"),
 	)
@@ -101,7 +101,7 @@ func TestBatch_WithBatchLimit(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithBatchLimit(2),
@@ -142,7 +142,7 @@ func TestBatch_CustomBatchCreate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchCreate(customFn),
@@ -178,7 +178,7 @@ func TestBatch_CustomBatchUpdate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchUpdate(customFn),
@@ -227,7 +227,7 @@ func TestBatch_CustomBatchDelete(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublicWithBatch(),
 		router.WithCustomBatchDelete(customFn),
@@ -270,7 +270,7 @@ func TestBatch_NoBatchMethodsNoRoutes(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	// Only AllPublic, no batch methods
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublic(),
@@ -293,7 +293,7 @@ func TestBatch_PartialBatchMethods(t *testing.T) {
 	setupBatchTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	// Only batch create, not update or delete
 	router.RegisterRoutes[BatchTestItem](b, "/items",
 		router.AllPublic(),

--- a/router/builder.go
+++ b/router/builder.go
@@ -2,15 +2,13 @@ package router
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"reflect"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/schema"
 
+	"github.com/sjgoldie/go-restgen/datastore"
 	"github.com/sjgoldie/go-restgen/handler"
 	"github.com/sjgoldie/go-restgen/metadata"
 )
@@ -21,7 +19,6 @@ type NestedFunc func(b *Builder)
 // Builder provides context for registering nested routes and manages the chi router
 type Builder struct {
 	router                  chi.Router             // Chi router being configured
-	db                      *bun.DB                // Database connection for schema introspection
 	parentMeta              *metadata.TypeMetadata // Metadata of the immediate parent (nil for root)
 	parentChildRelationAuth map[string]*AuthConfig // Parent's shared child relation auth map (children add to this via registerChildAuthConfig)
 	parentGetAuth           *AuthConfig            // Parent's GET auth config (for ParentAuth chain on child configs)
@@ -77,12 +74,9 @@ type metadataSetup struct {
 }
 
 // NewBuilder creates a new Builder for registering routes.
-// The db parameter provides access to Bun's schema introspection for resolving
-// field names, column names, table names, and relationships from model types.
-func NewBuilder(r chi.Router, db *bun.DB) *Builder {
+func NewBuilder(r chi.Router) *Builder {
 	return &Builder{
 		router:     r,
-		db:         db,
 		parentMeta: nil,
 	}
 }
@@ -198,7 +192,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	urlParamUUID := metadata.GenerateTypeID()
 
 	// Get table name from Bun schema
-	tableName := getTableName(b.db, tType)
+	tableName := datastore.TableName(tType)
 
 	// Check if this type has a parent relationship
 	var parentType reflect.Type
@@ -206,37 +200,37 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 		parentType = b.parentMeta.ModelType
 	}
 
-	var parentRel parentRelation
+	var parentRel datastore.Relation
 	var parentJoinCol string
 	var parentJoinField string
 	if joinOn != nil && b.parentMeta != nil {
 		// WithJoinOn provided — resolve Go field names to column names via Bun schema.
-		childCol, err := columnFromGoName(b.db, tType, joinOn.ChildCol)
+		childCol, err := datastore.ColumnName(tType, joinOn.ChildCol)
 		if err != nil {
 			slog.WarnContext(context.Background(), "WithJoinOn: invalid child field",
 				"type", typeName,
 				"field", joinOn.ChildCol,
 				"error", err)
 		}
-		parentCol, err := columnFromGoName(b.db, b.parentMeta.ModelType, joinOn.ParentCol)
+		parentCol, err := datastore.ColumnName(b.parentMeta.ModelType, joinOn.ParentCol)
 		if err != nil {
 			slog.WarnContext(context.Background(), "WithJoinOn: invalid parent field",
 				"type", typeName,
 				"field", joinOn.ParentCol,
 				"error", err)
 		}
-		parentRel = parentRelation{foreignKeyCol: childCol, parentJoinCol: parentCol}
+		parentRel = datastore.Relation{ForeignKeyCol: childCol, ParentJoinCol: parentCol}
 		parentJoinCol = parentCol
 		parentJoinField = joinOn.ParentCol
 	} else {
 		var err error
-		parentRel, err = findParentRelationshipFromType(b.db, tType, parentType)
+		parentRel, err = datastore.FindRelation(tType, parentType)
 		if err != nil {
 			slog.WarnContext(context.Background(), "could not find parent relationship",
 				"type", typeName,
 				"error", err)
 		}
-		parentJoinCol = parentRel.parentJoinCol
+		parentJoinCol = parentRel.ParentJoinCol
 	}
 
 	// Default parent join column/field to "id"/"ID" for standard FK relationships
@@ -248,7 +242,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	}
 
 	// Validate parent relationship
-	validateParentRelationship(b.parentMeta, parentRel.foreignKeyCol, typeName)
+	validateParentRelationship(b.parentMeta, parentRel.ForeignKeyCol, typeName)
 
 	// Determine PK field name - default to "ID" convention
 	if pkField == "" {
@@ -265,7 +259,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 		ModelType:       tType,
 		ParentType:      parentType,
 		ParentMeta:      b.parentMeta,
-		ForeignKeyCol:   parentRel.foreignKeyCol,
+		ForeignKeyCol:   parentRel.ForeignKeyCol,
 		ParentJoinCol:   parentJoinCol,
 		ParentJoinField: parentJoinField,
 		ChildMeta:       make(map[string]*metadata.TypeMetadata),
@@ -291,7 +285,7 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 		for _, config := range authMap {
 			if config != nil {
 				config.ParentAuth = b.parentGetAuth
-				config.ParentIncludeName = parentRel.fieldName
+				config.ParentIncludeName = parentRel.FieldName
 			}
 		}
 	}
@@ -530,7 +524,6 @@ func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc
 		if nested != nil && nestedRouter != nil {
 			childBuilder := &Builder{
 				router:                  nestedRouter,
-				db:                      b.db,
 				parentMeta:              meta,
 				parentChildRelationAuth: setup.childRelationAuth,
 				parentGetAuth:           setup.authMap[MethodGet],
@@ -595,85 +588,6 @@ func createParentIDMiddleware(paramUUID string) func(http.Handler) http.Handler 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
-}
-
-// parentRelation holds the results of finding a parent relationship
-type parentRelation struct {
-	foreignKeyCol string // FK column name (e.g., "author_id")
-	parentJoinCol string // Parent join column name (e.g., "id") — right side of join: tag
-	fieldName     string // Struct field name for belongs-to (e.g., "Author")
-}
-
-// findParentRelationshipFromType uses Bun's schema to find the relationship between child and parent.
-// Checks for:
-// 1. Child has belongs-to Parent (e.g., Article belongs-to User) — FK is on child
-// 2. Parent has has-many/has-one Child — extract join columns from parent's relation
-func findParentRelationshipFromType(db *bun.DB, childType reflect.Type, parentType reflect.Type) (parentRelation, error) {
-	if parentType == nil {
-		return parentRelation{}, nil
-	}
-
-	childTable := db.Table(childType)
-
-	// Case 1: child has a belongs-to relation pointing to parent
-	for _, rel := range childTable.Relations {
-		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == parentType {
-			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
-				return parentRelation{
-					foreignKeyCol: rel.BasePKs[0].Name,
-					parentJoinCol: rel.JoinPKs[0].Name,
-					fieldName:     rel.Field.GoName,
-				}, nil
-			}
-		}
-	}
-
-	// Case 2: parent has has-many or has-one pointing to child
-	parentTable := db.Table(parentType)
-	for _, rel := range parentTable.Relations {
-		if (rel.Type == schema.HasManyRelation || rel.Type == schema.HasOneRelation) && rel.JoinTable.Type == childType {
-			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
-				return parentRelation{
-					foreignKeyCol: rel.JoinPKs[0].Name,
-					parentJoinCol: rel.BasePKs[0].Name,
-					fieldName:     rel.Field.GoName,
-				}, nil
-			}
-		}
-	}
-
-	// Case 3: parent has belongs-to pointing to child (inverted belongs-to,
-	// e.g., Post.Author belongs-to User — FK author_id is on the parent)
-	for _, rel := range parentTable.Relations {
-		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == childType {
-			if len(rel.BasePKs) > 0 && len(rel.JoinPKs) > 0 {
-				return parentRelation{
-					foreignKeyCol: rel.BasePKs[0].Name,
-					parentJoinCol: rel.JoinPKs[0].Name,
-					fieldName:     rel.Field.GoName,
-				}, nil
-			}
-		}
-	}
-
-	return parentRelation{}, fmt.Errorf("no relationship between %s and %s found", childType.Name(), parentType.Name())
-}
-
-// columnFromGoName resolves a Go field name to its SQL column name using Bun's schema.
-func columnFromGoName(db *bun.DB, tType reflect.Type, goName string) (string, error) {
-	table := db.Table(tType)
-	for _, field := range table.Fields {
-		if field.GoName == goName {
-			return field.Name, nil
-		}
-	}
-	return "", fmt.Errorf("field %s not found on type %s", goName, tType.Name())
-}
-
-// getTableName returns the SQL table name for a model type using Bun's schema.
-func getTableName(db *bun.DB, tType reflect.Type) string {
-	table := db.Table(tType)
-	return table.Name
 }
 
 // mergeQueryConfigs applies query configurations to metadata and returns a new copy.

--- a/router/builder_internal_test.go
+++ b/router/builder_internal_test.go
@@ -2,38 +2,20 @@ package router
 
 import (
 	"context"
-	"database/sql"
 	"io"
-	"reflect"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/dialect/sqlitedialect"
-	_ "github.com/uptrace/bun/driver/sqliteshim"
 
 	"github.com/sjgoldie/go-restgen/filestore"
 	"github.com/sjgoldie/go-restgen/metadata"
 )
 
-func testDB(t *testing.T) *bun.DB {
-	t.Helper()
-	sqlDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = sqlDB.Close() })
-	return bun.NewDB(sqlDB, sqlitedialect.New())
-}
-
 const testFieldName = "Name"
-const testAuthorIDCol = "author_id"
 
-// testModel is a simple model for testing route registration
 type testModel struct {
-	bun.BaseModel `bun:"table:test_models"`
-	ID            int    `bun:"id,pk,autoincrement" json:"id"`
-	Name          string `bun:"name" json:"name"`
+	ID   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 func TestMergeQueryConfigs(t *testing.T) {
@@ -177,130 +159,6 @@ func TestMergeQueryConfigs(t *testing.T) {
 	})
 }
 
-type columnFromGoNameTestModel struct {
-	bun.BaseModel `bun:"table:test_ftc"`
-	ID            int    `bun:"id,pk,autoincrement"`
-	NMI           string `bun:"nmi,notnull"`
-	AuthorID      int    `bun:"author_id,notnull"`
-}
-
-func TestColumnFromGoName(t *testing.T) {
-	db := testDB(t)
-	tType := reflect.TypeOf(columnFromGoNameTestModel{})
-
-	t.Run("standard field", func(t *testing.T) {
-		col, err := columnFromGoName(db, tType, "AuthorID")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if col != testAuthorIDCol {
-			t.Errorf("expected 'author_id', got '%s'", col)
-		}
-	})
-
-	t.Run("acronym field", func(t *testing.T) {
-		col, err := columnFromGoName(db, tType, "NMI")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if col != "nmi" {
-			t.Errorf("expected 'nmi', got '%s'", col)
-		}
-	})
-
-	t.Run("pk field", func(t *testing.T) {
-		col, err := columnFromGoName(db, tType, "ID")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if col != "id" {
-			t.Errorf("expected 'id', got '%s'", col)
-		}
-	})
-
-	t.Run("field not found", func(t *testing.T) {
-		_, err := columnFromGoName(db, tType, "Nonexistent")
-		if err == nil {
-			t.Fatal("expected error for nonexistent field")
-		}
-	})
-}
-
-// Models for testing findParentRelationshipFromType — inverted belongs-to case
-// (parent has belongs-to pointing to child, e.g., Post.Author belongs-to User)
-type parentRelUser struct {
-	bun.BaseModel `bun:"table:parent_rel_users"`
-	ID            int    `bun:"id,pk,autoincrement"`
-	Name          string `bun:"name"`
-}
-
-type parentRelPost struct {
-	bun.BaseModel `bun:"table:parent_rel_posts"`
-	ID            int            `bun:"id,pk,autoincrement"`
-	AuthorID      int            `bun:"author_id,notnull"`
-	Author        *parentRelUser `bun:"rel:belongs-to,join:author_id=id"`
-	Title         string         `bun:"title"`
-}
-
-func TestFindParentRelationshipFromType(t *testing.T) {
-	db := testDB(t)
-	userType := reflect.TypeOf(parentRelUser{})
-	postType := reflect.TypeOf(parentRelPost{})
-
-	t.Run("child belongs-to parent", func(t *testing.T) {
-		// Post belongs-to User (standard case: FK author_id is on Post)
-		rel, err := findParentRelationshipFromType(db, postType, userType)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if rel.foreignKeyCol != testAuthorIDCol {
-			t.Errorf("expected foreignKeyCol 'author_id', got %q", rel.foreignKeyCol)
-		}
-		if rel.parentJoinCol != "id" {
-			t.Errorf("expected parentJoinCol 'id', got %q", rel.parentJoinCol)
-		}
-		if rel.fieldName != "Author" {
-			t.Errorf("expected fieldName 'Author', got %q", rel.fieldName)
-		}
-	})
-
-	t.Run("parent belongs-to child (inverted)", func(t *testing.T) {
-		// User registered as child of Post — Post.Author belongs-to User
-		// FK author_id is on the parent (Post), not on the child (User)
-		rel, err := findParentRelationshipFromType(db, userType, postType)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if rel.foreignKeyCol != testAuthorIDCol {
-			t.Errorf("expected foreignKeyCol 'author_id', got %q", rel.foreignKeyCol)
-		}
-		if rel.parentJoinCol != "id" {
-			t.Errorf("expected parentJoinCol 'id', got %q", rel.parentJoinCol)
-		}
-		if rel.fieldName != "Author" {
-			t.Errorf("expected fieldName 'Author', got %q", rel.fieldName)
-		}
-	})
-
-	t.Run("no relationship", func(t *testing.T) {
-		unrelatedType := reflect.TypeOf(testModel{})
-		_, err := findParentRelationshipFromType(db, unrelatedType, userType)
-		if err == nil {
-			t.Fatal("expected error for unrelated types")
-		}
-	})
-
-	t.Run("nil parent returns empty", func(t *testing.T) {
-		rel, err := findParentRelationshipFromType(db, postType, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if rel.foreignKeyCol != "" {
-			t.Errorf("expected empty foreignKeyCol, got %q", rel.foreignKeyCol)
-		}
-	})
-}
-
 func TestRegisterChildAuthConfig(t *testing.T) {
 	t.Run("empty relationName does nothing", func(t *testing.T) {
 		sharedMap := make(map[string]*AuthConfig)
@@ -398,7 +256,7 @@ func TestSharedChildRelationAuth(t *testing.T) {
 		// This test verifies that when we use AllPublicWithBatch and register child routes,
 		// the batch auth configs have access to the same ChildAuth map as regular GET/LIST configs
 		r := chi.NewRouter()
-		b := NewBuilder(r, testDB(t))
+		b := NewBuilder(r)
 
 		// We need to capture the auth configs to verify they share the same ChildAuth
 		// Since we can't easily access them after registration, we'll verify the behavior
@@ -489,7 +347,7 @@ func TestFileResourceRegistration(t *testing.T) {
 		}
 
 		r := chi.NewRouter()
-		b := NewBuilder(r, testDB(t))
+		b := NewBuilder(r)
 		RegisterRoutes[testModel](b, "/test", AsFileResource())
 	})
 }

--- a/router/builder_test.go
+++ b/router/builder_test.go
@@ -4,7 +4,6 @@ package router_test
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,8 +17,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/dialect/sqlitedialect"
-	_ "github.com/uptrace/bun/driver/sqliteshim"
 
 	"github.com/sjgoldie/go-restgen/datastore"
 	"github.com/sjgoldie/go-restgen/filestore"
@@ -27,16 +24,6 @@ import (
 	"github.com/sjgoldie/go-restgen/router"
 	"github.com/sjgoldie/go-restgen/service"
 )
-
-func testDB(t *testing.T) *bun.DB {
-	t.Helper()
-	sqlDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { sqlDB.Close() })
-	return bun.NewDB(sqlDB, sqlitedialect.New())
-}
 
 func TestMain(m *testing.M) {
 	// Initialize datastore for all tests
@@ -135,7 +122,7 @@ func setupBuilderTest(t *testing.T) (*chi.Mux, *bun.DB) {
 
 	// Create router with nested routes using Builder API
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRoutes[TestUser](b, "/users", router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{router.ScopePublic},
@@ -482,7 +469,7 @@ func TestMultiReg_SameModelRootAndNested(t *testing.T) {
 
 	// Setup router with Item at root AND nested under Project
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Root registration: /items (all items)
 	router.RegisterRoutes[MultiRegItem](b, "/items", router.AuthConfig{
@@ -587,7 +574,7 @@ func TestMultiReg_SameModelDifferentParents(t *testing.T) {
 
 	// Setup router with Item under both Project and User
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[MultiRegProject](b, "/projects", router.AuthConfig{
 		Methods: []string{router.MethodAll},
@@ -684,7 +671,7 @@ func TestMultiReg_DifferentOwnershipPerRegistration(t *testing.T) {
 	// - /projects/{id}/items: ownership enforced (sees only own items)
 	r := chi.NewRouter()
 	addMultiRegAuthMiddleware(r, "alice", []string{"user"})
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Root: public, no ownership
 	router.RegisterRoutes[MultiRegItem](b, "/items", router.AuthConfig{
@@ -777,7 +764,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Admin can see all project items (bypass)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "admin_user", []string{"admin"})
-		b := router.NewBuilder(r, testDB(t))
+		b := router.NewBuilder(r)
 
 		router.RegisterRoutes[MultiRegProject](b, "/projects", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -813,7 +800,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Admin does NOT bypass user items (different bypass scope)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "admin_user", []string{"admin"})
-		b := router.NewBuilder(r, testDB(t))
+		b := router.NewBuilder(r)
 
 		router.RegisterRoutes[MultiRegUser](b, "/users", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -850,7 +837,7 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 		// Moderator can see all user items (bypass)
 		r := chi.NewRouter()
 		addMultiRegAuthMiddleware(r, "mod_user", []string{"moderator"})
-		b := router.NewBuilder(r, testDB(t))
+		b := router.NewBuilder(r)
 
 		router.RegisterRoutes[MultiRegUser](b, "/users", router.AuthConfig{
 			Methods: []string{router.MethodAll},
@@ -904,7 +891,7 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 
 	// Setup router with query config options
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[MultiRegItem](b, "/items",
 		router.AuthConfig{
@@ -1084,7 +1071,7 @@ func TestBuilder_ValidationCreate(t *testing.T) {
 	setupJobTable()
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Register with validator: new jobs must have status "pending" and priority 1-5
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1162,7 +1149,7 @@ func TestBuilder_ValidationUpdate(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Validator: can only move to "in_progress" from "pending", and to "complete" from "in_progress"
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1242,7 +1229,7 @@ func TestBuilder_ValidationDelete(t *testing.T) {
 	_, _ = db.NewInsert().Model(inProgressJob).Returning("*").Exec(context.Background())
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	// Validator: can't delete jobs that are in_progress
 	router.RegisterRoutes[Job](b, "/jobs",
@@ -1299,7 +1286,7 @@ func TestBuilder_CustomHandlers(t *testing.T) {
 
 	// Setup router with ALL custom handler options
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	customGetCalled := false
 	customGetAllCalled := false
@@ -1450,7 +1437,7 @@ func TestWithAudit(t *testing.T) {
 
 	// Setup router with audit
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[AuditedTask](b, "/tasks",
 		router.AuthConfig{

--- a/router/endpoint_test.go
+++ b/router/endpoint_test.go
@@ -94,7 +94,7 @@ func TestWithEndpoint_Registration(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -140,7 +140,7 @@ func TestWithEndpoint_DifferentHTTPMethods(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -195,7 +195,7 @@ func TestWithEndpoint_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -244,7 +244,7 @@ func TestWithEndpoint_Forbidden(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -267,7 +267,7 @@ func TestWithEndpoint_CRUDStillWorks(t *testing.T) {
 	cleanFuncTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -311,7 +311,7 @@ func TestWithEndpoint_NotFound(t *testing.T) {
 	cleanFuncTestTable(t)
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -357,7 +357,7 @@ func TestRegisterRootEndpoint_Success(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRootEndpoint(b, "GET", "/health", healthFn, router.AllPublic())
 
@@ -397,7 +397,7 @@ func TestRegisterRootEndpoint_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRootEndpoint(b, "POST", "/webhooks/stripe", webhookFn, router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin"},
@@ -448,7 +448,7 @@ func TestWithEndpoint_WithOwnership(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AuthConfig{
@@ -497,7 +497,7 @@ func TestWithEndpoint_BlockedByDefault(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -527,7 +527,7 @@ func TestRegisterRootEndpoint_Forbidden(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRootEndpoint(b, "POST", "/webhooks/stripe", webhookFn, router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin"},
@@ -548,7 +548,7 @@ func TestRegisterRootEndpoint_NoContent(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRootEndpoint(b, "POST", "/webhooks/test", webhookFn, router.AllPublic())
 

--- a/router/sse_test.go
+++ b/router/sse_test.go
@@ -35,7 +35,7 @@ func TestWithSSE_Registration(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -96,7 +96,7 @@ func TestWithSSE_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -150,7 +150,7 @@ func TestWithSSE_Forbidden(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -178,7 +178,7 @@ func TestWithSSE_NotFound(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -226,7 +226,7 @@ func TestWithSSE_WithOwnership(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AuthConfig{
@@ -280,7 +280,7 @@ func TestWithSSE_BlockedByDefault(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -306,7 +306,7 @@ func TestWithSSE_CRUDStillWorks(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRoutes[FuncTestOrder](b, "/orders",
 		router.AllPublic(),
@@ -344,7 +344,7 @@ func TestRegisterRootSSE_Success(t *testing.T) {
 	}
 
 	r := chi.NewRouter()
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 
 	router.RegisterRootSSE(b, "/events/system", sseFn, router.AllPublic())
 
@@ -386,7 +386,7 @@ func TestRegisterRootSSE_WithAuth(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRootSSE(b, "/events/system", sseFn, router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin"},
@@ -427,7 +427,7 @@ func TestRegisterRootSSE_Forbidden(t *testing.T) {
 		})
 	})
 
-	b := router.NewBuilder(r, testDB(t))
+	b := router.NewBuilder(r)
 	router.RegisterRootSSE(b, "/events/system", sseFn, router.AuthConfig{
 		Methods: []string{router.MethodAll},
 		Scopes:  []string{"admin"},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -560,6 +560,7 @@ func TestService_UpdateByParentRelation(t *testing.T) {
 		TypeName:      "ChildModel",
 		TableName:     "child_models",
 		URLParamUUID:  parentMeta.URLParamUUID,
+		PKField:       "ID",
 		ModelType:     reflect.TypeOf(ChildModel{}),
 		ParentType:    reflect.TypeOf(ParentModel{}),
 		ParentMeta:    parentMeta,


### PR DESCRIPTION
## Summary
- **Bug fix:** `UpdateByParentRelation` now sets the resolved child PK on the struct before calling `Update`, so `WherePK()` targets the correct row instead of using the parent's URL ID
- **Refactor:** Extracts shared reflection utilities into `internal/common`, moves Bun schema functions (`ColumnName`, `TableName`, `FindRelation`) into `datastore` package using the singleton pattern
- **BREAKING CHANGE:** Removes `*bun.DB` param from `router.NewBuilder` — callers update from `router.NewBuilder(r, db.GetDB())` to `router.NewBuilder(r)`

## Test plan
- [x] Unit tests pass across all 8 packages (common, datastore, handler, router, service, errors, filestore, metrics)
- [x] New `TestWrapper_UpdateByParentRelation_DivergentIDs` verifies the bug fix with divergent parent/child IDs
- [x] New `datastore/schema_test.go` covers `ColumnName`, `TableName`, `FindRelation` (>80% coverage)
- [x] Bruno integration tests pass (all 16 suites)
- [x] All 13 pre-commit hooks pass

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)