### PR TITLE
fix: Implement http.Flusher on metrics responseWriter for SSE compatibility

### DIFF
--- a/examples/anything/go.mod
+++ b/examples/anything/go.mod
@@ -11,6 +11,8 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -25,7 +27,9 @@ require (
 	github.com/uptrace/bun/driver/sqliteshim v1.2.16 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
+	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect

--- a/examples/anything/go.sum
+++ b/examples/anything/go.sum
@@ -6,6 +6,11 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
 github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
@@ -48,8 +53,12 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=
 go.opentelemetry.io/otel v1.39.0/go.mod h1:kLlFTywNWrFyEdH0oj2xK0bFYZtHRYUdv1NklR/tgc8=
+go.opentelemetry.io/otel/metric v1.39.0 h1:d1UzonvEZriVfpNKEVmHXbdf909uGTOQjA0HF0Ls5Q0=
+go.opentelemetry.io/otel/metric v1.39.0/go.mod h1:jrZSWL33sD7bBxg1xjrqyDjnuzTUB0x1nBERXd7Ftcs=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/examples/anything/main.go
+++ b/examples/anything/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sjgoldie/go-restgen/datastore"
 	"github.com/sjgoldie/go-restgen/handler"
 	"github.com/sjgoldie/go-restgen/metadata"
+	"github.com/sjgoldie/go-restgen/metrics"
 	"github.com/sjgoldie/go-restgen/router"
 	"github.com/sjgoldie/go-restgen/service"
 )
@@ -200,6 +201,7 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	r.Use(metrics.Middleware())
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -128,6 +128,14 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+// Flush implements http.Flusher by delegating to the underlying ResponseWriter.
+// This is required so that middleware wrapping does not break SSE streaming.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // Unwrap returns the underlying ResponseWriter for middleware compatibility
 func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -151,6 +151,59 @@ func TestRecordCustomBeforeInitialize(t *testing.T) {
 	RecordCustom(context.Background(), "TestResource", "POST", 201, 42.5)
 }
 
+func TestResponseWriterImplementsFlusher(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var w http.ResponseWriter = &responseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("responseWriter wrapping a Flusher-capable writer should implement http.Flusher")
+	}
+
+	flusher.Flush()
+	if !rec.Flushed {
+		t.Error("Flush() should delegate to underlying ResponseWriter")
+	}
+}
+
+func TestResponseWriterFlushNoopWithoutFlusher(t *testing.T) {
+	var w http.ResponseWriter = &responseWriter{ResponseWriter: &minimalResponseWriter{}, statusCode: http.StatusOK}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("responseWriter should always implement http.Flusher")
+	}
+
+	// Should not panic when underlying writer doesn't support Flush
+	flusher.Flush()
+}
+
+func TestMiddlewarePreservesFlusher(t *testing.T) {
+	_ = Initialize(noop.NewMeterProvider())
+
+	var flusherAvailable bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, flusherAvailable = w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := Middleware()(handler)
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if !flusherAvailable {
+		t.Error("Middleware should preserve http.Flusher interface from underlying ResponseWriter")
+	}
+}
+
+// minimalResponseWriter implements only http.ResponseWriter (no Flusher)
+type minimalResponseWriter struct{}
+
+func (m *minimalResponseWriter) Header() http.Header         { return http.Header{} }
+func (m *minimalResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (m *minimalResponseWriter) WriteHeader(int)             {}
+
 func TestMiddlewareAutoInitializes(t *testing.T) {
 	// Reset state
 	requestDuration = nil


### PR DESCRIPTION
## Summary
- Implement `http.Flusher` on the metrics `responseWriter` wrapper by delegating to the underlying writer, fixing silent SSE streaming breakage when metrics middleware is enabled
- Add metrics middleware to the anything example to demonstrate combined metrics + SSE usage
- Add unit tests for Flusher delegation with and without Flusher-capable underlying writers

Fixes #76

## Test plan
- [x] Unit tests: `responseWriter` implements `http.Flusher` when underlying writer does
- [x] Unit tests: `Flush()` is a no-op when underlying writer doesn't support Flusher
- [x] Unit tests: Middleware preserves `http.Flusher` through the wrapped writer
- [x] All existing unit tests pass
- [x] All Bruno tests pass (15 suites, including anything suite with metrics + SSE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)