### PR TITLE
fix: Sanitize filenames to prevent Content-Disposition header injection

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -446,7 +446,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 				defer func() { _ = formFile.Close() }()
 				file = formFile
 				fileMeta = filestore.FileMetadata{
-					Filename:    header.Filename,
+					Filename:    sanitizeFilename(header.Filename),
 					ContentType: header.Header.Get("Content-Type"),
 					Size:        header.Size,
 				}
@@ -626,7 +626,7 @@ func Download[T any]() http.HandlerFunc {
 			w.Header().Set("Content-Length", strconv.FormatInt(result.Size, 10))
 		}
 		if result.Filename != "" {
-			w.Header().Set("Content-Disposition", "attachment; filename=\""+result.Filename+"\"")
+			w.Header().Set("Content-Disposition", contentDisposition(result.Filename))
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2387,7 +2387,7 @@ func TestDownload_WithContentLength(t *testing.T) {
 
 	// Check Content-Disposition header
 	contentDisposition := w.Header().Get("Content-Disposition")
-	if contentDisposition != `attachment; filename="test.txt"` {
+	if contentDisposition != `attachment; filename=test.txt` {
 		t.Errorf("Expected Content-Disposition header, got '%s'", contentDisposition)
 	}
 }

--- a/handler/sanitize.go
+++ b/handler/sanitize.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"mime"
+	"path/filepath"
+	"strings"
+)
+
+// sanitizeFilename cleans an untrusted filename for safe use in storage backends
+// and HTTP headers. It strips path components (preventing path traversal),
+// removes control characters, and trims whitespace.
+// Non-ASCII characters (UTF-8) are preserved.
+func sanitizeFilename(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = filepath.Base(name)
+	if name == "." || name == ".." {
+		return ""
+	}
+
+	name = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, name)
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	return name
+}
+
+// contentDisposition builds a safe Content-Disposition header value using
+// mime.FormatMediaType, which handles quoting for ASCII filenames and
+// RFC 2231 encoding for non-ASCII filenames.
+func contentDisposition(filename string) string {
+	return mime.FormatMediaType("attachment", map[string]string{"filename": filename})
+}

--- a/handler/sanitize_internal_test.go
+++ b/handler/sanitize_internal_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"testing"
+)
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"normal filename", "report.pdf", "report.pdf"},
+		{"path traversal unix", "../../etc/passwd", "passwd"},
+		{"path traversal windows", `..\..\windows\system32\config`, "config"},
+		{"directory prefix", "/var/uploads/file.txt", "file.txt"},
+		{"null byte", "file\x00name.txt", "filename.txt"},
+		{"newline", "file\nname.txt", "filename.txt"},
+		{"carriage return", "file\rname.txt", "filename.txt"},
+		{"tab", "file\tname.txt", "filename.txt"},
+		{"DEL character", "file\x7fname.txt", "filename.txt"},
+		{"mixed control chars", "a\x01b\x02c\x03.txt", "abc.txt"},
+		{"double quotes preserved", `evil".html`, `evil".html`},
+		{"non-ASCII UTF-8", "café report.pdf", "café report.pdf"},
+		{"CJK characters", "日本語.pdf", "日本語.pdf"},
+		{"emoji", "📊 data.xlsx", "📊 data.xlsx"},
+		{"empty string", "", ""},
+		{"dot only", ".", ""},
+		{"double dot", "..", ""},
+		{"whitespace only", "   ", ""},
+		{"leading trailing spaces", "  file.txt  ", "file.txt"},
+		{"hidden file", ".hidden", ".hidden"},
+		{"mixed attack", "../../../\x00evil\r\nfile.txt", "evilfile.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFilename(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContentDisposition(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{"simple filename", "test.txt", `attachment; filename=test.txt`},
+		{"filename with spaces", "my file.txt", `attachment; filename="my file.txt"`},
+		{"filename with quotes", `evil".html`, `attachment; filename="evil\".html"`},
+		{"non-ASCII uses RFC 2231", "café.pdf", "attachment; filename*=utf-8''caf%C3%A9.pdf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contentDisposition(tt.filename)
+			if got != tt.expected {
+				t.Errorf("contentDisposition(%q) = %q, want %q", tt.filename, got, tt.expected)
+			}
+		})
+	}
+}

