### PR TITLE
feat: configurable file upload size limit

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -135,6 +135,7 @@ router.RegisterRoutes[Model](builder, "/path",
 
     // File uploads (model must embed filestore.FileFields)
     router.AsFileResource(),
+    router.WithMaxUploadSize(10 << 20),  // optional: max upload size in bytes (default: 32 MB)
 
     // Request body limits
     router.WithMaxBodySize(1024),        // optional: max JSON body size in bytes (default: 1 MB)

--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,15 @@ Requests exceeding the limit receive `413 Request Entity Too Large`.
 
 ### Multipart Uploads
 
-File upload endpoints using `multipart/form-data` are **not** affected by `WithMaxBodySize`. They use a separate 32 MB limit handled internally by the file upload handler.
+File upload endpoints using `multipart/form-data` are **not** affected by `WithMaxBodySize`. They default to a 32 MB limit. Use `WithMaxUploadSize` to configure per route:
+
+```go
+router.RegisterRoutes[Image](b, "/images",
+    router.AsFileResource(),
+    router.AllPublic(),
+    router.WithMaxUploadSize(10 << 20), // 10 MB limit
+)
+```
 
 ## Error Responses
 

--- a/examples/files_proxy/main.go
+++ b/examples/files_proxy/main.go
@@ -128,6 +128,7 @@ func main() {
 			router.RegisterRoutes[Image](b, "/images",
 				router.AsFileResource(),
 				router.AllPublic(),
+				router.WithMaxUploadSize(10<<20), // 10 MB limit
 				router.WithFilters("Filename", "ContentType"),
 				router.WithSorts("Filename", "CreatedAt"),
 			)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -429,12 +429,11 @@ func Create[T any](createFunc CustomCreateFunc[T]) http.HandlerFunc {
 		var fileMeta filestore.FileMetadata
 
 		// Parse request body - either multipart form or JSON
-		contentType := r.Header.Get("Content-Type")
-		if strings.HasPrefix(contentType, "multipart/form-data") {
+		mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if mediaType == "multipart/form-data" {
 			// Limit request body size to prevent memory exhaustion
-			const maxUploadSize = 32 << 20 // 32 MB
-			r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
-			if err := r.ParseMultipartForm(maxUploadSize); err != nil { // #nosec G120 -- body already bounded by MaxBytesReader above
+			r.Body = http.MaxBytesReader(w, r.Body, meta.MaxUploadSize)
+			if err := r.ParseMultipartForm(meta.MaxUploadSize); err != nil { // #nosec G120 -- body already bounded by MaxBytesReader above
 				slog.DebugContext(ctx, "failed to parse multipart form", "error", err)
 				WriteError(w, http.StatusBadRequest, ErrCodeBadRequest, http.StatusText(http.StatusBadRequest))
 				return

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -2026,6 +2026,7 @@ var testFileMeta = &metadata.TypeMetadata{
 	PKField:        "ID",
 	ModelType:      reflect.TypeOf(TestFileModel{}),
 	IsFileResource: true,
+	MaxUploadSize:  metadata.DefaultMaxUploadSize,
 }
 
 // mockFileStorage is a mock implementation of FileStorage for testing
@@ -2625,6 +2626,94 @@ func TestCreate_MultipartFormParseError(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_MultipartFormExceedsMaxUploadSize(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	fileWriter, err := writer.CreateFormFile("file", "big-file.txt")
+	if err != nil {
+		t.Fatal("Failed to create form file:", err)
+	}
+	fileWriter.Write(bytes.Repeat([]byte("x"), 200))
+
+	metadataField, _ := writer.CreateFormField("metadata")
+	metadataField.Write([]byte(`{"name":"Big File"}`))
+	writer.Close()
+
+	smallUploadMeta := &metadata.TypeMetadata{
+		TypeID:         "test_file_model_id",
+		TypeName:       "TestFileModel",
+		TableName:      "test_file_models",
+		URLParamUUID:   "test_file_uuid",
+		PKField:        "ID",
+		ModelType:      reflect.TypeOf(TestFileModel{}),
+		IsFileResource: true,
+		MaxUploadSize:  100,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rctx := chi.NewRouteContext()
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, metadata.MetadataKey, smallUploadMeta)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.Create(handler.StandardCreate[TestFileModel])(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d for upload exceeding MaxUploadSize, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}
+
+func TestCreate_MultipartFormWithinMaxUploadSize(t *testing.T) {
+	_, err := testDB.GetDB().NewCreateTable().Model((*TestFileModel)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create test_file_models table:", err)
+	}
+	defer testDB.GetDB().NewDropTable().Model((*TestFileModel)(nil)).IfExists().Exec(context.Background())
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	fileWriter, err := writer.CreateFormFile("file", "small-file.txt")
+	if err != nil {
+		t.Fatal("Failed to create form file:", err)
+	}
+	fileWriter.Write([]byte("small"))
+
+	metadataField, _ := writer.CreateFormField("metadata")
+	metadataField.Write([]byte(`{"name":"Small File"}`))
+	writer.Close()
+
+	uploadMeta := &metadata.TypeMetadata{
+		TypeID:         "test_file_model_id",
+		TypeName:       "TestFileModel",
+		TableName:      "test_file_models",
+		URLParamUUID:   "test_file_uuid",
+		PKField:        "ID",
+		ModelType:      reflect.TypeOf(TestFileModel{}),
+		IsFileResource: true,
+		MaxUploadSize:  1 << 20,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rctx := chi.NewRouteContext()
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, metadata.MetadataKey, uploadMeta)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	handler.Create(handler.StandardCreate[TestFileModel])(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d for upload within MaxUploadSize, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
 	}
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -120,6 +120,9 @@ const ParentTenantKey parentTenantKeyType = "restgen_parent_tenant"
 // DefaultMaxBodySize is the default maximum size for JSON request bodies (1 MB).
 const DefaultMaxBodySize int64 = 1 << 20
 
+// DefaultMaxUploadSize is the default maximum size for multipart file uploads (32 MB).
+const DefaultMaxUploadSize int64 = 32 << 20
+
 // TypeMetadata contains all metadata for a registered type
 type TypeMetadata struct {
 	TypeID          string        // Unique UUID for this type
@@ -168,7 +171,8 @@ type TypeMetadata struct {
 	BatchLimit int // Maximum items in batch operations (0 = no limit)
 
 	// Request body limits
-	MaxBodySize int64 // Max JSON request body size in bytes (default: DefaultMaxBodySize)
+	MaxBodySize   int64 // Max JSON request body size in bytes (default: DefaultMaxBodySize)
+	MaxUploadSize int64 // Max multipart file upload size in bytes (default: DefaultMaxUploadSize)
 }
 
 // Clone returns a deep copy of the TypeMetadata.
@@ -196,6 +200,7 @@ func (m *TypeMetadata) Clone() *TypeMetadata {
 		IsFileResource:  m.IsFileResource,
 		BatchLimit:      m.BatchLimit,
 		MaxBodySize:     m.MaxBodySize,
+		MaxUploadSize:   m.MaxUploadSize,
 		TenantField:     m.TenantField,
 		IsTenantTable:   m.IsTenantTable,
 	}

--- a/router/builder.go
+++ b/router/builder.go
@@ -112,6 +112,7 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 	var tenantField string
 	var isTenantTable bool
 	var maxBodySize int64
+	var maxUploadSize int64
 
 	for _, opt := range options {
 		switch v := opt.(type) {
@@ -163,17 +164,19 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 			isTenantTable = true
 		case MaxBodySizeConfig:
 			maxBodySize = v.Size
+		case MaxUploadSizeConfig:
+			maxUploadSize = v.Size
 		case func(*Builder):
 			nested = v
 		}
 	}
 
-	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, endpoints, sses, relationName, singleRoute, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize)
+	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, endpoints, sses, relationName, singleRoute, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize, maxUploadSize)
 }
 
 // prepareMetadata assembles type metadata and auth configuration before route registration.
 // This extracts the setup phase from registerRoutesWithBuilder to reduce cyclomatic complexity.
-func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64) (string, *metadataSetup) {
+func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64, maxUploadSize int64) (string, *metadataSetup) {
 	// Ensure path starts with /
 	if len(path) > 0 && path[0] != '/' {
 		path = "/" + path
@@ -311,6 +314,13 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 		meta.MaxBodySize = metadata.DefaultMaxBodySize
 	}
 
+	// Set max upload size for file resources
+	if maxUploadSize > 0 {
+		meta.MaxUploadSize = maxUploadSize
+	} else {
+		meta.MaxUploadSize = metadata.DefaultMaxUploadSize
+	}
+
 	// Create middleware to inject metadata into context
 	metadataMiddleware := createMetadataMiddleware(meta)
 
@@ -323,8 +333,8 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 }
 
 // registerRoutesWithBuilder is the internal implementation
-func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], endpoints []endpointEntry[T], sses []sseEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64) {
-	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize)
+func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], endpoints []endpointEntry[T], sses []sseEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64, maxUploadSize int64) {
+	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize, maxUploadSize)
 	meta := setup.meta
 	authMap := setup.authMap
 	metadataMiddleware := setup.metadataMiddleware

--- a/router/builder_internal_test.go
+++ b/router/builder_internal_test.go
@@ -19,6 +19,14 @@ import (
 const testFieldName = "Name"
 const testParentIDCol = "parent_id"
 
+// fileModel with bun tags for file resource tests (prepareMetadata needs bun table)
+type fileModel struct {
+	bun.BaseModel `bun:"table:file_models"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+	filestore.FileFields
+}
+
 type testModel struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
@@ -621,6 +629,58 @@ func TestCreateMetadataMiddleware(t *testing.T) {
 		n, _ := capturedBody.Body.Read(buf)
 		if n != 256 {
 			t.Errorf("expected to read 256 bytes at limit, got %d", n)
+		}
+	})
+}
+
+func TestWithMaxUploadSize(t *testing.T) {
+	t.Run("returns MaxUploadSizeConfig with given size", func(t *testing.T) {
+		config := WithMaxUploadSize(10 << 20)
+		if config.Size != 10<<20 {
+			t.Errorf("expected size %d, got %d", 10<<20, config.Size)
+		}
+	})
+}
+
+func TestMaxUploadSizeDefault(t *testing.T) {
+	if !filestore.IsInitialized() {
+		storage := &mockFileStorage{}
+		if err := filestore.Initialize(storage); err != nil {
+			t.Fatalf("failed to initialize filestore: %v", err)
+		}
+	}
+
+	t.Run("file resource gets DefaultMaxUploadSize when not specified", func(t *testing.T) {
+		r := chi.NewRouter()
+		b := NewBuilder(r)
+
+		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, 0, 0)
+
+		if setup.meta.MaxUploadSize != metadata.DefaultMaxUploadSize {
+			t.Errorf("expected default MaxUploadSize %d, got %d", metadata.DefaultMaxUploadSize, setup.meta.MaxUploadSize)
+		}
+	})
+
+	t.Run("custom MaxUploadSize is set on metadata", func(t *testing.T) {
+		r := chi.NewRouter()
+		b := NewBuilder(r)
+
+		customSize := int64(10 << 20)
+		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, 0, customSize)
+
+		if setup.meta.MaxUploadSize != customSize {
+			t.Errorf("expected MaxUploadSize %d, got %d", customSize, setup.meta.MaxUploadSize)
+		}
+	})
+
+	t.Run("non-file resource gets DefaultMaxUploadSize", func(t *testing.T) {
+		r := chi.NewRouter()
+		b := NewBuilder(r)
+
+		_, setup := prepareMetadata[testModel](b, "/items", nil, nil, nil, nil, 0, "", false, "", nil, "", false, 0, 0)
+
+		if setup.meta.MaxUploadSize != metadata.DefaultMaxUploadSize {
+			t.Errorf("expected default MaxUploadSize %d, got %d", metadata.DefaultMaxUploadSize, setup.meta.MaxUploadSize)
 		}
 	})
 }

--- a/router/custom.go
+++ b/router/custom.go
@@ -118,7 +118,7 @@ type MaxBodySizeConfig struct {
 
 // WithMaxBodySize sets the maximum allowed size in bytes for JSON request bodies.
 // If not set, the default is 1 MB (metadata.DefaultMaxBodySize).
-// This does not affect multipart uploads which have their own 32 MB limit.
+// This does not affect multipart uploads — use WithMaxUploadSize for file resources.
 //
 // Example:
 //
@@ -128,6 +128,26 @@ type MaxBodySizeConfig struct {
 //	)
 func WithMaxBodySize(size int64) MaxBodySizeConfig {
 	return MaxBodySizeConfig{Size: size}
+}
+
+// MaxUploadSizeConfig holds the maximum multipart file upload size for file resource routes.
+type MaxUploadSizeConfig struct {
+	Size int64
+}
+
+// WithMaxUploadSize sets the maximum allowed size in bytes for multipart file uploads.
+// If not set, the default is 32 MB (metadata.DefaultMaxUploadSize).
+// This only affects file resource routes (registered with AsFileResource).
+//
+// Example:
+//
+//	router.RegisterRoutes[Image](b, "/images",
+//	    router.AsFileResource(),
+//	    router.AllPublic(),
+//	    router.WithMaxUploadSize(10 << 20), // 10 MB limit
+//	)
+func WithMaxUploadSize(size int64) MaxUploadSizeConfig {
+	return MaxUploadSizeConfig{Size: size}
 }
 
 // CustomBatchCreateConfig holds custom batch create handler configuration.


### PR DESCRIPTION
## Summary
- Add `WithMaxUploadSize` route option to configure per-route file upload limits (default remains 32 MB)
- Replace `strings.HasPrefix` Content-Type matching with `mime.ParseMediaType` in Create handler

## Test plan
- [x] Unit tests: default value (32MB), custom value, upload exceeding limit rejected, upload within limit accepted
- [x] Builder tests: `WithMaxUploadSize` config struct, `prepareMetadata` default/custom wiring
- [x] All existing unit tests pass (8 packages)
- [x] All Bruno integration tests pass (16 suites)
- [x] Coverage: handler 88.3%, router 92.1%, metadata 98.6%

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)