### PR TITLE
fix: Skip redundant SELECT in StandardDelete for non-file resources

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -4,17 +4,18 @@ go-restgen uses a combination of unit tests, integration tests, and end-to-end A
 
 ## Test Coverage Summary
 
-**Core Framework Coverage: 83.0%** (excluding examples)
+**Core Framework Coverage: 86.6%** (excluding examples)
 
-- **metadata**: 98.4% - Registry and ownership configuration tests
-- **router**: 90.2% - Route registration, middleware, and auth tests
+- **metadata**: 98.6% - Registry and ownership configuration tests
+- **metrics**: 92.7% - Metrics middleware tests
+- **router**: 92.3% - Route registration, middleware, and auth tests
 - **filestore**: 88.9% - File storage abstraction tests
+- **handler**: 88.2% - HTTP handler tests
 - **service**: 82.7% - Comprehensive CRUD operation tests
-- **handler**: 80.7% - HTTP handler tests
-- **datastore**: 78.6% - Database operations (uses SQLite in-memory)
+- **datastore**: 82.3% - Database operations (uses SQLite in-memory)
 - **errors**: 100.0% - Domain error types
 
-**Integration Test Coverage: ~197 end-to-end API tests** (Bruno) across 12 examples
+**Integration Test Coverage: 300 end-to-end API tests** (Bruno) across 16 examples
 
 All unit tests use SQLite in-memory databases - no external database required!
 
