### PR TITLE
feat: Add AI coding agent skill installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,30 @@ See the [simple example](./examples/simple) for a simple working example to get 
 
 ## Using with AI Coding Agents
 
-The [AGENT.md](./AGENT.md) file provides a concise reference optimized for AI coding assistants (Claude, Copilot, etc.). Point your AI agent to this file for quick, accurate go-restgen implementations.
+### Claude Code / Cursor (Auto-Install)
+
+Install go-restgen rules so your AI agent automatically knows the framework patterns:
+
+```bash
+# Claude Code (default)
+go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest
+
+# Cursor
+go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=cursor
+
+# Both
+go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=all
+```
+
+This writes rule files into your project's agent-specific directory (`.claude/skills/go-restgen/` or `.cursor/rules/`). The agent auto-detects them and loads framework context whenever you work on the project — no manual prompting needed.
+
+### Other Agents
+
+For agents that support project-level instruction files (Codex CLI, Cline, etc.), copy the contents of [AGENT.md](./AGENT.md) into your agent's instructions file. For detailed handler signatures and all route options, also include [cmd/install-skill/skill/patterns.md](./cmd/install-skill/skill/patterns.md).
+
+### Manual Prompting
+
+For any AI agent, you can point it directly to the reference file:
 
 **Sample prompt:**
 ```

--- a/cmd/install-skill/cursor/go-restgen.mdc
+++ b/cmd/install-skill/cursor/go-restgen.mdc
@@ -1,0 +1,481 @@
+---
+description: go-restgen REST API framework patterns — model definitions, route registration, auth, nesting, custom endpoints, SSE, file uploads, tenancy, and query configuration.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+# go-restgen Framework Guide
+
+You are working with go-restgen, a type-safe REST API framework for Go using generics. It auto-generates CRUD endpoints from model definitions. Built on Chi (router) and Bun (ORM).
+
+## Core Pattern
+
+```go
+// 1. Define model with Bun tags
+type Product struct {
+    bun.BaseModel `bun:"table:products"`
+    ID            int       `bun:"id,pk,autoincrement" json:"id"`
+    Name          string    `bun:"name,notnull" json:"name"`
+    Price         float64   `bun:"price,notnull" json:"price"`
+    CreatedAt     time.Time `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
+    UpdatedAt     time.Time `bun:"updated_at,notnull" json:"updated_at,omitempty"`
+}
+
+// 2. Timestamp hook
+func (p *Product) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+    now := time.Now()
+    switch query.(type) {
+    case *bun.InsertQuery:
+        p.CreatedAt = now
+        p.UpdatedAt = now
+    case *bun.UpdateQuery:
+        p.UpdatedAt = now
+    }
+    return nil
+}
+
+// 3. Setup: datastore, chi router, builder
+db, _ := datastore.NewSQLite(":memory:")
+datastore.Initialize(db)
+defer datastore.Cleanup()
+db.GetDB().NewCreateTable().Model((*Product)(nil)).IfNotExists().Exec(context.Background())
+
+r := chi.NewRouter()
+b := router.NewBuilder(r)
+
+// 4. Register routes with options
+router.RegisterRoutes[Product](b, "/products",
+    router.AllPublic(),
+    router.WithFilters("Name", "Price"),
+    router.WithSorts("Name", "Price", "CreatedAt"),
+    router.WithPagination(20, 100),
+)
+```
+
+This generates: `GET/POST /products`, `GET/PUT/DELETE /products/{id}`.
+
+## Auth Patterns
+
+```go
+router.AllPublic()                                          // No auth
+router.AllScoped("admin")                                   // Require scope
+router.IsAuthenticated()                                    // Any valid auth
+router.AllWithOwnershipUnless([]string{"UserID"}, "admin")  // Owner-only + admin bypass
+
+// Per-method
+router.AuthConfig{
+    Methods: []string{router.MethodGet, router.MethodList},
+    Scopes:  []string{router.ScopePublic},
+},
+router.AuthConfig{
+    Methods: []string{router.MethodPost, router.MethodPut, router.MethodDelete},
+    Scopes:  []string{"admin"},
+},
+```
+
+Auth middleware sets `AuthInfo` on context:
+```go
+authInfo := &router.AuthInfo{UserID: userID, TenantID: tenantID, Scopes: scopes}
+ctx := context.WithValue(r.Context(), router.AuthInfoKey, authInfo)
+```
+
+## Nesting
+
+```go
+router.RegisterRoutes[Blog](b, "/blogs", router.AllPublic(), func(b *router.Builder) {
+    router.RegisterRoutes[Post](b, "/posts",
+        router.AllPublic(),
+        router.WithRelationName("Posts"),  // enables ?include=Posts on parent
+    )
+})
+```
+
+Child model needs FK + belongs-to tag:
+```go
+BlogID int `bun:"blog_id,notnull,skipupdate" json:"blog_id"`
+Blog  *Blog `bun:"rel:belongs-to,join:blog_id=id" json:"-"`
+```
+
+## Custom Endpoints (Anything Funcs)
+
+```go
+// Item-level: METHOD /resource/{id}/{name}
+router.WithEndpoint("GET", "status", handlerFn, router.AuthConfig{...})
+
+// Root-level: METHOD /any/path (no parent model)
+router.RegisterRootEndpoint(b, "GET", "/system/info", handlerFn, router.AllPublic())
+
+// Item-level SSE: GET /resource/{id}/{name}
+router.WithSSE("events", sseFn, router.AuthConfig{...})
+
+// Root-level SSE: GET /any/path
+router.RegisterRootSSE(b, "/events/system", sseFn, router.AllPublic())
+```
+
+## Key Conventions
+
+- **PK field**: named `ID` by default, override with `router.WithAlternatePK("MyPK")`
+- **FK fields**: include `skipupdate` to prevent modification
+- **Ownership fields**: string type matching `AuthInfo.UserID`
+- **Timestamps**: use `BeforeAppendModel` hook
+- **UUID PKs**: use `uuid.UUID` type with `bun:"id,pk,type:uuid"`
+- **Routes blocked by default**: must explicitly configure auth
+- **Path IDs take precedence**: JSON body IDs and FKs are ignored
+
+## All Route Registration Options
+
+```go
+router.RegisterRoutes[Model](builder, "/path",
+    // Access control (pick one)
+    router.AllPublic(),
+    router.AllScoped("admin"),
+    router.IsAuthenticated(),
+    router.PublicList(),
+    router.PublicGet(),
+    router.PublicReadOnly(),
+    router.AllPublicWithBatch(),
+    router.AllScopedWithBatch("admin"),
+
+    // Per-method auth
+    router.AuthConfig{
+        Methods: []string{router.MethodGet, router.MethodList},
+        Scopes:  []string{router.ScopePublic},
+    },
+
+    // Ownership
+    router.AllWithOwnershipUnless([]string{"UserID"}, "admin"),
+
+    // Single resource (belongs-to or /me)
+    router.AsSingleRoute("AuthorID"),
+    router.AsSingleRouteWithPut(""),
+
+    // Query options (individual)
+    router.WithFilters("Status", "Name"),
+    router.WithSorts("Name", "CreatedAt"),
+    router.WithPagination(20, 100),
+    router.WithDefaultSort("-CreatedAt"),
+    router.WithSums("Price", "Stock"),
+
+    // Query options (combined)
+    router.WithQuery(router.QueryConfig{
+        FilterableFields: []string{"Status", "Name"},
+        SortableFields:   []string{"Name", "CreatedAt"},
+        SummableFields:   []string{"Price"},
+        DefaultSort:      "-CreatedAt",
+        DefaultLimit:     20,
+        MaxLimit:         100,
+    }),
+
+    // Relations
+    router.WithRelationName("Posts"),
+    router.WithJoinOn("NMI", "NMI"),
+    router.WithAlternatePK("MyPK"),
+
+    // Custom CRUD handlers
+    router.WithCustomGet(customGetFn),
+    router.WithCustomGetAll(customGetAllFn),
+    router.WithCustomCreate(customCreateFn),
+    router.WithCustomUpdate(customUpdateFn),
+    router.WithCustomDelete(customDeleteFn),
+
+    // Custom batch handlers
+    router.WithCustomBatchCreate(customBatchCreateFn),
+    router.WithCustomBatchUpdate(customBatchUpdateFn),
+    router.WithCustomBatchDelete(customBatchDeleteFn),
+    router.WithBatchLimit(100),
+
+    // Validation and audit
+    router.WithValidator(validatorFn),
+    router.WithAudit(auditFn),
+
+    // File uploads (model must embed filestore.FileFields)
+    router.AsFileResource(),
+
+    // Multi-tenant isolation
+    router.WithTenantScope("OrgID"),
+    router.IsTenantTable(),
+
+    // Actions (POST /resource/{id}/{name})
+    router.WithAction("publish", publishFn, router.AuthConfig{Scopes: []string{"user"}}),
+
+    // Custom endpoints (any method, any return type)
+    router.WithEndpoint("GET", "status", endpointFn, router.AuthConfig{Scopes: []string{router.ScopePublic}}),
+
+    // SSE endpoints (always GET)
+    router.WithSSE("events", sseFn, router.AuthConfig{Scopes: []string{router.ScopePublic}}),
+
+    // Nesting callback
+    func(b *router.Builder) {
+        router.RegisterRoutes[Child](b, "/children", router.AllPublic())
+    },
+)
+
+// Root-level (outside RegisterRoutes)
+router.RegisterRootEndpoint(b, "GET", "/system/info", rootEndpointFn, router.AllPublic())
+router.RegisterRootSSE(b, "/events/system", rootSSEFn, router.AllPublic())
+```
+
+## Handler Signatures
+
+### Custom CRUD Handlers
+
+```go
+// GET /resource/{id}
+type CustomGetFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+) (*T, error)
+
+// GET /resource (list)
+type CustomGetAllFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+) ([]*T, int, map[string]float64, error)
+
+// POST /resource
+type CustomCreateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    item T,
+    file io.Reader,
+    fileMeta filestore.FileMetadata,
+) (*T, error)
+
+// PUT /resource/{id}
+type CustomUpdateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item T,
+) (*T, error)
+
+// DELETE /resource/{id}
+type CustomDeleteFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+) error
+```
+
+### Action Handler
+
+```go
+// POST /resource/{id}/{name}
+type ActionFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    payload []byte,
+) (*T, error)
+```
+
+### Endpoint Handlers (Anything Funcs)
+
+```go
+// Item-level: METHOD /resource/{id}/{name}
+// Returns any type + explicit status code
+type EndpointHandler[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    payload []byte,
+) (any, int, error)
+
+// Root-level: METHOD /any/path
+// No parent model, raw request access
+type RootEndpointHandler func(
+    ctx context.Context,
+    auth *metadata.AuthInfo,
+    r *http.Request,
+) (any, int, error)
+```
+
+Endpoint response rules:
+- `(result, statusCode, nil)` -> JSON + status code
+- `(result, 0, nil)` -> 200 OK + JSON (0 defaults to 200)
+- `(nil, _, nil)` -> 204 No Content
+- `(_, _, error)` -> error response
+
+### SSE Handlers
+
+```go
+// Item-level: GET /resource/{id}/{name}
+type SSEFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    events chan<- handler.SSEEvent,
+) error
+
+// Root-level: GET /any/path
+type RootSSEFunc func(
+    ctx context.Context,
+    auth *metadata.AuthInfo,
+    r *http.Request,
+    events chan<- handler.SSEEvent,
+) error
+
+// SSEEvent struct
+type SSEEvent struct {
+    Event string // Event type (omitted if empty)
+    Data  any    // JSON-encoded by framework
+    ID    string // Event ID (omitted if empty)
+}
+```
+
+### Batch Handlers
+
+```go
+type CustomBatchCreateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) ([]*T, error)
+
+type CustomBatchUpdateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) ([]*T, error)
+
+type CustomBatchDeleteFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) error
+```
+
+### Validator and Audit
+
+```go
+// Validator — return error to reject with 400
+router.WithValidator(func(vc metadata.ValidationContext[T]) error {
+    // vc.Operation: metadata.OpCreate, OpUpdate, OpDelete
+    // vc.New: incoming item (nil for delete)
+    // vc.Old: existing item (nil for create)
+    // vc.Ctx: request context
+    return nil
+})
+
+// Audit — return a model to insert in same transaction, nil to skip
+router.WithAudit(func(ac metadata.AuditContext[T]) any {
+    // ac.Operation, ac.New, ac.Old, ac.Ctx (same as validator)
+    return &AuditLog{...}
+})
+```
+
+## Query Parameters
+
+| Parameter | Example | Description |
+|-----------|---------|-------------|
+| Filter | `?filter[Status]=active` | Exact match |
+| Filter ops | `?filter[Age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
+| Sort | `?sort=Name,-CreatedAt` | `-` prefix for descending |
+| Limit | `?limit=10` | Max results |
+| Offset | `?offset=20` | Skip results |
+| Count | `?count=true` | X-Total-Count header |
+| Include | `?include=Posts.Comments` | Load relations (dot notation for nested) |
+| Sum | `?sum=Price,Stock` | X-Sum-Price, X-Sum-Stock headers |
+
+**Nested includes:** child direction needs `WithRelationName` at each level. Parent direction (e.g., `?include=Author`) auto-derived from `rel:belongs-to` tags. Auth is cumulative AND, ownership is cumulative OR.
+
+## Error Handling
+
+```go
+import apperrors "github.com/sjgoldie/go-restgen/errors"
+
+return nil, apperrors.ErrNotFound                          // 404
+return nil, apperrors.ErrDuplicate                         // 400
+return nil, apperrors.ErrInvalidReference                  // 400
+return nil, apperrors.ErrUnavailable                       // 503
+return nil, apperrors.NewValidationError("invalid input")  // 400 with message
+```
+
+## File Resources
+
+Model embeds `filestore.FileFields` (StorageKey, Filename, ContentType, Size):
+
+```go
+type Document struct {
+    bun.BaseModel    `bun:"table:documents"`
+    ID               int    `bun:"id,pk,autoincrement" json:"id"`
+    filestore.FileFields
+    AltText          string `bun:"alt_text" json:"alt_text,omitempty"`
+}
+```
+
+Upload: `POST /documents` with multipart form (`file` field + optional `metadata` JSON field).
+Download: `GET /documents/{id}/download` (proxy streams, signed URL redirects 307).
+
+## Multi-Tenant Isolation
+
+```go
+// Tenant entity: PK = tenant ID
+router.RegisterRoutes[Organization](b, "/organizations",
+    router.IsTenantTable(),
+    router.IsAuthenticated(),
+)
+
+// Tenant-scoped: auto-filters + auto-sets tenant field
+router.RegisterRoutes[Project](b, "/projects",
+    router.WithTenantScope("OrgID"),
+    router.AllWithOwnershipUnless([]string{"OwnerID"}, "admin"),
+)
+```
+
+Auth middleware must set `TenantID` on `AuthInfo`.
+
+## Database Setup
+
+```go
+// SQLite (in-memory for dev/test)
+db, _ := datastore.NewSQLite(":memory:")
+
+// PostgreSQL
+db, _ := datastore.NewPostgres("postgres://user:pass@localhost:5432/dbname?sslmode=disable")
+
+// External connection (you own the *sql.DB)
+db := datastore.NewPostgresWithDB(sqlDB)
+
+// Always:
+datastore.Initialize(db)
+defer datastore.Cleanup()
+```
+
+## Auth Method Constants
+
+```go
+router.MethodGet, router.MethodList, router.MethodPost, router.MethodPut, router.MethodDelete
+router.MethodAll           // Expands to Get, List, Post, Put, Delete (excludes batch)
+router.MethodBatchCreate, router.MethodBatchUpdate, router.MethodBatchDelete
+router.MethodAllWithBatch  // All including batch
+router.ScopePublic         // No auth required
+router.ScopeAuthOnly       // Auth required, no scope check
+router.AuthInfoKey         // Typed context key for AuthInfo
+```

--- a/cmd/install-skill/main.go
+++ b/cmd/install-skill/main.go
@@ -1,0 +1,109 @@
+// Command install-skill installs go-restgen AI coding agent rules into the
+// current directory. Run this from your project root.
+//
+// Supported agents: claude (Claude Code), cursor (Cursor IDE).
+//
+// Usage:
+//
+//	cd /path/to/your/project
+//	go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest
+//	go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=cursor
+//	go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=all
+package main
+
+import (
+	"embed"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed skill/SKILL.md skill/patterns.md
+var claudeFiles embed.FS
+
+//go:embed cursor/go-restgen.mdc
+var cursorFiles embed.FS
+
+func main() {
+	agent := flag.String("agent", "claude", "target agent: claude, cursor, or all")
+	flag.Parse()
+
+	root, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var installed []string
+	switch *agent {
+	case "claude":
+		installed, err = installClaude(root)
+	case "cursor":
+		installed, err = installCursor(root)
+	case "all":
+		installed, err = installAll(root)
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown agent %q (use claude, cursor, or all)\n", *agent)
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, path := range installed {
+		fmt.Printf("  wrote %s\n", path)
+	}
+	fmt.Println("\ngo-restgen rules installed. Your AI agent will now auto-detect the framework in this project.")
+}
+
+func installClaude(root string) ([]string, error) {
+	destDir := filepath.Join(root, ".claude", "skills", "go-restgen")
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		return nil, fmt.Errorf("creating %s: %w", destDir, err)
+	}
+
+	var written []string
+	for _, name := range []string{"SKILL.md", "patterns.md"} {
+		data, err := claudeFiles.ReadFile("skill/" + name)
+		if err != nil {
+			return written, fmt.Errorf("reading embedded %s: %w", name, err)
+		}
+		dest := filepath.Join(destDir, name)
+		if err := os.WriteFile(dest, data, 0o600); err != nil {
+			return written, fmt.Errorf("writing %s: %w", dest, err)
+		}
+		written = append(written, dest)
+	}
+	return written, nil
+}
+
+func installCursor(root string) ([]string, error) {
+	destDir := filepath.Join(root, ".cursor", "rules")
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		return nil, fmt.Errorf("creating %s: %w", destDir, err)
+	}
+
+	data, err := cursorFiles.ReadFile("cursor/go-restgen.mdc")
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded go-restgen.mdc: %w", err)
+	}
+	dest := filepath.Join(destDir, "go-restgen.mdc")
+	if err := os.WriteFile(dest, data, 0o600); err != nil {
+		return nil, fmt.Errorf("writing %s: %w", dest, err)
+	}
+	return []string{dest}, nil
+}
+
+func installAll(root string) ([]string, error) {
+	claude, err := installClaude(root)
+	if err != nil {
+		return claude, err
+	}
+	cursor, err := installCursor(root)
+	if err != nil {
+		return append(claude, cursor...), err
+	}
+	return append(claude, cursor...), nil
+}

--- a/cmd/install-skill/skill/SKILL.md
+++ b/cmd/install-skill/skill/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: go-restgen
+description: go-restgen REST API framework patterns — model definitions, route registration, auth, nesting, custom endpoints, SSE, file uploads, tenancy, and query configuration.
+---
+
+# go-restgen Framework Guide
+
+You are working with go-restgen, a type-safe REST API framework for Go using generics. It auto-generates CRUD endpoints from model definitions. Built on Chi (router) and Bun (ORM).
+
+Read `patterns.md` in this skill directory for complete handler signatures, all route options, and detailed examples.
+
+## Core Pattern
+
+```go
+// 1. Define model with Bun tags
+type Product struct {
+    bun.BaseModel `bun:"table:products"`
+    ID            int       `bun:"id,pk,autoincrement" json:"id"`
+    Name          string    `bun:"name,notnull" json:"name"`
+    Price         float64   `bun:"price,notnull" json:"price"`
+    CreatedAt     time.Time `bun:"created_at,notnull,skipupdate" json:"created_at,omitempty"`
+    UpdatedAt     time.Time `bun:"updated_at,notnull" json:"updated_at,omitempty"`
+}
+
+// 2. Timestamp hook
+func (p *Product) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+    now := time.Now()
+    switch query.(type) {
+    case *bun.InsertQuery:
+        p.CreatedAt = now
+        p.UpdatedAt = now
+    case *bun.UpdateQuery:
+        p.UpdatedAt = now
+    }
+    return nil
+}
+
+// 3. Setup: datastore, chi router, builder
+db, _ := datastore.NewSQLite(":memory:")
+datastore.Initialize(db)
+defer datastore.Cleanup()
+db.GetDB().NewCreateTable().Model((*Product)(nil)).IfNotExists().Exec(context.Background())
+
+r := chi.NewRouter()
+b := router.NewBuilder(r)
+
+// 4. Register routes with options
+router.RegisterRoutes[Product](b, "/products",
+    router.AllPublic(),
+    router.WithFilters("Name", "Price"),
+    router.WithSorts("Name", "Price", "CreatedAt"),
+    router.WithPagination(20, 100),
+)
+```
+
+This generates: `GET/POST /products`, `GET/PUT/DELETE /products/{id}`.
+
+## Auth Patterns
+
+```go
+router.AllPublic()                                          // No auth
+router.AllScoped("admin")                                   // Require scope
+router.IsAuthenticated()                                    // Any valid auth
+router.AllWithOwnershipUnless([]string{"UserID"}, "admin")  // Owner-only + admin bypass
+
+// Per-method
+router.AuthConfig{
+    Methods: []string{router.MethodGet, router.MethodList},
+    Scopes:  []string{router.ScopePublic},
+},
+router.AuthConfig{
+    Methods: []string{router.MethodPost, router.MethodPut, router.MethodDelete},
+    Scopes:  []string{"admin"},
+},
+```
+
+Auth middleware sets `AuthInfo` on context:
+```go
+authInfo := &router.AuthInfo{UserID: userID, TenantID: tenantID, Scopes: scopes}
+ctx := context.WithValue(r.Context(), router.AuthInfoKey, authInfo)
+```
+
+## Nesting
+
+```go
+router.RegisterRoutes[Blog](b, "/blogs", router.AllPublic(), func(b *router.Builder) {
+    router.RegisterRoutes[Post](b, "/posts",
+        router.AllPublic(),
+        router.WithRelationName("Posts"),  // enables ?include=Posts on parent
+    )
+})
+```
+
+Child model needs FK + belongs-to tag:
+```go
+BlogID int `bun:"blog_id,notnull,skipupdate" json:"blog_id"`
+Blog  *Blog `bun:"rel:belongs-to,join:blog_id=id" json:"-"`
+```
+
+## Custom Endpoints (Anything Funcs)
+
+```go
+// Item-level: METHOD /resource/{id}/{name}
+router.WithEndpoint("GET", "status", handlerFn, router.AuthConfig{...})
+
+// Root-level: METHOD /any/path (no parent model)
+router.RegisterRootEndpoint(b, "GET", "/system/info", handlerFn, router.AllPublic())
+
+// Item-level SSE: GET /resource/{id}/{name}
+router.WithSSE("events", sseFn, router.AuthConfig{...})
+
+// Root-level SSE: GET /any/path
+router.RegisterRootSSE(b, "/events/system", sseFn, router.AllPublic())
+```
+
+## Key Conventions
+
+- **PK field**: named `ID` by default, override with `router.WithAlternatePK("MyPK")`
+- **FK fields**: include `skipupdate` to prevent modification
+- **Ownership fields**: string type matching `AuthInfo.UserID`
+- **Timestamps**: use `BeforeAppendModel` hook
+- **UUID PKs**: use `uuid.UUID` type with `bun:"id,pk,type:uuid"`
+- **Routes blocked by default**: must explicitly configure auth
+- **Path IDs take precedence**: JSON body IDs and FKs are ignored

--- a/cmd/install-skill/skill/patterns.md
+++ b/cmd/install-skill/skill/patterns.md
@@ -1,0 +1,359 @@
+# go-restgen Detailed Patterns
+
+## All Route Registration Options
+
+```go
+router.RegisterRoutes[Model](builder, "/path",
+    // Access control (pick one)
+    router.AllPublic(),
+    router.AllScoped("admin"),
+    router.IsAuthenticated(),
+    router.PublicList(),
+    router.PublicGet(),
+    router.PublicReadOnly(),
+    router.AllPublicWithBatch(),
+    router.AllScopedWithBatch("admin"),
+
+    // Per-method auth
+    router.AuthConfig{
+        Methods: []string{router.MethodGet, router.MethodList},
+        Scopes:  []string{router.ScopePublic},
+    },
+
+    // Ownership
+    router.AllWithOwnershipUnless([]string{"UserID"}, "admin"),
+
+    // Single resource (belongs-to or /me)
+    router.AsSingleRoute("AuthorID"),
+    router.AsSingleRouteWithPut(""),
+
+    // Query options (individual)
+    router.WithFilters("Status", "Name"),
+    router.WithSorts("Name", "CreatedAt"),
+    router.WithPagination(20, 100),
+    router.WithDefaultSort("-CreatedAt"),
+    router.WithSums("Price", "Stock"),
+
+    // Query options (combined)
+    router.WithQuery(router.QueryConfig{
+        FilterableFields: []string{"Status", "Name"},
+        SortableFields:   []string{"Name", "CreatedAt"},
+        SummableFields:   []string{"Price"},
+        DefaultSort:      "-CreatedAt",
+        DefaultLimit:     20,
+        MaxLimit:         100,
+    }),
+
+    // Relations
+    router.WithRelationName("Posts"),
+    router.WithJoinOn("NMI", "NMI"),
+    router.WithAlternatePK("MyPK"),
+
+    // Custom CRUD handlers
+    router.WithCustomGet(customGetFn),
+    router.WithCustomGetAll(customGetAllFn),
+    router.WithCustomCreate(customCreateFn),
+    router.WithCustomUpdate(customUpdateFn),
+    router.WithCustomDelete(customDeleteFn),
+
+    // Custom batch handlers
+    router.WithCustomBatchCreate(customBatchCreateFn),
+    router.WithCustomBatchUpdate(customBatchUpdateFn),
+    router.WithCustomBatchDelete(customBatchDeleteFn),
+    router.WithBatchLimit(100),
+
+    // Validation and audit
+    router.WithValidator(validatorFn),
+    router.WithAudit(auditFn),
+
+    // File uploads (model must embed filestore.FileFields)
+    router.AsFileResource(),
+
+    // Multi-tenant isolation
+    router.WithTenantScope("OrgID"),
+    router.IsTenantTable(),
+
+    // Actions (POST /resource/{id}/{name})
+    router.WithAction("publish", publishFn, router.AuthConfig{Scopes: []string{"user"}}),
+
+    // Custom endpoints (any method, any return type)
+    router.WithEndpoint("GET", "status", endpointFn, router.AuthConfig{Scopes: []string{router.ScopePublic}}),
+
+    // SSE endpoints (always GET)
+    router.WithSSE("events", sseFn, router.AuthConfig{Scopes: []string{router.ScopePublic}}),
+
+    // Nesting callback
+    func(b *router.Builder) {
+        router.RegisterRoutes[Child](b, "/children", router.AllPublic())
+    },
+)
+
+// Root-level (outside RegisterRoutes)
+router.RegisterRootEndpoint(b, "GET", "/system/info", rootEndpointFn, router.AllPublic())
+router.RegisterRootSSE(b, "/events/system", rootSSEFn, router.AllPublic())
+```
+
+## Handler Signatures
+
+### Custom CRUD Handlers
+
+```go
+// GET /resource/{id}
+type CustomGetFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+) (*T, error)
+
+// GET /resource (list)
+type CustomGetAllFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+) ([]*T, int, map[string]float64, error)
+
+// POST /resource
+type CustomCreateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    item T,
+    file io.Reader,
+    fileMeta filestore.FileMetadata,
+) (*T, error)
+
+// PUT /resource/{id}
+type CustomUpdateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item T,
+) (*T, error)
+
+// DELETE /resource/{id}
+type CustomDeleteFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+) error
+```
+
+### Action Handler
+
+```go
+// POST /resource/{id}/{name}
+type ActionFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    payload []byte,
+) (*T, error)
+```
+
+### Endpoint Handlers (Anything Funcs)
+
+```go
+// Item-level: METHOD /resource/{id}/{name}
+// Returns any type + explicit status code
+type EndpointHandler[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    payload []byte,
+) (any, int, error)
+
+// Root-level: METHOD /any/path
+// No parent model, raw request access
+type RootEndpointHandler func(
+    ctx context.Context,
+    auth *metadata.AuthInfo,
+    r *http.Request,
+) (any, int, error)
+```
+
+Endpoint response rules:
+- `(result, statusCode, nil)` -> JSON + status code
+- `(result, 0, nil)` -> 200 OK + JSON (0 defaults to 200)
+- `(nil, _, nil)` -> 204 No Content
+- `(_, _, error)` -> error response
+
+### SSE Handlers
+
+```go
+// Item-level: GET /resource/{id}/{name}
+type SSEFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    id string,
+    item *T,
+    events chan<- handler.SSEEvent,
+) error
+
+// Root-level: GET /any/path
+type RootSSEFunc func(
+    ctx context.Context,
+    auth *metadata.AuthInfo,
+    r *http.Request,
+    events chan<- handler.SSEEvent,
+) error
+
+// SSEEvent struct
+type SSEEvent struct {
+    Event string // Event type (omitted if empty)
+    Data  any    // JSON-encoded by framework
+    ID    string // Event ID (omitted if empty)
+}
+```
+
+### Batch Handlers
+
+```go
+type CustomBatchCreateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) ([]*T, error)
+
+type CustomBatchUpdateFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) ([]*T, error)
+
+type CustomBatchDeleteFunc[T any] func(
+    ctx context.Context,
+    svc *service.Common[T],
+    meta *metadata.TypeMetadata,
+    auth *metadata.AuthInfo,
+    items []T,
+) error
+```
+
+### Validator and Audit
+
+```go
+// Validator — return error to reject with 400
+router.WithValidator(func(vc metadata.ValidationContext[T]) error {
+    // vc.Operation: metadata.OpCreate, OpUpdate, OpDelete
+    // vc.New: incoming item (nil for delete)
+    // vc.Old: existing item (nil for create)
+    // vc.Ctx: request context
+    return nil
+})
+
+// Audit — return a model to insert in same transaction, nil to skip
+router.WithAudit(func(ac metadata.AuditContext[T]) any {
+    // ac.Operation, ac.New, ac.Old, ac.Ctx (same as validator)
+    return &AuditLog{...}
+})
+```
+
+## Query Parameters
+
+| Parameter | Example | Description |
+|-----------|---------|-------------|
+| Filter | `?filter[Status]=active` | Exact match |
+| Filter ops | `?filter[Age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
+| Sort | `?sort=Name,-CreatedAt` | `-` prefix for descending |
+| Limit | `?limit=10` | Max results |
+| Offset | `?offset=20` | Skip results |
+| Count | `?count=true` | X-Total-Count header |
+| Include | `?include=Posts.Comments` | Load relations (dot notation for nested) |
+| Sum | `?sum=Price,Stock` | X-Sum-Price, X-Sum-Stock headers |
+
+**Nested includes:** child direction needs `WithRelationName` at each level. Parent direction (e.g., `?include=Author`) auto-derived from `rel:belongs-to` tags. Auth is cumulative AND, ownership is cumulative OR.
+
+## Error Handling
+
+```go
+import apperrors "github.com/sjgoldie/go-restgen/errors"
+
+return nil, apperrors.ErrNotFound                          // 404
+return nil, apperrors.ErrDuplicate                         // 400
+return nil, apperrors.ErrInvalidReference                  // 400
+return nil, apperrors.ErrUnavailable                       // 503
+return nil, apperrors.NewValidationError("invalid input")  // 400 with message
+```
+
+## File Resources
+
+Model embeds `filestore.FileFields` (StorageKey, Filename, ContentType, Size):
+
+```go
+type Document struct {
+    bun.BaseModel    `bun:"table:documents"`
+    ID               int    `bun:"id,pk,autoincrement" json:"id"`
+    filestore.FileFields
+    AltText          string `bun:"alt_text" json:"alt_text,omitempty"`
+}
+```
+
+Upload: `POST /documents` with multipart form (`file` field + optional `metadata` JSON field).
+Download: `GET /documents/{id}/download` (proxy streams, signed URL redirects 307).
+
+## Multi-Tenant Isolation
+
+```go
+// Tenant entity: PK = tenant ID
+router.RegisterRoutes[Organization](b, "/organizations",
+    router.IsTenantTable(),
+    router.IsAuthenticated(),
+)
+
+// Tenant-scoped: auto-filters + auto-sets tenant field
+router.RegisterRoutes[Project](b, "/projects",
+    router.WithTenantScope("OrgID"),
+    router.AllWithOwnershipUnless([]string{"OwnerID"}, "admin"),
+)
+```
+
+Auth middleware must set `TenantID` on `AuthInfo`.
+
+## Database Setup
+
+```go
+// SQLite (in-memory for dev/test)
+db, _ := datastore.NewSQLite(":memory:")
+
+// PostgreSQL
+db, _ := datastore.NewPostgres("postgres://user:pass@localhost:5432/dbname?sslmode=disable")
+
+// External connection (you own the *sql.DB)
+db := datastore.NewPostgresWithDB(sqlDB)
+
+// Always:
+datastore.Initialize(db)
+defer datastore.Cleanup()
+```
+
+## Auth Method Constants
+
+```go
+router.MethodGet, router.MethodList, router.MethodPost, router.MethodPut, router.MethodDelete
+router.MethodAll           // Expands to Get, List, Post, Put, Delete (excludes batch)
+router.MethodBatchCreate, router.MethodBatchUpdate, router.MethodBatchDelete
+router.MethodAllWithBatch  // All including batch
+router.ScopePublic         // No auth required
+router.ScopeAuthOnly       // Auth required, no scope check
+router.AuthInfoKey         // Typed context key for AuthInfo
+```


### PR DESCRIPTION
## Summary
- Adds `cmd/install-skill` — a `go run` tool that installs go-restgen framework rules into a project's agent-specific directory
- Supports Claude Code (`.claude/skills/go-restgen/`) and Cursor (`.cursor/rules/go-restgen.mdc`) via `--agent` flag
- Updates README "Using with AI Coding Agents" section with auto-install instructions, manual copy guidance for other agents, and generic prompting fallback

## Usage
```bash
# Claude Code (default)
cd /path/to/your/project
go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest

# Cursor
go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=cursor

# Both
go run github.com/sjgoldie/go-restgen/cmd/install-skill@latest --agent=all
```

## Test plan
- [x] `go vet ./...` passes
- [x] Unit tests pass (8/8 packages)
- [x] Bruno integration tests pass (15/15 suites)
- [x] All 13 pre-commit hooks pass
- [x] Manual test: installed skill into external project, verified Claude Code detects it via `/skills`

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)