--- a/handler/sanitize_test.go
+++ b/handler/sanitize_test.go
@@ -1,0 +1,155 @@
+//nolint:staticcheck,errcheck,gosec // Test code - string context keys and unchecked test cleanup are acceptable
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sjgoldie/go-restgen/filestore"
+	"github.com/sjgoldie/go-restgen/handler"
+	"github.com/sjgoldie/go-restgen/metadata"
+)
+
+func TestDownload_ContentDisposition_SafeEncoding(t *testing.T) {
+	tests := []struct {
+		name           string
+		filename       string
+		expectedHeader string
+	}{
+		{
+			"normal filename",
+			"test.txt",
+			`attachment; filename=test.txt`,
+		},
+		{
+			"filename with spaces gets quoted",
+			"my file.txt",
+			`attachment; filename="my file.txt"`,
+		},
+		{
+			"filename with quotes",
+			`evil".html`,
+			`attachment; filename="evil\".html"`,
+		},
+		{
+			"non-ASCII filename uses RFC 2231",
+			"café.pdf",
+			"attachment; filename*=utf-8''caf%C3%A9.pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := testDB.GetDB().NewCreateTable().Model((*TestFileModel)(nil)).IfNotExists().Exec(context.Background())
+			if err != nil {
+				t.Fatal("Failed to create table:", err)
+			}
+			defer testDB.GetDB().NewDropTable().Model((*TestFileModel)(nil)).IfExists().Exec(context.Background())
+
+			testFileStorage.files["test-key"] = "content"
+			defer delete(testFileStorage.files, "test-key")
+
+			file := &TestFileModel{
+				Name: "Test",
+				FileFields: filestore.FileFields{
+					StorageKey:  "test-key",
+					Filename:    tt.filename,
+					ContentType: "text/plain",
+					Size:        7,
+				},
+			}
+			_, err = testDB.GetDB().NewInsert().Model(file).Returning("*").Exec(context.Background())
+			if err != nil {
+				t.Fatal("Failed to create file:", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/files/1/download", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add(testFileMeta.URLParamUUID, "1")
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+			ctx = context.WithValue(ctx, metadata.MetadataKey, testFileMeta)
+			req = req.WithContext(ctx)
+
+			w := httptest.NewRecorder()
+			handler.Download[TestFileModel]()(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("Expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+			}
+
+			cd := w.Header().Get("Content-Disposition")
+			if cd != tt.expectedHeader {
+				t.Errorf("Content-Disposition = %q, want %q", cd, tt.expectedHeader)
+			}
+		})
+	}
+}
+
+func TestCreate_MultipartUpload_SanitizesFilename(t *testing.T) {
+	tests := []struct {
+		name             string
+		uploadFilename   string
+		expectedFilename string
+	}{
+		{"normal filename", "photo.png", "photo.png"},
+		{"path traversal", "../../etc/passwd", "passwd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := testDB.GetDB().NewCreateTable().Model((*TestFileModel)(nil)).IfNotExists().Exec(context.Background())
+			if err != nil {
+				t.Fatal("Failed to create table:", err)
+			}
+			defer testDB.GetDB().NewDropTable().Model((*TestFileModel)(nil)).IfExists().Exec(context.Background())
+
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+
+			fileWriter, err := writer.CreateFormFile("file", tt.uploadFilename)
+			if err != nil {
+				t.Fatal("Failed to create form file:", err)
+			}
+			fileWriter.Write([]byte("file content"))
+
+			metadataField, err := writer.CreateFormField("metadata")
+			if err != nil {
+				t.Fatal("Failed to create metadata field:", err)
+			}
+			metadataField.Write([]byte(`{"name":"Test"}`))
+
+			writer.Close()
+
+			req := httptest.NewRequest(http.MethodPost, "/files", &body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+
+			rctx := chi.NewRouteContext()
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+			ctx = context.WithValue(ctx, metadata.MetadataKey, testFileMeta)
+			req = req.WithContext(ctx)
+
+			w := httptest.NewRecorder()
+			handler.Create(handler.StandardCreate[TestFileModel])(w, req)
+
+			if w.Code != http.StatusCreated {
+				t.Fatalf("Expected status %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+			}
+
+			var result TestFileModel
+			if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if result.Filename != tt.expectedFilename {
+				t.Errorf("Filename = %q, want %q", result.Filename, tt.expectedFilename)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Sanitize uploaded filenames at the HTTP boundary using `filepath.Base` + control character stripping, preventing path traversal and header injection attacks
- Use `mime.FormatMediaType` for safe Content-Disposition header encoding on download, with proper RFC 2231 support for non-ASCII filenames
- Protects user-implemented storage backends (S3, local filesystem, etc.) from receiving unsanitized filenames

## Test plan
- [x] 21 unit tests for `sanitizeFilename` covering: normal filenames, path traversal (unix/windows), control chars, null bytes, DEL, quotes, non-ASCII (UTF-8, CJK, emoji), empty/dot/whitespace edge cases, mixed attacks
- [x] 4 unit tests for `contentDisposition` covering: simple, quoted, escaped quotes, RFC 2231 encoding
- [x] 4 integration tests for download Content-Disposition header encoding through the handler
- [x] 2 integration tests for upload filename sanitization through the handler
- [x] All existing unit tests pass
- [x] All benchmarks pass with no regressions
- [x] All 16 Bruno test suites pass (271 requests)

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)