@@ -29,7 +30,7 @@ go test ./metadata ./datastore ./router ./service ./handler ./errors ./filestore
 go tool cover -func=/tmp/coverage.out
 ```
 
-This gives accurate framework coverage (75.3%) without including example applications.
+This gives accurate framework coverage (86.6%) without including example applications.
 
 ### All Tests (Including Examples)
 
@@ -170,12 +171,13 @@ For CI/CD pipelines:
 ## Coverage Goals
 
 - **errors**: 100% (achieved: 100.0%) ✅
-- **metadata**: > 95% (achieved: 98.4%) ✅
-- **router**: > 85% (achieved: 90.2%) ✅
+- **metadata**: > 95% (achieved: 98.6%) ✅
+- **metrics**: > 90% (achieved: 92.7%) ✅
+- **router**: > 85% (achieved: 92.3%) ✅
 - **filestore**: > 85% (achieved: 88.9%) ✅
+- **handler**: > 85% (achieved: 88.2%) ✅
 - **service**: > 80% (achieved: 82.7%) ✅
-- **handler**: > 75% (achieved: 80.7%) ✅
-- **datastore**: > 75% (achieved: 78.6%) ✅
+- **datastore**: > 80% (achieved: 82.3%) ✅
 
 Main coverage gaps are in error path testing that requires mocking (service unavailability, rare edge cases).
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -540,26 +540,25 @@ func Update[T any](updateFunc CustomUpdateFunc[T]) http.HandlerFunc {
 }
 
 // StandardDelete is the default Delete implementation.
-// If the item implements FileResource, also deletes the file from storage.
+// If the item implements FileResource, fetches it first to extract the storage key
+// for file cleanup after deletion. For non-file resources, delegates directly to
+// svc.Delete which handles existence checks and validation internally.
 func StandardDelete[T any](ctx context.Context, svc *service.Common[T], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, id string) error {
-	// Get the item first (validates existence and permissions)
-	item, err := svc.Get(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	// Extract storage key if this is a file resource (via type assertion)
 	var storageKey string
-	if fr, ok := any(item).(filestore.FileResource); ok {
-		storageKey = fr.GetStorageKey()
+	if meta.IsFileResource {
+		item, err := svc.Get(ctx, id)
+		if err != nil {
+			return err
+		}
+		if fr, ok := any(item).(filestore.FileResource); ok {
+			storageKey = fr.GetStorageKey()
+		}
 	}
 
-	// Delete the DB record
 	if err := svc.Delete(ctx, id); err != nil {
 		return err
 	}
 
-	// Delete from storage if there was a file (log but don't fail if this fails)
 	if storageKey != "" {
 		if err := svc.DeleteStoredFile(ctx, storageKey); err != nil {
 			slog.WarnContext(ctx, "failed to delete file from storage", "key", storageKey, "error", err)

--- a/handler/handler_bench_test.go
+++ b/handler/handler_bench_test.go
@@ -702,6 +702,47 @@ func BenchmarkOperations(b *testing.B) {
 }
 
 // ============================================================================
+// Benchmark: Delete Operations
+// ============================================================================
+
+// BenchmarkDelete tests delete performance for non-file resources
+func BenchmarkDelete(b *testing.B) {
+	if err := setupBenchDB(); err != nil {
+		b.Fatal(err)
+	}
+
+	h := handler.Delete[BenchBlog](handler.StandardDelete[BenchBlog])
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		cleanupBenchDB(b)
+		blogIDs, _, _, _ := seedBenchData(b, 1, 0, 0, 0)
+		blogID := blogIDs[0]
+
+		req := httptest.NewRequest("DELETE", fmt.Sprintf("/blogs/%d", blogID), nil)
+		req = addAuthToRequest(req, "user-0", []string{"user"})
+		req = addMetaToRequest(req, benchBlogMeta)
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("blogId", fmt.Sprintf("%d", blogID))
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		w := httptest.NewRecorder()
+		b.StartTimer()
+
+		h(w, req)
+
+		b.StopTimer()
+		if w.Code != http.StatusNoContent {
+			b.Fatalf("Expected 204, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+}
+
+// ============================================================================
 // Benchmark: Nested Collections
 // ============================================================================
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2900,3 +2900,81 @@ func TestHandler_GetAll_ErrorPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestStandardDelete_FileResource_CleansUpFile(t *testing.T) {
+	_, err := testDB.GetDB().NewCreateTable().Model((*TestFileModel)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create table:", err)
+	}
+	defer testDB.GetDB().NewDropTable().Model((*TestFileModel)(nil)).IfExists().Exec(context.Background())
+
+	testFileStorage.files["delete-test-key"] = "file content"
+	defer delete(testFileStorage.files, "delete-test-key")
+
+	file := &TestFileModel{
+		Name: "deleteme.txt",
+	}
+	file.SetStorageKey("delete-test-key")
+	file.SetFilename("deleteme.txt")
+	file.SetContentType("text/plain")
+	file.SetSize(12)
+
+	_, err = testDB.GetDB().NewInsert().Model(file).Returning("*").Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert file model:", err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(testFileMeta))
+	r.Delete("/files/{test_file_uuid}", handler.Delete[TestFileModel](handler.StandardDelete[TestFileModel]))
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/files/%d", file.ID), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Expected %d, got %d: %s", http.StatusNoContent, w.Code, w.Body.String())
+	}
+
+	if _, exists := testFileStorage.files["delete-test-key"]; exists {
+		t.Error("Expected file to be deleted from storage")
+	}
+
+	count, err := testDB.GetDB().NewSelect().Model((*TestFileModel)(nil)).Where("id = ?", file.ID).Count(context.Background())
+	if err != nil {
+		t.Fatal("Failed to check existence:", err)
+	}
+	if count != 0 {
+		t.Error("Expected DB record to be deleted")
+	}
+}
+
+func TestStandardDelete_NonFileResource_Succeeds(t *testing.T) {
+	cleanTable(t)
+
+	user := &TestUser{Name: "Delete Me", Email: "deleteme@example.com"}
+	_, err := testDB.GetDB().NewInsert().Model(user).Returning("*").Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert user:", err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Delete("/users/{id}", handler.Delete[TestUser](handler.StandardDelete[TestUser]))
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/users/%d", user.ID), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Expected %d, got %d: %s", http.StatusNoContent, w.Code, w.Body.String())
+	}
+
+	count, err := testDB.GetDB().NewSelect().Model((*TestUser)(nil)).Where("id = ?", user.ID).Count(context.Background())
+	if err != nil {
+		t.Fatal("Failed to check existence:", err)
+	}
+	if count != 0 {
+		t.Error("Expected user to be deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- `StandardDelete` no longer pre-fetches the item for non-file resources, eliminating one redundant SELECT per delete
- File resources still pre-fetch to extract the storage key for file cleanup
- Updates TESTING.md with current coverage numbers (86.6% overall, up from 83.0%)

## Test plan
- [x] New unit test: `TestStandardDelete_FileResource_CleansUpFile` — verifies file storage cleanup still works
- [x] New unit test: `TestStandardDelete_NonFileResource_Succeeds` — verifies non-file delete works correctly
- [x] New benchmark: `BenchmarkDelete` for delete operations
- [x] All existing unit tests pass (116 handler tests)
- [x] All 300 Bruno integration tests pass across 16 example applications
- [x] All 13 pre-commit hooks pass

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)