### PR TITLE
feat: structured JSON error responses (#80)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -534,18 +534,22 @@ Built-in support on GetAll endpoints:
 
 ## Error Handling
 
+All errors are returned as structured JSON: `{"error": "not_found", "message": "Not Found"}`
+
 ```go
 import apperrors "github.com/sjgoldie/go-restgen/errors"
 
 // In custom handlers, return domain errors:
-return nil, apperrors.ErrNotFound           // 404
-return nil, apperrors.ErrDuplicate          // 400
-return nil, apperrors.ErrInvalidReference   // 400
-return nil, apperrors.ErrUnavailable        // 503
+return nil, apperrors.ErrNotFound           // 404 {"error":"not_found"}
+return nil, apperrors.ErrDuplicate          // 400 {"error":"duplicate"}
+return nil, apperrors.ErrInvalidReference   // 400 {"error":"invalid_reference"}
+return nil, apperrors.ErrUnavailable        // 503 {"error":"service_unavailable"}
 
 // Custom validation error (message sent to client):
-return nil, apperrors.NewValidationError("title cannot be empty")  // 400
+return nil, apperrors.NewValidationError("title cannot be empty")  // 400 {"error":"validation_error","message":"title cannot be empty"}
 ```
+
+For custom middleware, use `handler.WriteError(w, statusCode, errorCode, message)`.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,37 @@ Requests exceeding the limit receive `413 Request Entity Too Large`.
 
 File upload endpoints using `multipart/form-data` are **not** affected by `WithMaxBodySize`. They use a separate 32 MB limit handled internally by the file upload handler.
 
+## Error Responses
+
+All error responses are returned as structured JSON with a consistent format:
+
+```json
+{"error": "not_found", "message": "Not Found"}
+```
+
+| HTTP Status | Error Code | Message |
+|-------------|-----------|---------|
+| 400 | `bad_request` | Bad Request |
+| 400 | `validation_error` | Custom message from validator |
+| 400 | `duplicate` | Bad Request |
+| 400 | `invalid_reference` | Bad Request |
+| 401 | `unauthorized` | Unauthorized |
+| 403 | `forbidden` | Forbidden |
+| 404 | `not_found` | Not Found |
+| 504 | `request_timeout` | Gateway Timeout |
+| 413 | `request_too_large` | Request Entity Too Large |
+| 500 | `internal_error` | Internal Server Error |
+| 501 | `not_implemented` | Not Implemented |
+| 503 | `service_unavailable` | Service Unavailable |
+
+The `error` field is a machine-readable code for programmatic error handling. The `message` field uses `http.StatusText()` — the standard HTTP status text for the response code. For validation errors, the `message` contains the custom message from your validator function. Error code constants are exported as `handler.ErrCodeBadRequest`, `handler.ErrCodeNotFound`, etc.
+
+`handler.WriteError` is exported for use in custom middleware and handlers:
+
+```go
+handler.WriteError(w, http.StatusBadRequest, "bad_request", "custom error message")
+```
+
 ## Multi-Registration
 
 go-restgen supports registering the same model type at multiple routes with different configurations. This is useful when:
@@ -2240,12 +2271,15 @@ r.Get("/users/search", searchUsersHandler)
 ### Direct Access to Services
 
 ```go
-import "github.com/sjgoldie/go-restgen/service"
+import (
+    "github.com/sjgoldie/go-restgen/handler"
+    "github.com/sjgoldie/go-restgen/service"
+)
 
 func myCustomHandler(w http.ResponseWriter, r *http.Request) {
     svc, err := service.New[User]()
     if err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
+        handler.WriteError(w, http.StatusInternalServerError, handler.ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
         return
     }
 

--- a/bruno/auth-example/10-comments-create-public-fail.bru
+++ b/bruno/auth-example/10-comments-create-public-fail.bru
@@ -19,10 +19,15 @@ body:json {
 
 assert {
   res.status: eq 401
+  res.body.error: eq unauthorized
+  res.body.message: eq Unauthorized
 }
 
 tests {
   test("Creating comment without auth should fail (auth required)", function() {
     expect(res.status).to.equal(401);
+    const body = res.getBody();
+    expect(body.error).to.equal("unauthorized");
+    expect(body.message).to.equal("Unauthorized");
   });
 }

--- a/bruno/batch-example/09-batch-update-not-found.bru
+++ b/bruno/batch-example/09-batch-update-not-found.bru
@@ -18,4 +18,6 @@ body:json {
 
 assert {
   res.status: eq 404
+  res.body.error: eq not_found
+  res.body.message: eq Not Found
 }

--- a/bruno/simple-example/07-get-deleted-user.bru
+++ b/bruno/simple-example/07-get-deleted-user.bru
@@ -12,4 +12,6 @@ get {
 
 assert {
   res.status: eq 404
+  res.body.error: eq not_found
+  res.body.message: eq Not Found
 }

--- a/bruno/simple-example/18-create-body-too-large.bru
+++ b/bruno/simple-example/18-create-body-too-large.bru
@@ -19,10 +19,15 @@ body:json {
 
 assert {
   res.status: eq 413
+  res.body.error: eq request_too_large
+  res.body.message: eq Request Entity Too Large
 }
 
 tests {
-  test("Oversized JSON body returns 413", function() {
+  test("Oversized JSON body returns 413 with JSON error", function() {
     expect(res.status).to.equal(413);
+    const body = res.getBody();
+    expect(body.error).to.equal("request_too_large");
+    expect(body.message).to.equal("Request Entity Too Large");
   });
 }

--- a/bruno/simple-example/19-update-body-too-large.bru
+++ b/bruno/simple-example/19-update-body-too-large.bru
@@ -19,10 +19,15 @@ body:json {
 
 assert {
   res.status: eq 413
+  res.body.error: eq request_too_large
+  res.body.message: eq Request Entity Too Large
 }
 
 tests {
-  test("Oversized JSON body on update returns 413", function() {
+  test("Oversized JSON body on update returns 413 with JSON error", function() {
     expect(res.status).to.equal(413);
+    const body = res.getBody();
+    expect(body.error).to.equal("request_too_large");
+    expect(body.message).to.equal("Request Entity Too Large");
   });
 }

--- a/bruno/validator-example/03-create-task-invalid-status.bru
+++ b/bruno/validator-example/03-create-task-invalid-status.bru
@@ -21,5 +21,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains pending
+  res.body.error: eq validation_error
+  res.body.message: contains pending
 }

--- a/bruno/validator-example/04-create-task-invalid-priority-low.bru
+++ b/bruno/validator-example/04-create-task-invalid-priority-low.bru
@@ -19,5 +19,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains priority
+  res.body.error: eq validation_error
+  res.body.message: contains priority
 }

--- a/bruno/validator-example/05-create-task-invalid-priority-high.bru
+++ b/bruno/validator-example/05-create-task-invalid-priority-high.bru
@@ -19,5 +19,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains priority
+  res.body.error: eq validation_error
+  res.body.message: contains priority
 }

--- a/bruno/validator-example/06-create-task-missing-title.bru
+++ b/bruno/validator-example/06-create-task-missing-title.bru
@@ -19,5 +19,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains title
+  res.body.error: eq validation_error
+  res.body.message: contains title
 }

--- a/bruno/validator-example/09-modify-completed-rejected.bru
+++ b/bruno/validator-example/09-modify-completed-rejected.bru
@@ -21,5 +21,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains completed
+  res.body.error: eq validation_error
+  res.body.message: contains completed
 }

--- a/bruno/validator-example/10-delete-completed-rejected.bru
+++ b/bruno/validator-example/10-delete-completed-rejected.bru
@@ -12,5 +12,6 @@ delete {
 
 assert {
   res.status: eq 400
-  res.body: contains completed
+  res.body.error: eq validation_error
+  res.body.message: contains completed
 }

--- a/bruno/validator-example/13-modify-cancelled-rejected.bru
+++ b/bruno/validator-example/13-modify-cancelled-rejected.bru
@@ -20,5 +20,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains cancelled
+  res.body.error: eq validation_error
+  res.body.message: contains cancelled
 }

--- a/bruno/validator-example/15-transition-pending-to-completed-rejected.bru
+++ b/bruno/validator-example/15-transition-pending-to-completed-rejected.bru
@@ -20,5 +20,6 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: contains invalid status transition
+  res.body.error: eq validation_error
+  res.body.message: contains invalid status transition
 }

--- a/handler/batch_test.go
+++ b/handler/batch_test.go
@@ -167,8 +167,8 @@ func TestBatchCreate_ExceedsLimit(t *testing.T) {
 		t.Errorf("Expected status 400, got %d: %s", w.Code, w.Body.String())
 	}
 
-	if !strings.Contains(w.Body.String(), "batch size exceeds limit") {
-		t.Errorf("Expected error message about batch limit, got %s", w.Body.String())
+	if !strings.Contains(w.Body.String(), "bad_request") {
+		t.Errorf("Expected error code bad_request, got %s", w.Body.String())
 	}
 }
 
@@ -533,25 +533,25 @@ func TestBatchCreate_ErrorHandling(t *testing.T) {
 			name:           "DuplicateError",
 			err:            apperrors.ErrDuplicate,
 			expectedStatus: http.StatusBadRequest,
-			expectedMsg:    "already exist",
+			expectedMsg:    "duplicate",
 		},
 		{
 			name:           "InvalidReferenceError",
 			err:            apperrors.ErrInvalidReference,
 			expectedStatus: http.StatusBadRequest,
-			expectedMsg:    "invalid reference",
+			expectedMsg:    "invalid_reference",
 		},
 		{
 			name:           "DeadlineExceeded",
 			err:            context.DeadlineExceeded,
 			expectedStatus: http.StatusGatewayTimeout,
-			expectedMsg:    "timeout",
+			expectedMsg:    "request_timeout",
 		},
 		{
 			name:           "Unavailable",
 			err:            apperrors.ErrUnavailable,
 			expectedStatus: http.StatusServiceUnavailable,
-			expectedMsg:    "temporarily unavailable",
+			expectedMsg:    "service_unavailable",
 		},
 	}
 

--- a/handler/error_response.go
+++ b/handler/error_response.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// Error code constants for structured JSON error responses.
+const (
+	ErrCodeBadRequest         = "bad_request"
+	ErrCodeUnauthorized       = "unauthorized"
+	ErrCodeForbidden          = "forbidden"
+	ErrCodeNotFound           = "not_found"
+	ErrCodeDuplicate          = "duplicate"
+	ErrCodeValidationError    = "validation_error"
+	ErrCodeInvalidReference   = "invalid_reference"
+	ErrCodeRequestTooLarge    = "request_too_large"
+	ErrCodeRequestTimeout     = "request_timeout"
+	ErrCodeInternalError      = "internal_error"
+	ErrCodeServiceUnavailable = "service_unavailable"
+	ErrCodeNotImplemented     = "not_implemented"
+)
+
+// ErrorResponse is the structured JSON error returned by all error paths.
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+// WriteError writes a structured JSON error response.
+// Exported for use by middleware and custom handlers.
+func WriteError(w http.ResponseWriter, code int, errCode, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(ErrorResponse{Error: errCode, Message: message}); err != nil {
+		slog.Error("failed to encode error response", "error", err)
+	}
+}

--- a/handler/error_response_test.go
+++ b/handler/error_response_test.go
@@ -1,0 +1,372 @@
+//nolint:staticcheck,errcheck,gosec // Test code - string context keys and unchecked test cleanup are acceptable
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+	apperrors "github.com/sjgoldie/go-restgen/errors"
+	"github.com/sjgoldie/go-restgen/handler"
+	"github.com/sjgoldie/go-restgen/metadata"
+	"github.com/sjgoldie/go-restgen/service"
+)
+
+type errorBody struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+func assertJSONError(t *testing.T, w *httptest.ResponseRecorder, expectedStatus int, expectedError, expectedMessage string) {
+	t.Helper()
+
+	if w.Code != expectedStatus {
+		t.Errorf("Expected status %d, got %d: %s", expectedStatus, w.Code, w.Body.String())
+		return
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Expected Content-Type 'application/json', got %q", ct)
+	}
+
+	var body errorBody
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Errorf("Expected JSON error body, got %q (unmarshal error: %v)", w.Body.String(), err)
+		return
+	}
+
+	if body.Error != expectedError {
+		t.Errorf("Expected error code %q, got %q", expectedError, body.Error)
+	}
+
+	if body.Message != expectedMessage {
+		t.Errorf("Expected message %q, got %q", expectedMessage, body.Message)
+	}
+}
+
+type failWriter struct {
+	header http.Header
+	code   int
+}
+
+func (f *failWriter) Header() http.Header       { return f.header }
+func (f *failWriter) WriteHeader(code int)      { f.code = code }
+func (f *failWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("write failed") }
+
+func TestErrorResponse_WriteError_EncodeFail(t *testing.T) {
+	w := &failWriter{header: http.Header{}}
+	handler.WriteError(w, http.StatusInternalServerError, handler.ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
+
+	if w.code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.code)
+	}
+	if w.header.Get("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %q", w.header.Get("Content-Type"))
+	}
+}
+
+func TestErrorResponse_GetNotFound(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users/{id}", handler.Get[TestUser](handler.StandardGet[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users/999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusNotFound, "not_found", http.StatusText(http.StatusNotFound))
+}
+
+func TestErrorResponse_CreateDuplicate(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	user := &TestUser{Name: "Existing", Email: "dup@example.com"}
+	_, err := db.GetDB().NewInsert().Model(user).Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert test user:", err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Post("/users", handler.Create[TestUser](handler.StandardCreate[TestUser]))
+
+	body, _ := json.Marshal(TestUser{Name: "Another", Email: "dup@example.com"})
+	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "duplicate", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_CreateInvalidJSON(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Post("/users", handler.Create[TestUser](handler.StandardCreate[TestUser]))
+
+	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_CreateBodyTooLarge(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(userMeta))
+		r.Use(withBodyLimit(100))
+		r.Post("/", handler.Create[TestUser](handler.StandardCreate[TestUser]))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(oversizedJSON(200)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusRequestEntityTooLarge, "request_too_large", http.StatusText(http.StatusRequestEntityTooLarge))
+}
+
+func TestErrorResponse_ValidationError(t *testing.T) {
+	cleanTable(t)
+
+	customCreate := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, items []TestUser) ([]*TestUser, error) {
+		return nil, apperrors.NewValidationError("name is required")
+	}
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(userMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](customCreate))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users/batch", strings.NewReader(`[{"email":"a@b.com"}]`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "validation_error", "name is required")
+}
+
+func TestErrorResponse_DeadlineExceeded(t *testing.T) {
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+		return nil, 0, nil, context.DeadlineExceeded
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](getAllFunc))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusGatewayTimeout, "request_timeout", http.StatusText(http.StatusGatewayTimeout))
+}
+
+func TestErrorResponse_ServiceUnavailable(t *testing.T) {
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+		return nil, 0, nil, apperrors.ErrUnavailable
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](getAllFunc))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusServiceUnavailable, "service_unavailable", http.StatusText(http.StatusServiceUnavailable))
+}
+
+func TestErrorResponse_InternalServerError(t *testing.T) {
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+		return nil, 0, nil, fmt.Errorf("unexpected database error")
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](getAllFunc))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusInternalServerError, "internal_error", http.StatusText(http.StatusInternalServerError))
+}
+
+func TestErrorResponse_InvalidReference(t *testing.T) {
+	cleanTable(t)
+
+	customCreate := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, items []TestUser) ([]*TestUser, error) {
+		return nil, apperrors.ErrInvalidReference
+	}
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(userMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](customCreate))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users/batch", strings.NewReader(`[{"name":"a","email":"a@b.com"}]`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "invalid_reference", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_BatchNotImplemented(t *testing.T) {
+	cleanTable(t)
+
+	fileMeta := &metadata.TypeMetadata{
+		TypeID:         userMeta.TypeID,
+		TypeName:       userMeta.TypeName,
+		TableName:      userMeta.TableName,
+		URLParamUUID:   userMeta.URLParamUUID,
+		ModelType:      userMeta.ModelType,
+		PKField:        "ID",
+		IsFileResource: true,
+	}
+
+	r := chi.NewRouter()
+	r.Route("/files", func(r chi.Router) {
+		r.Use(withMeta(fileMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](handler.StandardBatchCreate[TestUser]))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/files/batch", strings.NewReader(`[{"name":"f","email":"f@b.com"}]`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusNotImplemented, "not_implemented", http.StatusText(http.StatusNotImplemented))
+}
+
+func TestErrorResponse_MissingID(t *testing.T) {
+	cleanTable(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = ctxWithMeta(ctx, userMeta)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.Get[TestUser](handler.StandardGet[TestUser])(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_BatchEmptyArray(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(userMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](handler.StandardBatchCreate[TestUser]))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users/batch", strings.NewReader(`[]`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_BatchExceedsLimit(t *testing.T) {
+	cleanTable(t)
+
+	limitedMeta := &metadata.TypeMetadata{
+		TypeID:       userMeta.TypeID,
+		TypeName:     userMeta.TypeName,
+		TableName:    userMeta.TableName,
+		URLParamUUID: userMeta.URLParamUUID,
+		ModelType:    userMeta.ModelType,
+		BatchLimit:   2,
+	}
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(limitedMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](handler.StandardBatchCreate[TestUser]))
+	})
+
+	body := `[{"name":"A","email":"a@b.com"},{"name":"B","email":"b@b.com"},{"name":"C","email":"c@b.com"}]`
+	req := httptest.NewRequest(http.MethodPost, "/users/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_BatchInvalidJSON(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Route("/users", func(r chi.Router) {
+		r.Use(withMeta(userMeta))
+		r.Post("/batch", handler.BatchCreate[TestUser](handler.StandardBatchCreate[TestUser]))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/users/batch", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_UpdateInvalidID(t *testing.T) {
+	cleanTable(t)
+
+	body := []byte(`{"name":"Updated","email":"updated@example.com"}`)
+	req := httptest.NewRequest(http.MethodPut, "/users/invalid", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "invalid")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, metadata.MetadataKey, userMeta)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.Update[TestUser](handler.StandardUpdate[TestUser])(w, req)
+
+	assertJSONError(t, w, http.StatusBadRequest, "bad_request", http.StatusText(http.StatusBadRequest))
+}
+
+func TestErrorResponse_DeleteNotFound(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Delete("/users/{id}", handler.Delete[TestUser](handler.StandardDelete[TestUser]))
+
+	req := httptest.NewRequest(http.MethodDelete, "/users/999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertJSONError(t, w, http.StatusNotFound, "not_found", http.StatusText(http.StatusNotFound))
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -138,11 +138,11 @@ func handleBodyReadError(ctx context.Context, w http.ResponseWriter, err error, 
 	var maxBytesErr *http.MaxBytesError
 	if errors.As(err, &maxBytesErr) {
 		slog.DebugContext(ctx, msg, "error", err)
-		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		WriteError(w, http.StatusRequestEntityTooLarge, ErrCodeRequestTooLarge, http.StatusText(http.StatusRequestEntityTooLarge))
 		return
 	}
 	slog.DebugContext(ctx, msg, "error", err)
-	http.Error(w, "bad request", http.StatusBadRequest)
+	WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 }
 
 // handleMutationError handles errors from Create/Update operations
@@ -151,34 +151,34 @@ func handleMutationError(ctx context.Context, w http.ResponseWriter, err error, 
 		return // Client disconnected, no response needed
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		http.Error(w, "request timeout", http.StatusGatewayTimeout)
+		WriteError(w, http.StatusGatewayTimeout, ErrCodeRequestTimeout, http.StatusText(http.StatusGatewayTimeout))
 		return
 	}
-	// Check for validation error - return custom message to client
+	// Check for validation error - return developer-authored message to client
 	var validationErr *apperrors.ValidationError
 	if errors.As(err, &validationErr) {
-		http.Error(w, validationErr.Message, http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeValidationError, validationErr.Message)
 		return
 	}
 	if errors.Is(err, apperrors.ErrDuplicate) {
-		http.Error(w, "resource already exists", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeDuplicate, http.StatusText(http.StatusBadRequest))
 		return
 	}
 	if errors.Is(err, apperrors.ErrInvalidReference) {
-		http.Error(w, "invalid reference to related resource", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeInvalidReference, http.StatusText(http.StatusBadRequest))
 		return
 	}
 	if errors.Is(err, apperrors.ErrNotFound) {
-		http.Error(w, "not found", http.StatusNotFound)
+		WriteError(w, http.StatusNotFound, ErrCodeNotFound, http.StatusText(http.StatusNotFound))
 		return
 	}
 	if errors.Is(err, apperrors.ErrUnavailable) {
 		w.Header().Set("Retry-After", "5")
-		http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+		WriteError(w, http.StatusServiceUnavailable, ErrCodeServiceUnavailable, http.StatusText(http.StatusServiceUnavailable))
 		return
 	}
 	slog.ErrorContext(ctx, "failed to "+operation+" item", "error", err)
-	http.Error(w, "internal server error", http.StatusInternalServerError)
+	WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 }
 
 // requestContext holds common setup data for /{id} handlers.
@@ -202,14 +202,14 @@ func setupRequest[T any](w http.ResponseWriter, r *http.Request, getFunc CustomG
 	svc, err := service.New[T]()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to create service", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 		return zero, err
 	}
 
 	meta, err := metadata.FromContext(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "metadata not found in context", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 		return zero, err
 	}
 
@@ -218,7 +218,7 @@ func setupRequest[T any](w http.ResponseWriter, r *http.Request, getFunc CustomG
 		id = chi.URLParam(r, meta.URLParamUUID)
 		if id == "" {
 			slog.DebugContext(ctx, "missing id parameter", "paramUUID", meta.URLParamUUID)
-			http.Error(w, "bad request", http.StatusBadRequest)
+			WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 			return zero, fmt.Errorf("missing id parameter %s", meta.URLParamUUID)
 		}
 	}
@@ -265,7 +265,7 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 		svc, err := service.New[T]()
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to create service", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 			return
 		}
 
@@ -273,7 +273,7 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 		meta, err := metadata.FromContext(ctx)
 		if err != nil {
 			slog.ErrorContext(ctx, "metadata not found in context", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 			return
 		}
 
@@ -290,16 +290,16 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 				return // Client disconnected, no response needed
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
-				http.Error(w, "request timeout", http.StatusGatewayTimeout)
+				WriteError(w, http.StatusGatewayTimeout, ErrCodeRequestTimeout, http.StatusText(http.StatusGatewayTimeout))
 				return
 			}
 			if errors.Is(err, apperrors.ErrUnavailable) {
 				w.Header().Set("Retry-After", "5")
-				http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+				WriteError(w, http.StatusServiceUnavailable, ErrCodeServiceUnavailable, http.StatusText(http.StatusServiceUnavailable))
 				return
 			}
 			slog.ErrorContext(ctx, "failed to get all items", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 			return
 		}
 
@@ -409,7 +409,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 		svc, err := service.New[T]()
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to create service", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 			return
 		}
 
@@ -417,7 +417,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 		meta, err := metadata.FromContext(ctx)
 		if err != nil {
 			slog.ErrorContext(ctx, "metadata not found in context", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 			return
 		}
 
@@ -436,7 +436,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 			r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 			if err := r.ParseMultipartForm(maxUploadSize); err != nil { // #nosec G120 -- body already bounded by MaxBytesReader above
 				slog.DebugContext(ctx, "failed to parse multipart form", "error", err)
-				http.Error(w, "bad request: failed to parse multipart form", http.StatusBadRequest)
+				WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 				return
 			}
 
@@ -459,7 +459,7 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 			if metadataValues, ok := r.MultipartForm.Value["metadata"]; ok && len(metadataValues) > 0 {
 				if err := json.Unmarshal([]byte(metadataValues[0]), &item); err != nil {
 					slog.DebugContext(ctx, "failed to parse metadata JSON", "error", err)
-					http.Error(w, "bad request: invalid metadata JSON", http.StatusBadRequest)
+					WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 					return
 				}
 			}
@@ -520,7 +520,7 @@ func Update[T any](updateFunc CustomUpdateFunc[T]) http.HandlerFunc {
 		if rc.id != "" {
 			if err := common.SetFieldFromString(&item, rc.meta.PKField, rc.id); err != nil {
 				slog.ErrorContext(rc.ctx, "failed to set ID field", "error", err)
-				http.Error(w, "bad request", http.StatusBadRequest)
+				WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 				return
 			}
 		}
@@ -599,7 +599,7 @@ func Download[T any]() http.HandlerFunc {
 		result, err := rc.svc.Download(rc.ctx, rc.id)
 		if err != nil {
 			if errors.Is(err, filestore.ErrStorageKeyNotFound) {
-				http.Error(w, "not found", http.StatusNotFound)
+				WriteError(w, http.StatusNotFound, ErrCodeNotFound, http.StatusText(http.StatusNotFound))
 				return
 			}
 			handleMutationError(rc.ctx, w, err, "download")
@@ -687,25 +687,25 @@ func StandardBatchDelete[T any](ctx context.Context, svc *service.Common[T], met
 
 // setupBatch performs common validation and setup for batch operations.
 // Returns nil if successful, otherwise writes error response and returns error.
-func setupBatch[T any](w http.ResponseWriter, r *http.Request, opName string) *batchSetup[T] {
+func setupBatch[T any](w http.ResponseWriter, r *http.Request) *batchSetup[T] {
 	ctx := r.Context()
 
 	svc, err := service.New[T]()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to create service", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 		return nil
 	}
 
 	meta, err := metadata.FromContext(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "metadata not found in context", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 		return nil
 	}
 
 	if meta.IsFileResource {
-		http.Error(w, opName+" not supported for file resources", http.StatusNotImplemented)
+		WriteError(w, http.StatusNotImplemented, ErrCodeNotImplemented, http.StatusText(http.StatusNotImplemented))
 		return nil
 	}
 
@@ -714,21 +714,21 @@ func setupBatch[T any](w http.ResponseWriter, r *http.Request, opName string) *b
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			slog.DebugContext(ctx, "failed to decode batch request", "error", err)
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			WriteError(w, http.StatusRequestEntityTooLarge, ErrCodeRequestTooLarge, http.StatusText(http.StatusRequestEntityTooLarge))
 			return nil
 		}
 		slog.DebugContext(ctx, "failed to decode batch request", "error", err)
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 		return nil
 	}
 
 	if len(items) == 0 {
-		http.Error(w, "batch request must contain at least one item", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 		return nil
 	}
 
 	if meta.BatchLimit > 0 && len(items) > meta.BatchLimit {
-		http.Error(w, "batch size exceeds limit", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 		return nil
 	}
 
@@ -746,7 +746,7 @@ func setupBatch[T any](w http.ResponseWriter, r *http.Request, opName string) *b
 // BatchCreate handles POST requests to /resources/batch for batch creation.
 func BatchCreate[T any](createFunc CustomBatchCreateFunc[T]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setup := setupBatch[T](w, r, "batch create")
+		setup := setupBatch[T](w, r)
 		if setup == nil {
 			return
 		}
@@ -768,7 +768,7 @@ func BatchCreate[T any](createFunc CustomBatchCreateFunc[T]) http.HandlerFunc {
 // BatchUpdate handles PUT requests to /resources/batch for batch updates.
 func BatchUpdate[T any](updateFunc CustomBatchUpdateFunc[T]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setup := setupBatch[T](w, r, "batch update")
+		setup := setupBatch[T](w, r)
 		if setup == nil {
 			return
 		}
@@ -790,7 +790,7 @@ func BatchUpdate[T any](updateFunc CustomBatchUpdateFunc[T]) http.HandlerFunc {
 // BatchDelete handles DELETE requests to /resources/batch for batch deletion.
 func BatchDelete[T any](deleteFunc CustomBatchDeleteFunc[T]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		setup := setupBatch[T](w, r, "batch delete")
+		setup := setupBatch[T](w, r)
 		if setup == nil {
 			return
 		}
@@ -810,31 +810,31 @@ func handleBatchError(ctx context.Context, w http.ResponseWriter, err error, ope
 		return
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		http.Error(w, "request timeout", http.StatusGatewayTimeout)
+		WriteError(w, http.StatusGatewayTimeout, ErrCodeRequestTimeout, http.StatusText(http.StatusGatewayTimeout))
 		return
 	}
 	var validationErr *apperrors.ValidationError
 	if errors.As(err, &validationErr) {
-		http.Error(w, validationErr.Message, http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeValidationError, validationErr.Message)
 		return
 	}
 	if errors.Is(err, apperrors.ErrDuplicate) {
-		http.Error(w, "one or more resources already exist", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeDuplicate, http.StatusText(http.StatusBadRequest))
 		return
 	}
 	if errors.Is(err, apperrors.ErrInvalidReference) {
-		http.Error(w, "one or more items have invalid reference", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, ErrCodeInvalidReference, http.StatusText(http.StatusBadRequest))
 		return
 	}
 	if errors.Is(err, apperrors.ErrNotFound) {
-		http.Error(w, "one or more items not found", http.StatusNotFound)
+		WriteError(w, http.StatusNotFound, ErrCodeNotFound, http.StatusText(http.StatusNotFound))
 		return
 	}
 	if errors.Is(err, apperrors.ErrUnavailable) {
 		w.Header().Set("Retry-After", "5")
-		http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+		WriteError(w, http.StatusServiceUnavailable, ErrCodeServiceUnavailable, http.StatusText(http.StatusServiceUnavailable))
 		return
 	}
 	slog.ErrorContext(ctx, "failed to "+operation, "error", err)
-	http.Error(w, "internal server error", http.StatusInternalServerError)
+	WriteError(w, http.StatusInternalServerError, ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2856,7 +2856,7 @@ func TestHandler_GetAll_ErrorPaths(t *testing.T) {
 				return nil, 0, nil, context.DeadlineExceeded
 			},
 			expectedCode: http.StatusGatewayTimeout,
-			expectedBody: "request timeout",
+			expectedBody: "Gateway Timeout",
 		},
 		{
 			name: "service unavailable",
@@ -2864,7 +2864,7 @@ func TestHandler_GetAll_ErrorPaths(t *testing.T) {
 				return nil, 0, nil, apperrors.ErrUnavailable
 			},
 			expectedCode: http.StatusServiceUnavailable,
-			expectedBody: "service temporarily unavailable",
+			expectedBody: "Service Unavailable",
 		},
 		{
 			name: "generic error",
@@ -2872,7 +2872,7 @@ func TestHandler_GetAll_ErrorPaths(t *testing.T) {
 				return nil, 0, nil, fmt.Errorf("some internal error")
 			},
 			expectedCode: http.StatusInternalServerError,
-			expectedBody: "internal server error",
+			expectedBody: "Internal Server Error",
 		},
 	}
 

--- a/router/auth_middleware.go
+++ b/router/auth_middleware.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/sjgoldie/go-restgen/handler"
 	"github.com/sjgoldie/go-restgen/metadata"
 )
 
@@ -89,11 +90,11 @@ func wrapWithAuth(next http.Handler, config *AuthConfig) http.Handler {
 		switch result.Status {
 		case authUnauthorized:
 			slog.WarnContext(ctx, "auth rejected: unauthorized", "path", r.URL.Path, "method", r.Method)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			handler.WriteError(w, http.StatusUnauthorized, handler.ErrCodeUnauthorized, http.StatusText(http.StatusUnauthorized))
 			return
 		case authForbidden:
 			slog.WarnContext(ctx, "auth rejected: forbidden", "path", r.URL.Path, "method", r.Method)
-			http.Error(w, "forbidden", http.StatusForbidden)
+			handler.WriteError(w, http.StatusForbidden, handler.ErrCodeForbidden, http.StatusText(http.StatusForbidden))
 			return
 			// authOK falls through to continue processing
 		}
@@ -111,11 +112,11 @@ func wrapWithAuth(next http.Handler, config *AuthConfig) http.Handler {
 			switch parentResult.status {
 			case authUnauthorized:
 				slog.WarnContext(ctx, "auth rejected: parent ownership requires auth", "path", r.URL.Path, "method", r.Method, "type", meta.TypeName)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				handler.WriteError(w, http.StatusUnauthorized, handler.ErrCodeUnauthorized, http.StatusText(http.StatusUnauthorized))
 				return
 			case authForbidden:
 				slog.WarnContext(ctx, "auth rejected: parent ownership forbidden", "path", r.URL.Path, "method", r.Method, "type", meta.TypeName)
-				http.Error(w, "forbidden", http.StatusForbidden)
+				handler.WriteError(w, http.StatusForbidden, handler.ErrCodeForbidden, http.StatusText(http.StatusForbidden))
 				return
 			}
 			// Store parent ownership info in context for datastore to apply filtering
@@ -128,7 +129,7 @@ func wrapWithAuth(next http.Handler, config *AuthConfig) http.Handler {
 		if meta != nil && (meta.TenantField != "" || meta.IsTenantTable) {
 			if authInfo == nil || authInfo.TenantID == "" {
 				slog.WarnContext(ctx, "auth rejected: tenant-scoped route requires TenantID", "path", r.URL.Path, "method", r.Method, "type", meta.TypeName)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				handler.WriteError(w, http.StatusUnauthorized, handler.ErrCodeUnauthorized, http.StatusText(http.StatusUnauthorized))
 				return
 			}
 			ctx = applyTenantContext(ctx, authInfo.TenantID)
@@ -242,7 +243,7 @@ func buildParentAllowedIncludes(authInfo *AuthInfo, config *AuthConfig, includes
 func blockUnauthorized(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		slog.WarnContext(r.Context(), "auth rejected: no auth config", "path", r.URL.Path, "method", r.Method)
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		handler.WriteError(w, http.StatusUnauthorized, handler.ErrCodeUnauthorized, http.StatusText(http.StatusUnauthorized))
 	})
 }
 

--- a/router/builder.go
+++ b/router/builder.go
@@ -593,7 +593,7 @@ func createParentIDMiddleware(paramUUID string) func(http.Handler) http.Handler 
 			// Keep as string to support both int and UUID PKs
 			parentID := chi.URLParam(r, paramUUID)
 			if parentID == "" {
-				http.Error(w, "missing parent ID", http.StatusBadRequest)
+				handler.WriteError(w, http.StatusBadRequest, handler.ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 				return
 			}
 


### PR DESCRIPTION
## Summary
- Replace all `http.Error()` calls with structured JSON responses via `handler.WriteError()`
- Add exported error code constants (`ErrCodeBadRequest`, `ErrCodeNotFound`, etc.) for use by custom middleware
- Use `http.StatusText()` for all message fields to avoid leaking internals — validation errors are the sole exception, keeping developer-authored messages

## Test plan
- [x] 17 new unit tests covering every error code path + encode failure edge case
- [x] All existing handler/router unit tests pass
- [x] All 300 Bruno integration tests pass (12 Bruno test files updated with JSON assertions)
- [x] Benchmarks show no regression
- [x] Coverage: `error_response.go` at 100%, handler package at 88.3%

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)