### PR TITLE
feat: cursor-based pagination with response envelope (#84)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -119,11 +119,12 @@ router.RegisterRoutes[Model](builder, "/path",
     // Query options
     router.WithFilters("Status", "Name"),
     router.WithSorts("Name", "CreatedAt"),
-    router.WithPagination(20, 100),
+    router.WithPagination(20, 100),                // cursor-based pagination (default)
+    router.WithPagination(20, 100, router.OffsetMode), // offset-based pagination (opt-in)
     router.WithDefaultSort("-CreatedAt"),
     router.WithRelationName("Posts"),  // enables ?include=Posts on parent
     router.WithJoinOn("NMI", "NMI"),  // custom join: child.NMI = parent.NMI (no belongs-to tag needed)
-    router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock with X-Sum-* headers (works with any DB-numeric type including decimal.Decimal)
+    router.WithSums("Price", "Stock"),  // enables ?sum=Price,Stock in response body (works with any DB-numeric type including decimal.Decimal)
     router.WithAlternatePK("MyPK"),     // when PK field isn't named "ID"
 
     // Custom handlers
@@ -167,6 +168,7 @@ router.RegisterRoutes[Model](builder, "/path",
         DefaultSort:      "-CreatedAt",
         DefaultLimit:     20,
         MaxLimit:         100,
+        Pagination:       router.CursorMode, // default; use router.OffsetMode for offset-based
     }),
 )
 
@@ -306,7 +308,7 @@ func customGetAll(
     svc *service.Common[User],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*User, int, map[string]float64, error) {
+) ([]*User, int, map[string]float64, *metadata.CursorInfo, error) {
     // Custom logic here
     return svc.GetAll(ctx)
 }
@@ -530,11 +532,26 @@ Built-in support on GetAll endpoints:
 | Filter | `?filter[status]=active` | Exact match |
 | Filter ops | `?filter[age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
 | Sort | `?sort=name,-created_at` | `-` prefix for descending |
-| Limit | `?limit=10` | Max results |
-| Offset | `?offset=20` | Skip results |
-| Count | `?count=true` | Include X-Total-Count header |
+| Limit | `?limit=10` | Max results per page |
+| After | `?after=<cursor>` | Next page (cursor from `pagination.next_cursor`) |
+| Before | `?before=<cursor>` | Previous page (cursor from `pagination.prev_cursor`) |
+| Offset | `?offset=20` | Skip results (switches to offset pagination) |
+| Count | `?count=true` | Include `total_count` in `pagination` |
 | Include | `?include=Posts` or `?include=Posts.Comments` | Load relations (requires WithRelationName on child route). Dot notation for nested. |
-| Sum | `?sum=Price,Stock` | Sum fields, returns X-Sum-Price, X-Sum-Stock headers (requires WithSums). Works with any DB-numeric type including `decimal.Decimal`. Bool fields return count of `true` values. DB validates types — non-numeric columns return a database error. |
+| Sum | `?sum=Price,Stock` | Sum fields, returns in `sums` object in response body (requires WithSums). Works with any DB-numeric type including `decimal.Decimal`. Bool fields return count of `true` values. DB validates types — non-numeric columns return a database error. |
+
+**Response envelope (GetAll):**
+```json
+{
+  "data": [...],
+  "pagination": {"has_more": true, "next_cursor": "...", "prev_cursor": "...", "total_count": 42},
+  "sums": {"Price": 1500.0, "Stock": 200.0}
+}
+```
+Cursor mode fields: `has_more`, `next_cursor`, `prev_cursor`, `total_count` (if `count=true`).
+Offset mode fields: `limit`, `offset`, `total_count` (if `count=true`).
+Batch responses use `{"data": [...]}` envelope.
+Single-item responses (Get, Create, Update, Patch, Delete) return the raw object (no envelope).
 
 **Filter operator details:**
 - `in` - In list: `?filter[Status][in]=active,pending`

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ router.RegisterRoutes[User](b, "/users",
     router.AllPublic(),
     router.WithFilters("Name", "Email", "Status"),      // Allow filtering by these fields
     router.WithSorts("Name", "Email", "CreatedAt"),     // Allow sorting by these fields
-    router.WithPagination(20, 100),                     // Default 20 items, max 100
+    router.WithPagination(20, 100),                     // Cursor-based pagination (default), 20 items, max 100
     router.WithDefaultSort("-CreatedAt"),               // Default sort (- prefix = descending)
 )
 ```
@@ -885,6 +885,7 @@ router.RegisterRoutes[User](b, "/users",
         DefaultSort:      "-CreatedAt",
         DefaultLimit:     20,
         MaxLimit:         100,
+        Pagination:       router.CursorMode, // default; use router.OffsetMode for offset-based
     }),
 )
 ```
@@ -940,30 +941,74 @@ GET /users?sort=Status,-CreatedAt
 
 ### Pagination
 
-Control result size with `limit` and `offset`:
+go-restgen supports two pagination modes. **Cursor-based** is the default when using `WithPagination`.
+
+#### Cursor-Based Pagination (Default)
+
+Cursor pagination uses opaque cursors for efficient, consistent page navigation:
 
 ```bash
-# First 10 results
+# First page
 GET /users?limit=10
 
-# Skip first 20, get next 10
-GET /users?limit=10&offset=20
+# Next page (use next_cursor from previous response)
+GET /users?limit=10&after=<cursor>
+
+# Previous page (use prev_cursor from previous response)
+GET /users?limit=10&before=<cursor>
 ```
 
-**Response Headers:**
-- `X-Limit` - The limit applied to the query
-- `X-Offset` - The offset applied to the query
+**Response body** includes pagination metadata:
+```json
+{
+  "data": [...],
+  "pagination": {
+    "has_more": true,
+    "next_cursor": "eyJ2IjpbIkFsaWNlIl0sInBrIjoxfQ==",
+    "prev_cursor": "eyJ2IjpbIkJvYiJdLCJwayI6Mn0=",
+    "total_count": 47
+  }
+}
+```
+
+- `has_more` — whether more items exist beyond the current page
+- `next_cursor` — pass to `?after=` for the next page (absent on last page)
+- `prev_cursor` — pass to `?before=` for the previous page (absent on first page)
+- `total_count` — only included when `?count=true` is requested
+
+#### Offset-Based Pagination (Opt-In)
+
+Use `?offset=` to switch to traditional offset pagination, or configure it as the default:
+
+```go
+router.WithPagination(20, 100, router.OffsetMode) // offset-based as default
+```
+
+```bash
+GET /users?limit=10&offset=20&count=true
+```
+
+**Response body:**
+```json
+{
+  "data": [...],
+  "pagination": {
+    "limit": 10,
+    "offset": 20,
+    "total_count": 47
+  }
+}
+```
 
 ### Total Count
 
 Request total count (useful for pagination UI) with `count=true`:
 
 ```bash
-GET /users?limit=10&offset=20&count=true
+GET /users?limit=10&count=true
 ```
 
-**Response Headers:**
-- `X-Total-Count` - Total number of records (before pagination)
+The count is returned in `pagination.total_count` in the response body.
 
 ### Sum Aggregation
 
@@ -988,9 +1033,13 @@ GET /products?sum=Price,Stock
 GET /products?filter[Category]=Electronics&sum=Price,Stock&count=true
 ```
 
-**Response Headers:**
-- `X-Sum-Price` - Sum of the Price field across matching records
-- `X-Sum-Stock` - Sum of the Stock field across matching records
+**Response body** includes sums alongside data:
+```json
+{
+  "data": [...],
+  "sums": {"Price": 1500.0, "Stock": 200.0}
+}
+```
 
 Fields not listed in `WithSums` are silently ignored (returns 0). Bool fields return the count of `true` values. The database validates types — summing a non-numeric column (e.g. a string) returns a database error.
 
@@ -999,13 +1048,20 @@ See the [query example](./examples/query) for a complete working example with al
 ### Complete Example
 
 ```bash
-# Get active users, sorted by newest first, page 2 (10 per page), with total count
+# Cursor pagination: first page of active users, sorted by newest first, with total count
+curl 'http://localhost:8080/users?filter[Status]=active&sort=-CreatedAt&limit=10&count=true'
+
+# Response body:
+# {"data": [...], "pagination": {"has_more": true, "next_cursor": "...", "total_count": 47}}
+
+# Next page using cursor from previous response
+curl 'http://localhost:8080/users?filter[Status]=active&sort=-CreatedAt&limit=10&after=<next_cursor>'
+
+# Offset pagination (opt-in via offset parameter)
 curl 'http://localhost:8080/users?filter[Status]=active&sort=-CreatedAt&limit=10&offset=10&count=true'
 
-# Response headers include:
-# X-Total-Count: 47
-# X-Limit: 10
-# X-Offset: 10
+# Response body:
+# {"data": [...], "pagination": {"limit": 10, "offset": 10, "total_count": 47}}
 ```
 
 ## Request Body Size Limits
@@ -1353,7 +1409,7 @@ type CustomGetAllFunc[T any] func(
     svc *service.Common[T],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*T, int, map[string]float64, error)
+) ([]*T, int, map[string]float64, *metadata.CursorInfo, error)
 
 // CustomCreateFunc - for POST /resource
 // Includes file parameters for file resource support (nil for regular JSON requests).
@@ -1443,14 +1499,14 @@ router.RegisterRoutes[Task](b, "/tasks",
 ### Example: Filter GetAll by Owner
 
 ```go
-func customGetMyTasks(ctx context.Context, svc *service.Common[Task], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, error) {
+func customGetMyTasks(ctx context.Context, svc *service.Common[Task], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, *metadata.CursorInfo, error) {
     if auth == nil {
-        return nil, 0, nil, fmt.Errorf("not authenticated")
+        return nil, 0, nil, nil, fmt.Errorf("not authenticated")
     }
     // Return only tasks owned by current user
     tasks := []*Task{}
     err := db.GetDB().NewSelect().Model(&tasks).Where("owner_id = ?", auth.UserID).Scan(ctx)
-    return tasks, len(tasks), nil, err
+    return tasks, len(tasks), nil, nil, err
 }
 
 router.RegisterRoutes[Task](b, "/my-tasks",
@@ -2402,7 +2458,7 @@ func myCustomHandler(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    users, _, _, err := svc.GetAll(r.Context())
+    users, _, _, _, err := svc.GetAll(r.Context())
     // ... handle response
 }
 ```
@@ -2495,7 +2551,7 @@ go-restgen builds on these excellent projects:
 - [x] Nested resource support with automatic parent validation
 - [x] Multi-registration support (same model at different routes with different configs)
 - [x] Query parameter filtering and sorting
-- [x] Pagination with limit/offset and total count
+- [x] Cursor-based pagination (default) with offset pagination opt-in
 - [x] Custom validation for business rules
 - [x] Transactional audit logging
 - [x] UUID primary key support

--- a/bruno/auth-example/01-articles-public-read.bru
+++ b/bruno/auth-example/01-articles-public-read.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {

--- a/bruno/auth-example/06-blogs-get-all-alice.bru
+++ b/bruno/auth-example/06-blogs-get-all-alice.bru
@@ -16,12 +16,12 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice should only see her own blog due to ownership filtering", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.every(blog => blog.author_id === "alice")).to.be.true;
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.every(blog => blog.author_id === "alice")).to.be.true;
   });
 }

--- a/bruno/auth-example/07-blogs-get-all-admin.bru
+++ b/bruno/auth-example/07-blogs-get-all-admin.bru
@@ -16,12 +16,12 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin should see all blogs (bypasses ownership)", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.be.at.least(2);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.be.at.least(2);
   });
 }

--- a/bruno/auth-example/12-comments-get-public.bru
+++ b/bruno/auth-example/12-comments-get-public.bru
@@ -16,13 +16,13 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Blog owner can get comments", function() {
     expect(res.status).to.equal(200);
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
   });
 }
 

--- a/bruno/auth-example/14-reports-list-authenticated.bru
+++ b/bruno/auth-example/14-reports-list-authenticated.bru
@@ -16,7 +16,7 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {

--- a/bruno/auth-example/19-blogs-filter-alice-published.bru
+++ b/bruno/auth-example/19-blogs-filter-alice-published.bru
@@ -16,17 +16,17 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice sees only her published blogs (ownership + status filter)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be Alice's
-    expect(res.body.every(blog => blog.author_id === "alice")).to.be.true;
+    expect(res.body.data.every(blog => blog.author_id === "alice")).to.be.true;
     // All results should be published
-    expect(res.body.every(blog => blog.status === "published")).to.be.true;
+    expect(res.body.data.every(blog => blog.status === "published")).to.be.true;
     // Should have exactly 1 published blog
-    expect(res.body.length).to.equal(1);
+    expect(res.body.data.length).to.equal(1);
   });
 }

--- a/bruno/auth-example/20-blogs-filter-alice-draft.bru
+++ b/bruno/auth-example/20-blogs-filter-alice-draft.bru
@@ -16,17 +16,17 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice sees only her draft blogs (ownership + status filter)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be Alice's
-    expect(res.body.every(blog => blog.author_id === "alice")).to.be.true;
+    expect(res.body.data.every(blog => blog.author_id === "alice")).to.be.true;
     // All results should be draft
-    expect(res.body.every(blog => blog.status === "draft")).to.be.true;
+    expect(res.body.data.every(blog => blog.status === "draft")).to.be.true;
     // Should have exactly 1 draft blog
-    expect(res.body.length).to.equal(1);
+    expect(res.body.data.length).to.equal(1);
   });
 }

--- a/bruno/auth-example/21-blogs-filter-admin-published.bru
+++ b/bruno/auth-example/21-blogs-filter-admin-published.bru
@@ -16,17 +16,17 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin sees ALL published blogs from all users (bypass ownership + status filter)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be published
-    expect(res.body.every(blog => blog.status === "published")).to.be.true;
+    expect(res.body.data.every(blog => blog.status === "published")).to.be.true;
     // Should see published blogs from multiple users (Alice + Bob)
-    expect(res.body.length).to.equal(2);
-    const authors = res.body.map(b => b.author_id);
+    expect(res.body.data.length).to.equal(2);
+    const authors = res.body.data.map(b => b.author_id);
     expect(authors).to.include("alice");
     expect(authors).to.include("bob");
   });

--- a/bruno/auth-example/22-blogs-filter-admin-draft.bru
+++ b/bruno/auth-example/22-blogs-filter-admin-draft.bru
@@ -16,17 +16,17 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin sees ALL draft blogs from all users (bypass ownership + status filter)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be draft
-    expect(res.body.every(blog => blog.status === "draft")).to.be.true;
+    expect(res.body.data.every(blog => blog.status === "draft")).to.be.true;
     // Should see draft blogs from multiple users (Alice + Bob)
-    expect(res.body.length).to.equal(2);
-    const authors = res.body.map(b => b.author_id);
+    expect(res.body.data.length).to.equal(2);
+    const authors = res.body.data.map(b => b.author_id);
     expect(authors).to.include("alice");
     expect(authors).to.include("bob");
   });

--- a/bruno/auth-example/23-blogs-sort-alice-name.bru
+++ b/bruno/auth-example/23-blogs-sort-alice-name.bru
@@ -16,18 +16,18 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice's blogs sorted by name ascending (ownership + sort)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be Alice's
-    expect(res.body.every(blog => blog.author_id === "alice")).to.be.true;
+    expect(res.body.data.every(blog => blog.author_id === "alice")).to.be.true;
     // Should have 2 blogs
-    expect(res.body.length).to.equal(2);
+    expect(res.body.data.length).to.equal(2);
     // Verify sort order (Alice's Blog < Alice's Draft Blog alphabetically)
-    expect(res.body[0].name).to.equal("Alice's Blog");
-    expect(res.body[1].name).to.equal("Alice's Draft Blog");
+    expect(res.body.data[0].name).to.equal("Alice's Blog");
+    expect(res.body.data[1].name).to.equal("Alice's Draft Blog");
   });
 }

--- a/bruno/auth-example/24-blogs-sort-admin-name-desc.bru
+++ b/bruno/auth-example/24-blogs-sort-admin-name-desc.bru
@@ -16,17 +16,17 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin sees ALL blogs sorted by name descending (bypass + sort)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // Should see all 4 blogs
-    expect(res.body.length).to.equal(4);
+    expect(res.body.data.length).to.equal(4);
     // Verify descending sort order
-    for (let i = 0; i < res.body.length - 1; i++) {
-      expect(res.body[i].name >= res.body[i+1].name).to.be.true;
+    for (let i = 0; i < res.body.data.length - 1; i++) {
+      expect(res.body.data[i].name >= res.body.data[i+1].name).to.be.true;
     }
   });
 }

--- a/bruno/auth-example/25-blogs-combined-filter-sort.bru
+++ b/bruno/auth-example/25-blogs-combined-filter-sort.bru
@@ -16,18 +16,18 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin sees published blogs sorted by name (combined filter + sort)", function() {
-    expect(res.body).to.be.an('array');
+    expect(res.body.data).to.be.an('array');
     // All results should be published
-    expect(res.body.every(blog => blog.status === "published")).to.be.true;
+    expect(res.body.data.every(blog => blog.status === "published")).to.be.true;
     // Should have 2 published blogs (Alice's + Bob's)
-    expect(res.body.length).to.equal(2);
+    expect(res.body.data.length).to.equal(2);
     // Verify ascending sort order by name
-    expect(res.body[0].name).to.equal("Alice's Blog");
-    expect(res.body[1].name).to.equal("Bob's Published Blog");
+    expect(res.body.data[0].name).to.equal("Alice's Blog");
+    expect(res.body.data[1].name).to.equal("Bob's Published Blog");
   });
 }

--- a/bruno/auth-example/39-posts-under-other-user-blog.bru
+++ b/bruno/auth-example/39-posts-under-other-user-blog.bru
@@ -16,14 +16,14 @@ headers {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice cannot see posts under Bob's blog", function() {
     expect(res.status).to.equal(200);
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(0);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(0);
   });
 }
 

--- a/bruno/batch-example/02-batch-create.bru
+++ b/bruno/batch-example/02-batch-create.bru
@@ -20,14 +20,14 @@ body:json {
 
 assert {
   res.status: eq 201
-  res.body[0].id: isDefined
-  res.body[0].name: eq Widget A
-  res.body[1].name: eq Widget B
-  res.body[2].name: eq Widget C
+  res.body.data[0].id: isDefined
+  res.body.data[0].name: eq Widget A
+  res.body.data[1].name: eq Widget B
+  res.body.data[2].name: eq Widget C
 }
 
 script:post-response {
-  bru.setVar("productId1", res.body[0].id);
-  bru.setVar("productId2", res.body[1].id);
-  bru.setVar("productId3", res.body[2].id);
+  bru.setVar("productId1", res.body.data[0].id);
+  bru.setVar("productId2", res.body.data[1].id);
+  bru.setVar("productId3", res.body.data[2].id);
 }

--- a/bruno/batch-example/03-verify-batch-create.bru
+++ b/bruno/batch-example/03-verify-batch-create.bru
@@ -12,5 +12,5 @@ get {
 
 assert {
   res.status: eq 200
-  res.body.length: eq 3
+  res.body.data.length: eq 3
 }

--- a/bruno/batch-example/04-batch-update.bru
+++ b/bruno/batch-example/04-batch-update.bru
@@ -19,8 +19,8 @@ body:json {
 
 assert {
   res.status: eq 200
-  res.body[0].name: eq Widget A Updated
-  res.body[0].price: eq 8.99
-  res.body[1].name: eq Widget B Updated
-  res.body[1].price: eq 12.99
+  res.body.data[0].name: eq Widget A Updated
+  res.body.data[0].price: eq 8.99
+  res.body.data[1].name: eq Widget B Updated
+  res.body.data[1].price: eq 12.99
 }

--- a/bruno/batch-example/07-verify-batch-delete.bru
+++ b/bruno/batch-example/07-verify-batch-delete.bru
@@ -12,5 +12,5 @@ get {
 
 assert {
   res.status: eq 200
-  res.body.length: eq 1
+  res.body.data.length: eq 1
 }

--- a/bruno/batch-example/14-batch-create-with-include.bru
+++ b/bruno/batch-example/14-batch-create-with-include.bru
@@ -29,16 +29,16 @@ body:json {
 
 assert {
   res.status: eq 201
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Batch create returns 2 products", function() {
-    expect(res.body.length).to.equal(2);
+    expect(res.body.data.length).to.equal(2);
   });
 
   test("Products have correct names", function() {
-    expect(res.body[0].name).to.equal("Hoodie");
-    expect(res.body[1].name).to.equal("Cap");
+    expect(res.body.data[0].name).to.equal("Hoodie");
+    expect(res.body.data[1].name).to.equal("Cap");
   });
 }

--- a/bruno/batch-example/15-batch-create-variants.bru
+++ b/bruno/batch-example/15-batch-create-variants.bru
@@ -20,29 +20,29 @@ body:json {
 
 assert {
   res.status: eq 201
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Batch create returns 3 variants", function() {
-    expect(res.body.length).to.equal(3);
+    expect(res.body.data.length).to.equal(3);
   });
 
   test("All variants have correct product_id", function() {
     const expectedProductId = parseInt(bru.getVar("productWithVariantsId"));
-    res.body.forEach(function(variant) {
+    res.body.data.forEach(function(variant) {
       expect(variant.product_id).to.equal(expectedProductId);
     });
   });
 
   test("Variants have correct names", function() {
-    expect(res.body[0].name).to.equal("Medium");
-    expect(res.body[1].name).to.equal("XL");
-    expect(res.body[2].name).to.equal("XXL");
+    expect(res.body.data[0].name).to.equal("Medium");
+    expect(res.body.data[1].name).to.equal("XL");
+    expect(res.body.data[2].name).to.equal("XXL");
   });
 
   test("All variants have IDs", function() {
-    res.body.forEach(function(variant) {
+    res.body.data.forEach(function(variant) {
       expect(variant.id).to.be.a("number");
       expect(variant.id).to.be.above(0);
     });

--- a/bruno/batch-example/16-batch-patch.bru
+++ b/bruno/batch-example/16-batch-patch.bru
@@ -19,11 +19,11 @@ body:json {
 
 assert {
   res.status: eq 201
-  res.body[0].id: isDefined
-  res.body[1].id: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[1].id: isDefined
 }
 
 script:post-response {
-  bru.setVar("patchTargetId1", res.body[0].id);
-  bru.setVar("patchTargetId2", res.body[1].id);
+  bru.setVar("patchTargetId1", res.body.data[0].id);
+  bru.setVar("patchTargetId2", res.body.data[1].id);
 }

--- a/bruno/batch-example/17-batch-patch-apply.bru
+++ b/bruno/batch-example/17-batch-patch-apply.bru
@@ -19,8 +19,8 @@ body:json {
 
 assert {
   res.status: eq 200
-  res.body[0].name: eq Patch Target A Patched
-  res.body[0].sku: eq PTA01
-  res.body[1].price: eq 19.99
-  res.body[1].name: eq Patch Target B
+  res.body.data[0].name: eq Patch Target A Patched
+  res.body.data[0].sku: eq PTA01
+  res.body.data[1].price: eq 19.99
+  res.body.data[1].name: eq Patch Target B
 }

--- a/bruno/custom-example/07-get-my-tasks.bru
+++ b/bruno/custom-example/07-get-my-tasks.bru
@@ -16,8 +16,8 @@ headers {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
-  res.body[0].priority: eq 10
-  res.body[1].priority: eq 5
+  res.body.data: isArray
+  res.body.data: length 2
+  res.body.data[0].priority: eq 10
+  res.body.data[1].priority: eq 5
 }

--- a/bruno/custom-example/08-bob-sees-no-tasks.bru
+++ b/bruno/custom-example/08-bob-sees-no-tasks.bru
@@ -16,6 +16,6 @@ headers {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 0
+  res.body.data: isArray
+  res.body.data: length 0
 }

--- a/bruno/custom-join-example/06-list-usage-data.bru
+++ b/bruno/custom-join-example/06-list-usage-data.bru
@@ -12,17 +12,17 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 script:post-response {
-  if (res.body.length !== 5) {
-    throw new Error(`Expected 5 usage records for NMI001, got ${res.body.length}`);
+  if (res.body.data.length !== 5) {
+    throw new Error(`Expected 5 usage records for NMI001, got ${res.body.data.length}`);
   }
-  for (const record of res.body) {
+  for (const record of res.body.data) {
     if (record.nmi !== "NMI001") {
       throw new Error(`Expected NMI001, got ${record.nmi}`);
     }
   }
-  bru.setVar("usageId", res.body[0].id);
+  bru.setVar("usageId", res.body.data[0].id);
 }

--- a/bruno/custom-join-example/10-list-usage-nmi002.bru
+++ b/bruno/custom-join-example/10-list-usage-nmi002.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 script:post-response {
-  if (res.body.length !== 3) {
-    throw new Error(`Expected 3 usage records for NMI002, got ${res.body.length}`);
+  if (res.body.data.length !== 3) {
+    throw new Error(`Expected 3 usage records for NMI002, got ${res.body.data.length}`);
   }
-  for (const record of res.body) {
+  for (const record of res.body.data) {
     if (record.nmi !== "NMI002") {
       throw new Error(`Expected NMI002, got ${record.nmi}`);
     }

--- a/bruno/files-proxy-example/06-list-images.bru
+++ b/bruno/files-proxy-example/06-list-images.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: gte 1
+  res.body.data: isArray
+  res.body.data.length: gte 1
 }

--- a/bruno/files-proxy-example/09-list-images-multiple.bru
+++ b/bruno/files-proxy-example/09-list-images-multiple.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: eq 2
+  res.body.data: isArray
+  res.body.data.length: eq 2
 }

--- a/bruno/files-proxy-example/12-list-images-after-delete.bru
+++ b/bruno/files-proxy-example/12-list-images-after-delete.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: eq 1
+  res.body.data: isArray
+  res.body.data.length: eq 1
 }

--- a/bruno/files-signed-example/06-list-images.bru
+++ b/bruno/files-signed-example/06-list-images.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: gte 1
+  res.body.data: isArray
+  res.body.data.length: gte 1
 }

--- a/bruno/files-signed-example/09-list-images-multiple.bru
+++ b/bruno/files-signed-example/09-list-images-multiple.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: eq 2
+  res.body.data: isArray
+  res.body.data.length: eq 2
 }

--- a/bruno/files-signed-example/12-list-images-after-delete.bru
+++ b/bruno/files-signed-example/12-list-images-after-delete.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body.length: eq 1
+  res.body.data: isArray
+  res.body.data.length: eq 1
 }

--- a/bruno/nested-example/05-get-alice-posts.bru
+++ b/bruno/nested-example/05-get-alice-posts.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 script:post-response {
-  if (res.body.length !== 1) {
-    throw new Error(`Expected Alice to have 1 post, got ${res.body.length}`);
+  if (res.body.data.length !== 1) {
+    throw new Error(`Expected Alice to have 1 post, got ${res.body.data.length}`);
   }
-  if (res.body[0].user_id !== parseInt(bru.getVar("aliceId"))) {
+  if (res.body.data[0].user_id !== parseInt(bru.getVar("aliceId"))) {
     throw new Error(`Expected user_id to be ${bru.getVar("aliceId")}`);
   }
 }

--- a/bruno/nested-example/10-get-comments.bru
+++ b/bruno/nested-example/10-get-comments.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Post should have 2 comments", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(2);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(2);
   });
 }

--- a/bruno/nested-example/16-get-remaining-comments.bru
+++ b/bruno/nested-example/16-get-remaining-comments.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 script:post-response {
-  if (res.body.length !== 1) {
-    throw new Error(`Expected 1 comment after deletion, got ${res.body.length}`);
+  if (res.body.data.length !== 1) {
+    throw new Error(`Expected 1 comment after deletion, got ${res.body.data.length}`);
   }
-  if (res.body[0].id !== parseInt(bru.getVar("comment2Id"))) {
+  if (res.body.data[0].id !== parseInt(bru.getVar("comment2Id"))) {
     throw new Error(`Expected remaining comment to be comment2`);
   }
 }

--- a/bruno/query-example/10-filter-eq.bru
+++ b/bruno/query-example/10-filter-eq.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
   test("All results have Category = Fruit", function() {
-    expect(res.body.every(p => p.category === "Fruit")).to.be.true;
+    expect(res.body.data.every(p => p.category === "Fruit")).to.be.true;
   });
 }

--- a/bruno/query-example/11-filter-neq.bru
+++ b/bruno/query-example/11-filter-neq.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 5
+  res.body.data: isArray
+  res.body.data: length 5
 }
 
 tests {
   test("No results have Category = Fruit", function() {
-    expect(res.body.every(p => p.category !== "Fruit")).to.be.true;
+    expect(res.body.data.every(p => p.category !== "Fruit")).to.be.true;
   });
 }

--- a/bruno/query-example/12-filter-gt.bru
+++ b/bruno/query-example/12-filter-gt.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 4
+  res.body.data: isArray
+  res.body.data: length 4
 }
 
 tests {
   test("All results have Price > 80", function() {
-    expect(res.body.every(p => p.price > 80)).to.be.true;
+    expect(res.body.data.every(p => p.price > 80)).to.be.true;
   });
 }

--- a/bruno/query-example/13-filter-gte.bru
+++ b/bruno/query-example/13-filter-gte.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 5
+  res.body.data: isArray
+  res.body.data: length 5
 }
 
 tests {
   test("All results have Price >= 80", function() {
-    expect(res.body.every(p => p.price >= 80)).to.be.true;
+    expect(res.body.data.every(p => p.price >= 80)).to.be.true;
   });
 }

--- a/bruno/query-example/14-filter-lt.bru
+++ b/bruno/query-example/14-filter-lt.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
   test("All results have Price < 80", function() {
-    expect(res.body.every(p => p.price < 80)).to.be.true;
+    expect(res.body.data.every(p => p.price < 80)).to.be.true;
   });
 }

--- a/bruno/query-example/15-filter-lte.bru
+++ b/bruno/query-example/15-filter-lte.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 3
+  res.body.data: isArray
+  res.body.data: length 3
 }
 
 tests {
   test("All results have Price <= 80", function() {
-    expect(res.body.every(p => p.price <= 80)).to.be.true;
+    expect(res.body.data.every(p => p.price <= 80)).to.be.true;
   });
 }

--- a/bruno/query-example/16-filter-like.bru
+++ b/bruno/query-example/16-filter-like.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Eggplant
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Eggplant
 }

--- a/bruno/query-example/20-filter-combined-category-and-price.bru
+++ b/bruno/query-example/20-filter-combined-category-and-price.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Eggplant
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Eggplant
 }
 
 tests {
   test("Result is Vegetable with Price >= 50", function() {
-    expect(res.body[0].category).to.equal("Vegetable");
-    expect(res.body[0].price).to.be.at.least(50);
+    expect(res.body.data[0].category).to.equal("Vegetable");
+    expect(res.body.data[0].price).to.be.at.least(50);
   });
 }

--- a/bruno/query-example/21-filter-combined-with-sort.bru
+++ b/bruno/query-example/21-filter-combined-with-sort.bru
@@ -12,17 +12,17 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 6
+  res.body.data: isArray
+  res.body.data: length 6
 }
 
 tests {
   test("Results sorted by Price descending", function() {
-    expect(res.body[0].price).to.equal(999);
-    expect(res.body[1].price).to.equal(888);
-    expect(res.body[2].price).to.equal(150);
-    expect(res.body[3].price).to.equal(100);
-    expect(res.body[4].price).to.equal(80);
-    expect(res.body[5].price).to.equal(50);
+    expect(res.body.data[0].price).to.equal(999);
+    expect(res.body.data[1].price).to.equal(888);
+    expect(res.body.data[2].price).to.equal(150);
+    expect(res.body.data[3].price).to.equal(100);
+    expect(res.body.data[4].price).to.equal(80);
+    expect(res.body.data[5].price).to.equal(50);
   });
 }

--- a/bruno/query-example/22-filter-combined-with-pagination.bru
+++ b/bruno/query-example/22-filter-combined-with-pagination.bru
@@ -12,18 +12,18 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
   test("Returns 2 active products starting from offset 1", function() {
-    expect(res.body.every(p => p.active === true)).to.be.true;
-    expect(res.body[0].name).to.equal("Apple");
-    expect(res.body[1].name).to.equal("Banana");
+    expect(res.body.data.every(p => p.active === true)).to.be.true;
+    expect(res.body.data[0].name).to.equal("Apple");
+    expect(res.body.data[1].name).to.equal("Banana");
   });
 
-  test("X-Total-Count header shows total active products", function() {
-    expect(res.headers['x-total-count']).to.equal('5');
+  test("Total count shows total active products", function() {
+    expect(res.body.pagination.total_count).to.equal(5);
   });
 }

--- a/bruno/query-example/23-filter-bool-false.bru
+++ b/bruno/query-example/23-filter-bool-false.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
   test("All returned products are inactive", function() {
-    expect(res.body.every(p => p.active === false)).to.be.true;
+    expect(res.body.data.every(p => p.active === false)).to.be.true;
   });
 }

--- a/bruno/query-example/24-filter-string-numeric-value.bru
+++ b/bruno/query-example/24-filter-string-numeric-value.bru
@@ -12,13 +12,13 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq "123"
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq "123"
 }
 
 tests {
   test("String filter with numeric value stays as string", function() {
-    expect(res.body[0].name).to.equal("123");
+    expect(res.body.data[0].name).to.equal("123");
   });
 }

--- a/bruno/query-example/25-filter-string-true-value.bru
+++ b/bruno/query-example/25-filter-string-true-value.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].category: eq "true"
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].category: eq "true"
 }
 
 tests {
   test("String filter with 'true' value stays as string", function() {
-    expect(res.body[0].category).to.equal("true");
-    expect(res.body[0].name).to.equal("123");
+    expect(res.body.data[0].category).to.equal("true");
+    expect(res.body.data[0].name).to.equal("123");
   });
 }

--- a/bruno/query-example/26-filter-string-false-value.bru
+++ b/bruno/query-example/26-filter-string-false-value.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].category: eq "false"
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].category: eq "false"
 }
 
 tests {
   test("String filter with 'false' value stays as string", function() {
-    expect(res.body[0].category).to.equal("false");
-    expect(res.body[0].name).to.equal("FalseItem");
+    expect(res.body.data[0].category).to.equal("false");
+    expect(res.body.data[0].name).to.equal("FalseItem");
   });
 }

--- a/bruno/query-example/27-filter-int-string-value.bru
+++ b/bruno/query-example/27-filter-int-string-value.bru
@@ -12,14 +12,14 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].price: eq 100
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].price: eq 100
 }
 
 tests {
   test("Int filter with string value converts properly", function() {
-    expect(res.body[0].price).to.equal(100);
-    expect(res.body[0].name).to.equal("Apple");
+    expect(res.body.data[0].price).to.equal(100);
+    expect(res.body.data[0].name).to.equal("Apple");
   });
 }

--- a/bruno/query-example/30-filter-in.bru
+++ b/bruno/query-example/30-filter-in.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 3
+  res.body.data: isArray
+  res.body.data: length 3
 }
 
 tests {
   test("All results have Category in [Fruit, Bakery]", function() {
-    expect(res.body.every(p => p.category === "Fruit" || p.category === "Bakery")).to.be.true;
+    expect(res.body.data.every(p => p.category === "Fruit" || p.category === "Bakery")).to.be.true;
   });
 }

--- a/bruno/query-example/31-filter-nin.bru
+++ b/bruno/query-example/31-filter-nin.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 4
+  res.body.data: isArray
+  res.body.data: length 4
 }
 
 tests {
   test("No results have Category in [Fruit, Bakery]", function() {
-    expect(res.body.every(p => p.category !== "Fruit" && p.category !== "Bakery")).to.be.true;
+    expect(res.body.data.every(p => p.category !== "Fruit" && p.category !== "Bakery")).to.be.true;
   });
 }

--- a/bruno/query-example/32-filter-bt.bru
+++ b/bruno/query-example/32-filter-bt.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 3
+  res.body.data: isArray
+  res.body.data: length 3
 }
 
 tests {
   test("All results have Price between 50 and 100 (inclusive)", function() {
-    expect(res.body.every(p => p.price >= 50 && p.price <= 100)).to.be.true;
+    expect(res.body.data.every(p => p.price >= 50 && p.price <= 100)).to.be.true;
   });
 }

--- a/bruno/query-example/33-filter-nbt.bru
+++ b/bruno/query-example/33-filter-nbt.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 4
+  res.body.data: isArray
+  res.body.data: length 4
 }
 
 tests {
   test("All results have Price outside 50-100 range", function() {
-    expect(res.body.every(p => p.price < 50 || p.price > 100)).to.be.true;
+    expect(res.body.data.every(p => p.price < 50 || p.price > 100)).to.be.true;
   });
 }

--- a/bruno/query-example/40-sum-single-field.bru
+++ b/bruno/query-example/40-sum-single-field.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-Price header contains sum of all prices", function() {
+  test("Sums contain sum of all prices", function() {
     // Apple=100 + Banana=50 + Carrot=30 + Donut=150 + Eggplant=80 + 123=999 + FalseItem=888 = 2297
-    expect(res.headers['x-sum-price']).to.equal('2297');
+    expect(res.body.sums.Price).to.equal(2297);
   });
 }

--- a/bruno/query-example/41-sum-multiple-fields.bru
+++ b/bruno/query-example/41-sum-multiple-fields.bru
@@ -12,17 +12,17 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-Price header contains sum of all prices", function() {
+  test("Sums contain sum of all prices", function() {
     // Apple=100 + Banana=50 + Carrot=30 + Donut=150 + Eggplant=80 + 123=999 + FalseItem=888 = 2297
-    expect(res.headers['x-sum-price']).to.equal('2297');
+    expect(res.body.sums.Price).to.equal(2297);
   });
 
-  test("X-Sum-Stock header contains sum of all stocks", function() {
+  test("Sums contain sum of all stocks", function() {
     // Apple=50 + Banana=100 + Carrot=200 + Donut=25 + Eggplant=75 + 123=10 + FalseItem=5 = 465
-    expect(res.headers['x-sum-stock']).to.equal('465');
+    expect(res.body.sums.Stock).to.equal(465);
   });
 }

--- a/bruno/query-example/42-sum-with-filter.bru
+++ b/bruno/query-example/42-sum-with-filter.bru
@@ -12,17 +12,17 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
-  test("X-Sum-Price header contains sum of filtered prices only", function() {
+  test("Sums contain sum of filtered prices only", function() {
     // Only Fruit products: Apple=100 + Banana=50 = 150
-    expect(res.headers['x-sum-price']).to.equal('150');
+    expect(res.body.sums.Price).to.equal(150);
   });
 
   test("All returned products are Fruit", function() {
-    expect(res.body.every(p => p.category === 'Fruit')).to.be.true;
+    expect(res.body.data.every(p => p.category === 'Fruit')).to.be.true;
   });
 }

--- a/bruno/query-example/43-sum-with-count.bru
+++ b/bruno/query-example/43-sum-with-count.bru
@@ -12,17 +12,17 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
+  res.body.data: isArray
+  res.body.data: length 2
 }
 
 tests {
-  test("X-Sum-Price header contains sum of ALL prices (not just paginated)", function() {
+  test("Sums contain sum of ALL prices (not just paginated)", function() {
     // Sum should be for all 7 products, not just the 2 returned
-    expect(res.headers['x-sum-price']).to.equal('2297');
+    expect(res.body.sums.Price).to.equal(2297);
   });
 
-  test("X-Total-Count header shows total count", function() {
-    expect(res.headers['x-total-count']).to.equal('7');
+  test("Pagination shows total count", function() {
+    expect(res.body.pagination.total_count).to.equal(7);
   });
 }

--- a/bruno/query-example/44-sum-string-field.bru
+++ b/bruno/query-example/44-sum-string-field.bru
@@ -12,13 +12,13 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-Name header returns database SUM of varchar field", function() {
+  test("Sums return database SUM of varchar field", function() {
     // SQLite coerces numeric-looking text to numbers: "123" → 123, "Apple" → 0
     // Product "123" contributes 123, all others contribute 0 → SUM = 123
-    expect(res.headers['x-sum-name']).to.equal('123');
+    expect(res.body.sums.Name).to.equal(123);
   });
 }

--- a/bruno/query-example/45-sum-bool-field.bru
+++ b/bruno/query-example/45-sum-bool-field.bru
@@ -12,13 +12,13 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-Active header returns count of true values", function() {
+  test("Sums return count of true values for bool field", function() {
     // Bool fields are passed to the database — SUM counts true values (stored as 1)
     // 5 products with active=true, 2 with active=false → SUM = 5
-    expect(res.headers['x-sum-active']).to.equal('5');
+    expect(res.body.sums.Active).to.equal(5);
   });
 }

--- a/bruno/query-example/46-sum-not-allowed-field.bru
+++ b/bruno/query-example/46-sum-not-allowed-field.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-CreatedAt header returns 0 for non-allowed field", function() {
+  test("Sums return 0 for non-allowed field", function() {
     // Field not in SummableFields should return 0 (security - don't reveal field existence)
-    expect(res.headers['x-sum-createdat']).to.equal('0');
+    expect(res.body.sums.CreatedAt).to.equal(0);
   });
 }

--- a/bruno/query-example/47-sum-mixed-valid-invalid.bru
+++ b/bruno/query-example/47-sum-mixed-valid-invalid.bru
@@ -12,16 +12,16 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-Price header contains valid sum", function() {
-    expect(res.headers['x-sum-price']).to.equal('2297');
+  test("Sums contain valid sum for Price", function() {
+    expect(res.body.sums.Price).to.equal(2297);
   });
 
-  test("X-Sum-Name header returns database SUM of varchar field", function() {
+  test("Sums return database SUM of varchar field", function() {
     // SQLite coerces numeric-looking text: "123" → 123, others → 0
-    expect(res.headers['x-sum-name']).to.equal('123');
+    expect(res.body.sums.Name).to.equal(123);
   });
 }

--- a/bruno/query-example/48-sum-nonexistent-field.bru
+++ b/bruno/query-example/48-sum-nonexistent-field.bru
@@ -12,12 +12,12 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
-  test("X-Sum-FakeField header returns 0 for non-existent field", function() {
+  test("Sums return 0 for non-existent field", function() {
     // Non-existent field should return 0 (security - don't reveal field existence)
-    expect(res.headers['x-sum-fakefield']).to.equal('0');
+    expect(res.body.sums.FakeField).to.equal(0);
   });
 }

--- a/bruno/query-example/50-cursor-first-page.bru
+++ b/bruno/query-example/50-cursor-first-page.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Cursor Pagination - First page (limit=3)
+  type: http
+  seq: 50
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.has_more: eq true
+  res.body.pagination.next_cursor: isDefined
+}
+
+tests {
+  test("Returns first 3 products sorted by Name ASC", function() {
+    expect(res.body.data[0].name).to.equal("123");
+    expect(res.body.data[1].name).to.equal("Apple");
+    expect(res.body.data[2].name).to.equal("Banana");
+  });
+
+  test("No prev_cursor on first page", function() {
+    expect(res.body.pagination.prev_cursor).to.be.undefined;
+  });
+}
+
+script:post-response {
+  bru.setVar("cursorPage1Next", res.body.pagination.next_cursor);
+}

--- a/bruno/query-example/51-cursor-second-page.bru
+++ b/bruno/query-example/51-cursor-second-page.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Cursor Pagination - Second page (after cursor)
+  type: http
+  seq: 51
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&after={{cursorPage1Next}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.has_more: eq true
+  res.body.pagination.next_cursor: isDefined
+  res.body.pagination.prev_cursor: isDefined
+}
+
+tests {
+  test("Returns next 3 products", function() {
+    expect(res.body.data[0].name).to.equal("Carrot");
+    expect(res.body.data[1].name).to.equal("Donut");
+    expect(res.body.data[2].name).to.equal("Eggplant");
+  });
+}
+
+script:post-response {
+  bru.setVar("cursorPage2Next", res.body.pagination.next_cursor);
+  bru.setVar("cursorPage2Prev", res.body.pagination.prev_cursor);
+}

--- a/bruno/query-example/52-cursor-last-page.bru
+++ b/bruno/query-example/52-cursor-last-page.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Cursor Pagination - Last page (has_more=false)
+  type: http
+  seq: 52
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&after={{cursorPage2Next}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.pagination.has_more: eq false
+  res.body.pagination.prev_cursor: isDefined
+}
+
+tests {
+  test("Returns last product only", function() {
+    expect(res.body.data[0].name).to.equal("FalseItem");
+  });
+
+  test("No next_cursor on last page", function() {
+    expect(res.body.pagination.next_cursor).to.be.undefined;
+  });
+}
+
+script:post-response {
+  bru.setVar("cursorPage3Prev", res.body.pagination.prev_cursor);
+}

--- a/bruno/query-example/53-cursor-backward.bru
+++ b/bruno/query-example/53-cursor-backward.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Cursor Pagination - Backward (before cursor)
+  type: http
+  seq: 53
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&before={{cursorPage3Prev}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.next_cursor: isDefined
+  res.body.pagination.prev_cursor: isDefined
+}
+
+tests {
+  test("Returns previous page in natural order", function() {
+    expect(res.body.data[0].name).to.equal("Carrot");
+    expect(res.body.data[1].name).to.equal("Donut");
+    expect(res.body.data[2].name).to.equal("Eggplant");
+  });
+}

--- a/bruno/query-example/54-cursor-backward-to-first.bru
+++ b/bruno/query-example/54-cursor-backward-to-first.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Cursor Pagination - Backward to first page
+  type: http
+  seq: 54
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&before={{cursorPage2Prev}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.pagination.next_cursor: isDefined
+}
+
+tests {
+  test("Returns first page items in natural order", function() {
+    expect(res.body.data[0].name).to.equal("123");
+    expect(res.body.data[1].name).to.equal("Apple");
+    expect(res.body.data[2].name).to.equal("Banana");
+  });
+}

--- a/bruno/query-example/55-cursor-with-filter.bru
+++ b/bruno/query-example/55-cursor-with-filter.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Cursor Pagination - With filter (Vegetable, limit=1)
+  type: http
+  seq: 55
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=Vegetable&limit=1
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.pagination.has_more: eq true
+  res.body.pagination.next_cursor: isDefined
+}
+
+tests {
+  test("Returns first vegetable sorted by Name", function() {
+    expect(res.body.data[0].name).to.equal("Carrot");
+    expect(res.body.data[0].category).to.equal("Vegetable");
+  });
+}
+
+script:post-response {
+  bru.setVar("cursorVegNext", res.body.pagination.next_cursor);
+}

--- a/bruno/query-example/56-cursor-with-filter-next.bru
+++ b/bruno/query-example/56-cursor-with-filter-next.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Cursor Pagination - Filter second page
+  type: http
+  seq: 56
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=Vegetable&limit=1&after={{cursorVegNext}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.pagination.has_more: eq false
+}
+
+tests {
+  test("Returns second vegetable", function() {
+    expect(res.body.data[0].name).to.equal("Eggplant");
+    expect(res.body.data[0].category).to.equal("Vegetable");
+  });
+
+  test("No more pages", function() {
+    expect(res.body.pagination.next_cursor).to.be.undefined;
+  });
+}

--- a/bruno/query-example/57-cursor-with-sort-desc.bru
+++ b/bruno/query-example/57-cursor-with-sort-desc.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Cursor Pagination - Sort by Price DESC
+  type: http
+  seq: 57
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&sort=-Price
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.has_more: eq true
+  res.body.pagination.next_cursor: isDefined
+}
+
+tests {
+  test("Returns products sorted by price descending", function() {
+    expect(res.body.data[0].name).to.equal("123");
+    expect(res.body.data[0].price).to.equal(999);
+    expect(res.body.data[1].name).to.equal("FalseItem");
+    expect(res.body.data[1].price).to.equal(888);
+    expect(res.body.data[2].name).to.equal("Donut");
+    expect(res.body.data[2].price).to.equal(150);
+  });
+}
+
+script:post-response {
+  bru.setVar("cursorPriceDescNext", res.body.pagination.next_cursor);
+}

--- a/bruno/query-example/58-cursor-sort-desc-next.bru
+++ b/bruno/query-example/58-cursor-sort-desc-next.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Cursor Pagination - Sort DESC second page
+  type: http
+  seq: 58
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&sort=-Price&after={{cursorPriceDescNext}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.has_more: eq true
+}
+
+tests {
+  test("Continues price descending sort from cursor", function() {
+    expect(res.body.data[0].name).to.equal("Apple");
+    expect(res.body.data[0].price).to.equal(100);
+    expect(res.body.data[1].name).to.equal("Eggplant");
+    expect(res.body.data[1].price).to.equal(80);
+    expect(res.body.data[2].name).to.equal("Banana");
+    expect(res.body.data[2].price).to.equal(50);
+  });
+}

--- a/bruno/query-example/59-cursor-with-count.bru
+++ b/bruno/query-example/59-cursor-with-count.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Cursor Pagination - With count=true
+  type: http
+  seq: 59
+}
+
+get {
+  url: {{baseUrl}}/products?limit=3&count=true
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.pagination.has_more: eq true
+  res.body.pagination.total_count: eq 7
+  res.body.pagination.next_cursor: isDefined
+}
+
+tests {
+  test("Count reflects total items, not page size", function() {
+    expect(res.body.pagination.total_count).to.equal(7);
+    expect(res.body.data).to.have.length(3);
+  });
+}

--- a/bruno/query-example/60-cursor-invalid.bru
+++ b/bruno/query-example/60-cursor-invalid.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Cursor Pagination - Invalid cursor string
+  type: http
+  seq: 60
+}
+
+get {
+  url: {{baseUrl}}/products?after=not-a-valid-cursor
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 500
+  res.body.error: eq internal_error
+}

--- a/bruno/query-example/61-cursor-with-sum.bru
+++ b/bruno/query-example/61-cursor-with-sum.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Cursor Pagination - With sum aggregation
+  type: http
+  seq: 61
+}
+
+get {
+  url: {{baseUrl}}/products?limit=2&sum=Price&count=true
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 2
+  res.body.pagination.has_more: eq true
+  res.body.pagination.total_count: eq 7
+}
+
+tests {
+  test("Sum reflects all items, not just current page", function() {
+    expect(res.body.sums.Price).to.equal(2297);
+  });
+
+  test("Cursor pagination fields present", function() {
+    expect(res.body.pagination.next_cursor).to.be.a("string");
+    expect(res.body.pagination.has_more).to.be.true;
+  });
+}

--- a/bruno/query-example/62-cursor-empty-result.bru
+++ b/bruno/query-example/62-cursor-empty-result.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Cursor Pagination - Empty result set
+  type: http
+  seq: 62
+}
+
+get {
+  url: {{baseUrl}}/products?filter[Category]=NonExistent&limit=3
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 0
+}
+
+tests {
+  test("Empty result has correct pagination", function() {
+    expect(res.body.pagination.has_more).to.be.false;
+    expect(res.body.pagination.next_cursor).to.be.undefined;
+    expect(res.body.pagination.prev_cursor).to.be.undefined;
+  });
+}

--- a/bruno/simple-example/03-get-all-users.bru
+++ b/bruno/simple-example/03-get-all-users.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
+  res.body.data: isArray
+  res.body.data: length 1
 }

--- a/bruno/simple-example/10-filter-by-name.bru
+++ b/bruno/simple-example/10-filter-by-name.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Bob Smith
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Bob Smith
 }

--- a/bruno/simple-example/11-filter-by-email.bru
+++ b/bruno/simple-example/11-filter-by-email.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].email: eq bob@example.com
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].email: eq bob@example.com
 }

--- a/bruno/simple-example/12-sort-by-name-asc.bru
+++ b/bruno/simple-example/12-sort-by-name-asc.bru
@@ -12,8 +12,8 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
-  res.body[0].name: eq Bob Smith
-  res.body[1].name: eq Charlie Brown
+  res.body.data: isArray
+  res.body.data: length 2
+  res.body.data[0].name: eq Bob Smith
+  res.body.data[1].name: eq Charlie Brown
 }

--- a/bruno/simple-example/13-sort-by-name-desc.bru
+++ b/bruno/simple-example/13-sort-by-name-desc.bru
@@ -12,8 +12,8 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 2
-  res.body[0].name: eq Charlie Brown
-  res.body[1].name: eq Bob Smith
+  res.body.data: isArray
+  res.body.data: length 2
+  res.body.data[0].name: eq Charlie Brown
+  res.body.data[1].name: eq Bob Smith
 }

--- a/bruno/simple-example/14-pagination-limit.bru
+++ b/bruno/simple-example/14-pagination-limit.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Bob Smith
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Bob Smith
 }

--- a/bruno/simple-example/15-pagination-offset.bru
+++ b/bruno/simple-example/15-pagination-offset.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Charlie Brown
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Charlie Brown
 }

--- a/bruno/simple-example/16-count-total.bru
+++ b/bruno/simple-example/16-count-total.bru
@@ -12,6 +12,6 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
+  res.body.data: isArray
+  res.body.data: length 1
 }

--- a/bruno/simple-example/17-combined-filter-sort-pagination.bru
+++ b/bruno/simple-example/17-combined-filter-sort-pagination.bru
@@ -12,7 +12,7 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
-  res.body: length 1
-  res.body[0].name: eq Bob Smith
+  res.body.data: isArray
+  res.body.data: length 1
+  res.body.data[0].name: eq Bob Smith
 }

--- a/bruno/tenant-example/02-iconcolors-global-no-auth.bru
+++ b/bruno/tenant-example/02-iconcolors-global-no-auth.bru
@@ -12,13 +12,13 @@ get {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Global route returns seeded icon colors without auth", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(3);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(3);
   });
 }
 

--- a/bruno/tenant-example/07-org-list-own-only.bru
+++ b/bruno/tenant-example/07-org-list-own-only.bru
@@ -16,15 +16,15 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("IsTenantTable list shows only own org", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(1);
-    expect(res.body[0].id).to.equal("org-a");
-    expect(res.body[0].name).to.equal("Acme Corp");
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(1);
+    expect(res.body.data[0].id).to.equal("org-a");
+    expect(res.body.data[0].name).to.equal("Acme Corp");
   });
 }
 

--- a/bruno/tenant-example/11-projects-list-tenant-ownership.bru
+++ b/bruno/tenant-example/11-projects-list-tenant-ownership.bru
@@ -16,16 +16,16 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice sees only her own project in org-a (tenant + ownership)", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(1);
-    expect(res.body[0].name).to.equal("Alpha Project");
-    expect(res.body[0].org_id).to.equal("org-a");
-    expect(res.body[0].owner_id).to.equal("alice");
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(1);
+    expect(res.body.data[0].name).to.equal("Alpha Project");
+    expect(res.body.data[0].org_id).to.equal("org-a");
+    expect(res.body.data[0].owner_id).to.equal("alice");
   });
 }
 

--- a/bruno/tenant-example/12-projects-list-admin-same-tenant.bru
+++ b/bruno/tenant-example/12-projects-list-admin-same-tenant.bru
@@ -16,14 +16,14 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Admin sees all projects in same tenant", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(2);
-    expect(res.body.every(p => p.org_id === "org-a")).to.be.true;
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(2);
+    expect(res.body.data.every(p => p.org_id === "org-a")).to.be.true;
   });
 }
 

--- a/bruno/tenant-example/13-projects-list-cross-tenant.bru
+++ b/bruno/tenant-example/13-projects-list-cross-tenant.bru
@@ -16,15 +16,15 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Charlie sees only org-b projects, not org-a", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(1);
-    expect(res.body[0].name).to.equal("Gamma Project");
-    expect(res.body[0].org_id).to.equal("org-b");
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(1);
+    expect(res.body.data[0].name).to.equal("Gamma Project");
+    expect(res.body.data[0].org_id).to.equal("org-b");
   });
 }
 

--- a/bruno/tenant-example/19-tasks-list-own-tenant.bru
+++ b/bruno/tenant-example/19-tasks-list-own-tenant.bru
@@ -16,14 +16,14 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Alice sees tasks under her project", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(1);
-    expect(res.body[0].title).to.equal("Implement feature X");
-    expect(res.body[0].org_id).to.equal("org-a");
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(1);
+    expect(res.body.data[0].title).to.equal("Implement feature X");
+    expect(res.body.data[0].org_id).to.equal("org-a");
   });
 }

--- a/bruno/tenant-example/21-task-cross-tenant-list-empty.bru
+++ b/bruno/tenant-example/21-task-cross-tenant-list-empty.bru
@@ -20,8 +20,8 @@ assert {
 
 tests {
   test("Cross-tenant task list returns empty array", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(0);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(0);
   });
 }
 

--- a/bruno/tenant-example/29-iconcolors-with-auth.bru
+++ b/bruno/tenant-example/29-iconcolors-with-auth.bru
@@ -16,13 +16,13 @@ auth:bearer {
 
 assert {
   res.status: eq 200
-  res.body: isArray
+  res.body.data: isArray
 }
 
 tests {
   test("Global route unaffected by tenant auth - all colors visible", function() {
-    expect(res.body).to.be.an('array');
-    expect(res.body.length).to.equal(3);
+    expect(res.body.data).to.be.an('array');
+    expect(res.body.data.length).to.equal(3);
   });
 }
 

--- a/bruno/uuid-example/03-list-blogs.bru
+++ b/bruno/uuid-example/03-list-blogs.bru
@@ -12,5 +12,5 @@ get {
 
 assert {
   res.status: eq 200
-  res.body.length: gte 1
+  res.body.data.length: gte 1
 }

--- a/bruno/uuid-example/06-list-posts.bru
+++ b/bruno/uuid-example/06-list-posts.bru
@@ -12,5 +12,5 @@ get {
 
 assert {
   res.status: eq 200
-  res.body.length: eq 1
+  res.body.data.length: eq 1
 }

--- a/cmd/install-skill/cursor/go-restgen.mdc
+++ b/cmd/install-skill/cursor/go-restgen.mdc
@@ -152,7 +152,8 @@ router.RegisterRoutes[Model](builder, "/path",
     // Query options (individual)
     router.WithFilters("Status", "Name"),
     router.WithSorts("Name", "CreatedAt"),
-    router.WithPagination(20, 100),
+    router.WithPagination(20, 100),                // cursor-based (default)
+    router.WithPagination(20, 100, router.OffsetMode), // offset-based (opt-in)
     router.WithDefaultSort("-CreatedAt"),
     router.WithSums("Price", "Stock"),
 
@@ -164,6 +165,7 @@ router.RegisterRoutes[Model](builder, "/path",
         DefaultSort:      "-CreatedAt",
         DefaultLimit:     20,
         MaxLimit:         100,
+        Pagination:       router.CursorMode, // default; use router.OffsetMode for offset-based
     }),
 
     // Relations
@@ -237,7 +239,7 @@ type CustomGetAllFunc[T any] func(
     svc *service.Common[T],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*T, int, map[string]float64, error)
+) ([]*T, int, map[string]float64, *metadata.CursorInfo, error)
 
 // POST /resource
 type CustomCreateFunc[T any] func(
@@ -419,11 +421,17 @@ router.WithAudit(func(ac metadata.AuditContext[T]) any {
 | Filter | `?filter[Status]=active` | Exact match |
 | Filter ops | `?filter[Age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
 | Sort | `?sort=Name,-CreatedAt` | `-` prefix for descending |
-| Limit | `?limit=10` | Max results |
-| Offset | `?offset=20` | Skip results |
-| Count | `?count=true` | X-Total-Count header |
+| Limit | `?limit=10` | Max results per page |
+| After | `?after=<cursor>` | Next page (cursor from `pagination.next_cursor`) |
+| Before | `?before=<cursor>` | Previous page (cursor from `pagination.prev_cursor`) |
+| Offset | `?offset=20` | Skip results (switches to offset pagination) |
+| Count | `?count=true` | Include `total_count` in `pagination` |
 | Include | `?include=Posts.Comments` | Load relations (dot notation for nested) |
-| Sum | `?sum=Price,Stock` | X-Sum-Price, X-Sum-Stock headers |
+| Sum | `?sum=Price,Stock` | Returns in `sums` object in response body |
+
+**Response envelope (GetAll):** `{"data": [...], "pagination": {...}, "sums": {...}}`.
+Cursor mode: `has_more`, `next_cursor`, `prev_cursor`, `total_count`. Offset mode: `limit`, `offset`, `total_count`.
+Batch responses: `{"data": [...]}`. Single-item responses: raw object (no envelope).
 
 **Nested includes:** child direction needs `WithRelationName` at each level. Parent direction (e.g., `?include=Author`) auto-derived from `rel:belongs-to` tags. Auth is cumulative AND, ownership is cumulative OR.
 

--- a/cmd/install-skill/skill/SKILL.md
+++ b/cmd/install-skill/skill/SKILL.md
@@ -49,7 +49,7 @@ router.RegisterRoutes[Product](b, "/products",
     router.AllPublic(),
     router.WithFilters("Name", "Price"),
     router.WithSorts("Name", "Price", "CreatedAt"),
-    router.WithPagination(20, 100),
+    router.WithPagination(20, 100),  // cursor-based pagination (default)
 )
 ```
 

--- a/cmd/install-skill/skill/patterns.md
+++ b/cmd/install-skill/skill/patterns.md
@@ -30,7 +30,8 @@ router.RegisterRoutes[Model](builder, "/path",
     // Query options (individual)
     router.WithFilters("Status", "Name"),
     router.WithSorts("Name", "CreatedAt"),
-    router.WithPagination(20, 100),
+    router.WithPagination(20, 100),                // cursor-based (default)
+    router.WithPagination(20, 100, router.OffsetMode), // offset-based (opt-in)
     router.WithDefaultSort("-CreatedAt"),
     router.WithSums("Price", "Stock"),
 
@@ -42,6 +43,7 @@ router.RegisterRoutes[Model](builder, "/path",
         DefaultSort:      "-CreatedAt",
         DefaultLimit:     20,
         MaxLimit:         100,
+        Pagination:       router.CursorMode, // default; use router.OffsetMode for offset-based
     }),
 
     // Relations
@@ -115,7 +117,7 @@ type CustomGetAllFunc[T any] func(
     svc *service.Common[T],
     meta *metadata.TypeMetadata,
     auth *metadata.AuthInfo,
-) ([]*T, int, map[string]float64, error)
+) ([]*T, int, map[string]float64, *metadata.CursorInfo, error)
 
 // POST /resource
 type CustomCreateFunc[T any] func(
@@ -297,11 +299,17 @@ router.WithAudit(func(ac metadata.AuditContext[T]) any {
 | Filter | `?filter[Status]=active` | Exact match |
 | Filter ops | `?filter[Age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
 | Sort | `?sort=Name,-CreatedAt` | `-` prefix for descending |
-| Limit | `?limit=10` | Max results |
-| Offset | `?offset=20` | Skip results |
-| Count | `?count=true` | X-Total-Count header |
+| Limit | `?limit=10` | Max results per page |
+| After | `?after=<cursor>` | Next page (cursor from `pagination.next_cursor`) |
+| Before | `?before=<cursor>` | Previous page (cursor from `pagination.prev_cursor`) |
+| Offset | `?offset=20` | Skip results (switches to offset pagination) |
+| Count | `?count=true` | Include `total_count` in `pagination` |
 | Include | `?include=Posts.Comments` | Load relations (dot notation for nested) |
-| Sum | `?sum=Price,Stock` | X-Sum-Price, X-Sum-Stock headers |
+| Sum | `?sum=Price,Stock` | Returns in `sums` object in response body |
+
+**Response envelope (GetAll):** `{"data": [...], "pagination": {...}, "sums": {...}}`.
+Cursor mode: `has_more`, `next_cursor`, `prev_cursor`, `total_count`. Offset mode: `limit`, `offset`, `total_count`.
+Batch responses: `{"data": [...]}`. Single-item responses: raw object (no envelope).
 
 **Nested includes:** child direction needs `WithRelationName` at each level. Parent direction (e.g., `?include=Author`) auto-derived from `rel:belongs-to` tags. Auth is cumulative AND, ownership is cumulative OR.
 

--- a/datastore/nested_test.go
+++ b/datastore/nested_test.go
@@ -219,7 +219,7 @@ func TestWrapper_Nested_GetAll(t *testing.T) {
 	ctx1 = context.WithValue(ctx1, metadata.ParentIDsKey, map[string]string{
 		"authorId": itoa(author1.ID),
 	})
-	articles1, _, _, err := articleWrapper.GetAll(ctx1)
+	articles1, _, _, _, err := articleWrapper.GetAll(ctx1)
 	if err != nil {
 		t.Fatal("Failed to get articles for author1:", err)
 	}
@@ -232,7 +232,7 @@ func TestWrapper_Nested_GetAll(t *testing.T) {
 	ctx2 = context.WithValue(ctx2, metadata.ParentIDsKey, map[string]string{
 		"authorId": itoa(author2.ID),
 	})
-	articles2, _, _, err := articleWrapper.GetAll(ctx2)
+	articles2, _, _, _, err := articleWrapper.GetAll(ctx2)
 	if err != nil {
 		t.Fatal("Failed to get articles for author2:", err)
 	}
@@ -504,7 +504,7 @@ func TestCustomJoin_ListFiltersByParentJoinCol(t *testing.T) {
 	ctxList = context.WithValue(ctxList, metadata.ParentIDsKey, map[string]string{
 		"siteId": itoa(site.ID),
 	})
-	results, _, _, err := usageWrapper.GetAll(ctxList)
+	results, _, _, _, err := usageWrapper.GetAll(ctxList)
 	if err != nil {
 		t.Fatal("Failed to list usage data:", err)
 	}
@@ -608,7 +608,7 @@ func TestCustomJoin_MultipleParentsShareJoinCol(t *testing.T) {
 	ctxSite1 = context.WithValue(ctxSite1, metadata.ParentIDsKey, map[string]string{
 		"siteId": itoa(site1.ID),
 	})
-	results1, _, _, err := usageWrapper.GetAll(ctxSite1)
+	results1, _, _, _, err := usageWrapper.GetAll(ctxSite1)
 	if err != nil {
 		t.Fatal("Failed to list usage data for site1:", err)
 	}
@@ -617,7 +617,7 @@ func TestCustomJoin_MultipleParentsShareJoinCol(t *testing.T) {
 	ctxSite2 = context.WithValue(ctxSite2, metadata.ParentIDsKey, map[string]string{
 		"siteId": itoa(site2.ID),
 	})
-	results2, _, _, err := usageWrapper.GetAll(ctxSite2)
+	results2, _, _, _, err := usageWrapper.GetAll(ctxSite2)
 	if err != nil {
 		t.Fatal("Failed to list usage data for site2:", err)
 	}

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -120,7 +120,7 @@ func TestQuery_Filter_Eq(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -152,7 +152,7 @@ func TestQuery_Filter_Gt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -184,7 +184,7 @@ func TestQuery_Filter_Like(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -210,7 +210,7 @@ func TestQuery_Filter_NotAllowed(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -246,7 +246,7 @@ func TestQuery_Sort_Direction(t *testing.T) {
 			}
 			ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-			results, _, _, err := wrapper.GetAll(ctx)
+			results, _, _, _, err := wrapper.GetAll(ctx)
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -285,7 +285,7 @@ func TestQuery_Pagination_Limit(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -312,7 +312,7 @@ func TestQuery_Pagination_Offset(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -346,7 +346,7 @@ func TestQuery_Pagination_LimitAndOffset(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -379,7 +379,7 @@ func TestQuery_Count(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, _, err := wrapper.GetAll(ctx)
+	results, count, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -411,7 +411,7 @@ func TestQuery_CountWithFilter(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, _, err := wrapper.GetAll(ctx)
+	results, count, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -440,7 +440,7 @@ func TestQuery_MaxLimitEnforced(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -473,7 +473,7 @@ func TestQuery_DefaultLimit(t *testing.T) {
 	}
 
 	// No explicit limit - should use DefaultLimit (10)
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -505,7 +505,7 @@ func TestQuery_CombinedFilterSortPagination(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, _, err := wrapper.GetAll(ctx)
+	results, count, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -542,7 +542,7 @@ func TestQuery_Sort_InvalidField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -597,7 +597,7 @@ func TestQuery_DefaultSort_Direction(t *testing.T) {
 			seedQueryProducts(t, wrapper, ctx)
 
 			// No explicit sort - should use DefaultSort
-			results, _, _, err := wrapper.GetAll(ctx)
+			results, _, _, _, err := wrapper.GetAll(ctx)
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -633,7 +633,7 @@ func TestQuery_MultipleSort(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -645,6 +645,155 @@ func TestQuery_MultipleSort(t *testing.T) {
 	// First sort by name should put Apple first
 	if results[0].Name != productApple {
 		t.Errorf("Expected first result to be %s, got %s", productApple, results[0].Name)
+	}
+}
+
+func TestQuery_PKTieBreaker_DeterministicOrder(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	meta := &metadata.TypeMetadata{
+		TypeID:         "pk_tiebreaker_test",
+		TypeName:       "TestQueryProduct",
+		TableName:      "query_products",
+		URLParamUUID:   "productId",
+		ModelType:      reflect.TypeOf(TestQueryProduct{}),
+		PKField:        "ID",
+		SortableFields: []string{"Price"},
+		DefaultLimit:   10,
+		MaxLimit:       100,
+	}
+	ctx := ctxWithQueryMeta(meta)
+
+	// Seed products with identical prices to test tie-breaking
+	products := []TestQueryProduct{
+		{Name: "Zed", Category: "Test", Price: 50, InStock: true},
+		{Name: "Alpha", Category: "Test", Price: 50, InStock: true},
+		{Name: "Mike", Category: "Test", Price: 50, InStock: true},
+	}
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed product:", err)
+		}
+	}
+
+	opts := &metadata.QueryOptions{
+		Sort: []metadata.SortField{
+			{Field: "Price", Desc: false},
+		},
+	}
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	results, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	// All have the same price, so PK tie-breaker should order by ID ascending
+	for i := 1; i < len(results); i++ {
+		if results[i].ID <= results[i-1].ID {
+			t.Errorf("Expected ascending ID order as tie-breaker: ID %d came after ID %d", results[i].ID, results[i-1].ID)
+		}
+	}
+}
+
+func TestQuery_PKTieBreaker_DefaultSort(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	meta := &metadata.TypeMetadata{
+		TypeID:         "pk_tiebreaker_default_sort",
+		TypeName:       "TestQueryProduct",
+		TableName:      "query_products",
+		URLParamUUID:   "productId",
+		ModelType:      reflect.TypeOf(TestQueryProduct{}),
+		PKField:        "ID",
+		SortableFields: []string{"Price"},
+		DefaultSort:    "Price",
+		DefaultLimit:   10,
+		MaxLimit:       100,
+	}
+	ctx := ctxWithQueryMeta(meta)
+
+	// Seed products with identical prices
+	products := []TestQueryProduct{
+		{Name: "Third", Category: "Test", Price: 100, InStock: true},
+		{Name: "First", Category: "Test", Price: 100, InStock: true},
+		{Name: "Second", Category: "Test", Price: 100, InStock: true},
+	}
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed product:", err)
+		}
+	}
+
+	// No explicit sort — should use DefaultSort + PK tie-breaker
+	results, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	for i := 1; i < len(results); i++ {
+		if results[i].ID <= results[i-1].ID {
+			t.Errorf("Expected ascending ID order as tie-breaker with default sort: ID %d came after ID %d", results[i].ID, results[i-1].ID)
+		}
+	}
+}
+
+func TestQuery_PKTieBreaker_NoPagination(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	meta := &metadata.TypeMetadata{
+		TypeID:       "pk_tiebreaker_no_pagination",
+		TypeName:     "TestQueryProduct",
+		TableName:    "query_products",
+		URLParamUUID: "productId",
+		ModelType:    reflect.TypeOf(TestQueryProduct{}),
+		PKField:      "ID",
+		// No pagination, no sort, no sortable fields
+	}
+	ctx := ctxWithQueryMeta(meta)
+
+	products := []TestQueryProduct{
+		{Name: "C", Category: "Test", Price: 1, InStock: true},
+		{Name: "A", Category: "Test", Price: 1, InStock: true},
+		{Name: "B", Category: "Test", Price: 1, InStock: true},
+	}
+	for _, p := range products {
+		_, err := wrapper.Create(ctx, p)
+		if err != nil {
+			t.Fatal("Failed to seed product:", err)
+		}
+	}
+
+	// No sort at all — PK tie-breaker should still apply for deterministic results
+	results, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	for i := 1; i < len(results); i++ {
+		if results[i].ID <= results[i-1].ID {
+			t.Errorf("Expected ascending ID order when no sort specified: ID %d came after ID %d", results[i].ID, results[i-1].ID)
+		}
 	}
 }
 
@@ -664,7 +813,7 @@ func TestQuery_Filter_Neq(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -696,7 +845,7 @@ func TestQuery_Filter_Gte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -728,7 +877,7 @@ func TestQuery_Filter_Lt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -760,7 +909,7 @@ func TestQuery_Filter_Lte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -776,7 +925,7 @@ func TestQuery_Filter_Lte(t *testing.T) {
 	}
 }
 
-func TestQuery_Filter_In(t *testing.T) {
+func TestQuery_Filter_InNin(t *testing.T) {
 	db, cleanup := setupQueryTestDB(t)
 	defer cleanup()
 
@@ -784,60 +933,53 @@ func TestQuery_Filter_In(t *testing.T) {
 	ctx := ctxWithQueryMeta(testQueryProductMeta)
 	seedQueryProducts(t, wrapper, ctx)
 
-	// Filter by category IN (Fruit, Bakery)
-	opts := &metadata.QueryOptions{
-		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpIn},
-		},
-	}
-	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
-
-	results, _, _, err := wrapper.GetAll(ctx)
-	if err != nil {
-		t.Fatal("GetAll failed:", err)
-	}
-
-	if len(results) != 3 {
-		t.Errorf("Expected 3 products with category IN (Fruit, Bakery), got %d", len(results))
-	}
-
-	for _, p := range results {
-		if p.Category != categoryFruit && p.Category != categoryBakery {
-			t.Errorf("Expected category Fruit or Bakery, got %s", p.Category)
+	t.Run("IN", func(t *testing.T) {
+		opts := &metadata.QueryOptions{
+			Filters: map[string]metadata.FilterValue{
+				"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpIn},
+			},
 		}
-	}
-}
+		inCtx := context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-func TestQuery_Filter_Nin(t *testing.T) {
-	db, cleanup := setupQueryTestDB(t)
-	defer cleanup()
-
-	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
-	ctx := ctxWithQueryMeta(testQueryProductMeta)
-	seedQueryProducts(t, wrapper, ctx)
-
-	// Filter by category NOT IN (Fruit, Bakery)
-	opts := &metadata.QueryOptions{
-		Filters: map[string]metadata.FilterValue{
-			"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpNin},
-		},
-	}
-	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
-
-	results, _, _, err := wrapper.GetAll(ctx)
-	if err != nil {
-		t.Fatal("GetAll failed:", err)
-	}
-
-	if len(results) != 2 {
-		t.Errorf("Expected 2 products with category NOT IN (Fruit, Bakery), got %d", len(results))
-	}
-
-	for _, p := range results {
-		if p.Category == categoryFruit || p.Category == categoryBakery {
-			t.Errorf("Expected category NOT Fruit or Bakery, got %s", p.Category)
+		results, _, _, _, err := wrapper.GetAll(inCtx)
+		if err != nil {
+			t.Fatal("GetAll failed:", err)
 		}
-	}
+
+		if len(results) != 3 {
+			t.Errorf("Expected 3 products with category IN (Fruit, Bakery), got %d", len(results))
+		}
+
+		for _, p := range results {
+			if p.Category != categoryFruit && p.Category != categoryBakery {
+				t.Errorf("Expected category Fruit or Bakery, got %s", p.Category)
+			}
+		}
+	})
+
+	t.Run("NIN", func(t *testing.T) {
+		opts := &metadata.QueryOptions{
+			Filters: map[string]metadata.FilterValue{
+				"Category": {Value: categoryFruit + "," + categoryBakery, Operator: metadata.OpNin},
+			},
+		}
+		ninCtx := context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+		results, _, _, _, err := wrapper.GetAll(ninCtx)
+		if err != nil {
+			t.Fatal("GetAll failed:", err)
+		}
+
+		if len(results) != 2 {
+			t.Errorf("Expected 2 products with category NOT IN (Fruit, Bakery), got %d", len(results))
+		}
+
+		for _, p := range results {
+			if p.Category == categoryFruit || p.Category == categoryBakery {
+				t.Errorf("Expected category NOT Fruit or Bakery, got %s", p.Category)
+			}
+		}
+	})
 }
 
 func TestQuery_Filter_Bt(t *testing.T) {
@@ -856,7 +998,7 @@ func TestQuery_Filter_Bt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -889,7 +1031,7 @@ func TestQuery_Filter_Nbt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -922,7 +1064,7 @@ func TestQuery_Filter_Bool_True(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -955,7 +1097,7 @@ func TestQuery_Filter_Bool_False(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1006,7 +1148,7 @@ func TestQuery_Filter_Int_StringValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1039,7 +1181,7 @@ func TestQuery_Filter_String_NumericLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1069,7 +1211,7 @@ func TestQuery_Filter_String_TrueLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1099,7 +1241,7 @@ func TestQuery_Filter_String_FalseLookingValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1129,7 +1271,7 @@ func TestQuery_Filter_Bool_OneValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1162,7 +1304,7 @@ func TestQuery_Filter_Int_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1191,7 +1333,7 @@ func TestQuery_Filter_Bt_SingleValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1261,7 +1403,7 @@ func TestQuery_Filter_Float_Gt(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1288,7 +1430,7 @@ func TestQuery_Filter_Float_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1315,7 +1457,7 @@ func TestQuery_Filter_Uint_Gte(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1342,7 +1484,7 @@ func TestQuery_Filter_Uint_InvalidValue(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1369,7 +1511,7 @@ func TestQuery_Filter_Float_Between(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1410,7 +1552,7 @@ func TestQuery_Filter_Bt_UnknownField(t *testing.T) {
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
 	// This will fail to find the column name, but tests the code path
-	results, _, _, err := wrapper.GetAll(ctx)
+	results, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		// Expected - field doesn't exist
 		return
@@ -1450,7 +1592,7 @@ func TestQuery_Sum_SingleField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1476,7 +1618,7 @@ func TestQuery_Sum_MultipleFields(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1509,7 +1651,7 @@ func TestQuery_Sum_WithFilter(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1537,7 +1679,7 @@ func TestQuery_Sum_WithCount(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, sums, err := wrapper.GetAll(ctx)
+	results, count, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1574,7 +1716,7 @@ func TestQuery_Sum_VarcharField_NoPanic(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		// Database error is acceptable (PostgreSQL rejects SUM on text)
 		return
@@ -1600,7 +1742,7 @@ func TestQuery_Sum_BoolField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1626,7 +1768,7 @@ func TestQuery_Sum_FieldNotInAllowlist(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1651,7 +1793,7 @@ func TestQuery_Sum_NonExistentField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1676,7 +1818,7 @@ func TestQuery_Sum_MixedValidAndInvalid(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1703,7 +1845,7 @@ func TestQuery_Sum_NoSumsRequested(t *testing.T) {
 	opts := &metadata.QueryOptions{}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1773,7 +1915,7 @@ func TestQuery_Sum_DecimalField(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1798,7 +1940,7 @@ func TestQuery_Sum_MultipleDecimalFields(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1831,7 +1973,7 @@ func TestQuery_Sum_DecimalField_WithFilter(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	_, _, sums, err := wrapper.GetAll(ctx)
+	_, _, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1858,7 +2000,7 @@ func TestQuery_Sum_DecimalField_WithCount(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	results, count, sums, err := wrapper.GetAll(ctx)
+	results, count, sums, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -1875,5 +2017,559 @@ func TestQuery_Sum_DecimalField_WithCount(t *testing.T) {
 	expectedSum := 378.44
 	if sums["UnitPrice"] != expectedSum {
 		t.Errorf("Expected sum of UnitPrice to be %v, got %v", expectedSum, sums["UnitPrice"])
+	}
+}
+
+// Cursor pagination metadata — uses CursorPagination mode with limits
+var testCursorProductMeta = &metadata.TypeMetadata{
+	TypeID:           "cursor_product_id",
+	TypeName:         "TestQueryProduct",
+	TableName:        "query_products",
+	URLParamUUID:     "productId",
+	PKField:          "ID",
+	ModelType:        reflect.TypeOf(TestQueryProduct{}),
+	FilterableFields: []string{"Name", "Category", "Price", "InStock"},
+	SortableFields:   []string{"Name", "Price", "CreatedAt"},
+	DefaultLimit:     2,
+	MaxLimit:         100,
+	Pagination:       metadata.CursorPagination,
+}
+
+func TestCursor_ForwardPagination_FirstPage(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("Expected 2 items, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info")
+	}
+	if !cursorInfo.HasMore {
+		t.Error("Expected has_more=true on first page")
+	}
+	if cursorInfo.NextCursor == "" {
+		t.Error("Expected next_cursor on first page")
+	}
+	if cursorInfo.PrevCursor != "" {
+		t.Error("Expected no prev_cursor on first page (no after/before param)")
+	}
+}
+
+func TestCursor_ForwardPagination_SecondPage(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Get first page
+	items1, _, _, cursor1, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("First page failed:", err)
+	}
+	if cursor1 == nil || cursor1.NextCursor == "" {
+		t.Fatal("Expected next_cursor from first page")
+	}
+
+	// Get second page using after cursor
+	opts := &metadata.QueryOptions{After: cursor1.NextCursor}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	items2, _, _, cursor2, err := wrapper.GetAll(ctx2)
+	if err != nil {
+		t.Fatal("Second page failed:", err)
+	}
+
+	if len(items2) != 2 {
+		t.Fatalf("Expected 2 items on second page, got %d", len(items2))
+	}
+	if cursor2 == nil {
+		t.Fatal("Expected cursor info on second page")
+	}
+	if cursor2.PrevCursor == "" {
+		t.Error("Expected prev_cursor on second page")
+	}
+
+	// Items should not overlap
+	for _, i1 := range items1 {
+		for _, i2 := range items2 {
+			if i1.ID == i2.ID {
+				t.Errorf("Overlapping item ID=%d between pages", i1.ID)
+			}
+		}
+	}
+}
+
+func TestCursor_ForwardPagination_LastPage(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Paginate through all pages
+	var allItems []*TestQueryProduct
+	var afterCursor string
+	for {
+		opts := &metadata.QueryOptions{}
+		if afterCursor != "" {
+			opts.After = afterCursor
+		}
+		pageCtx := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+		items, _, _, cursorInfo, err := wrapper.GetAll(pageCtx)
+		if err != nil {
+			t.Fatal("GetAll failed:", err)
+		}
+		allItems = append(allItems, items...)
+
+		if cursorInfo == nil || !cursorInfo.HasMore {
+			// Last page
+			if cursorInfo != nil && cursorInfo.NextCursor != "" {
+				t.Error("Expected no next_cursor on last page when has_more=false")
+			}
+			break
+		}
+		afterCursor = cursorInfo.NextCursor
+	}
+
+	if len(allItems) != 5 {
+		t.Errorf("Expected 5 total items across all pages, got %d", len(allItems))
+	}
+}
+
+func TestCursor_BackwardPagination(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Get first two pages forward
+	items1, _, _, cursor1, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("First page failed:", err)
+	}
+
+	opts2 := &metadata.QueryOptions{After: cursor1.NextCursor}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts2)
+	items2, _, _, cursor2, err := wrapper.GetAll(ctx2)
+	if err != nil {
+		t.Fatal("Second page failed:", err)
+	}
+
+	// Go backward from second page using prev_cursor
+	opts3 := &metadata.QueryOptions{Before: cursor2.PrevCursor}
+	ctx3 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts3)
+	itemsBack, _, _, _, err := wrapper.GetAll(ctx3)
+	if err != nil {
+		t.Fatal("Backward page failed:", err)
+	}
+
+	// Backward page should return items before the second page
+	if len(itemsBack) == 0 {
+		t.Fatal("Expected items from backward pagination")
+	}
+
+	// Items should be in natural (ascending) order after reversal
+	for i := 1; i < len(itemsBack); i++ {
+		if itemsBack[i].ID < itemsBack[i-1].ID {
+			t.Errorf("Backward results not in ascending order: ID %d before %d", itemsBack[i-1].ID, itemsBack[i].ID)
+		}
+	}
+
+	// Backward items should overlap with first page (going back from page 2 start)
+	backIDs := map[int]bool{}
+	for _, item := range itemsBack {
+		backIDs[item.ID] = true
+	}
+	overlapCount := 0
+	for _, item := range items1 {
+		if backIDs[item.ID] {
+			overlapCount++
+		}
+	}
+	_ = items2
+	if overlapCount == 0 {
+		t.Error("Expected backward page to overlap with first page items")
+	}
+}
+
+func TestCursor_EmptyResultSet(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	// No seeding — empty table
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 0 {
+		t.Errorf("Expected 0 items, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info even for empty result")
+	}
+	if cursorInfo.HasMore {
+		t.Error("Expected has_more=false for empty result")
+	}
+	if cursorInfo.NextCursor != "" {
+		t.Error("Expected no next_cursor for empty result")
+	}
+	if cursorInfo.PrevCursor != "" {
+		t.Error("Expected no prev_cursor for empty result")
+	}
+}
+
+func TestCursor_SingleItemResultSet(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+
+	_, err := wrapper.Create(ctx, TestQueryProduct{Name: "Solo", Category: "Test", Price: 10, InStock: true})
+	if err != nil {
+		t.Fatal("Create failed:", err)
+	}
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("Expected 1 item, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info")
+	}
+	if cursorInfo.HasMore {
+		t.Error("Expected has_more=false for single item")
+	}
+}
+
+func TestCursor_InvalidCursorString(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{After: "not-valid-base64!!!"}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	_, _, _, _, err := wrapper.GetAll(ctx2)
+	if err == nil {
+		t.Error("Expected error for invalid cursor string")
+	}
+}
+
+func TestCursor_CorruptedCursorJSON(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Valid base64, invalid JSON
+	opts := &metadata.QueryOptions{After: "bm90LWpzb24="}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	_, _, _, _, err := wrapper.GetAll(ctx2)
+	if err == nil {
+		t.Error("Expected error for corrupted cursor JSON")
+	}
+}
+
+func TestCursor_MismatchedSortValues(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Create a cursor with wrong number of sort values
+	wrongCursor := metadata.Cursor{
+		Values: []any{"value1", "value2", "value3"}, // Too many values
+		PK:     float64(1),
+	}
+	encoded, err := metadata.EncodeCursor(wrongCursor)
+	if err != nil {
+		t.Fatal("Failed to encode cursor:", err)
+	}
+
+	opts := &metadata.QueryOptions{After: encoded}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	_, _, _, _, err = wrapper.GetAll(ctx2)
+	if err == nil {
+		t.Error("Expected error for mismatched sort values in cursor")
+	}
+}
+
+func TestCursor_WithSortField(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Sort by Price ascending, paginate with cursor
+	opts := &metadata.QueryOptions{
+		Sort: []metadata.SortField{{Field: "Price", Desc: false}},
+	}
+	ctx1 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	items1, _, _, cursor1, err := wrapper.GetAll(ctx1)
+	if err != nil {
+		t.Fatal("First page failed:", err)
+	}
+
+	if len(items1) != 2 {
+		t.Fatalf("Expected 2 items, got %d", len(items1))
+	}
+	// Should be sorted by price ascending
+	if items1[0].Price > items1[1].Price {
+		t.Errorf("Expected ascending price order: %d, %d", items1[0].Price, items1[1].Price)
+	}
+
+	// Get next page with same sort
+	opts2 := &metadata.QueryOptions{
+		Sort:  []metadata.SortField{{Field: "Price", Desc: false}},
+		After: cursor1.NextCursor,
+	}
+	ctx2 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts2)
+
+	items2, _, _, _, err := wrapper.GetAll(ctx2)
+	if err != nil {
+		t.Fatal("Second page failed:", err)
+	}
+
+	// Second page prices should all be >= last price of first page
+	lastPrice := items1[len(items1)-1].Price
+	for _, item := range items2 {
+		if item.Price < lastPrice {
+			t.Errorf("Second page item price %d is less than first page last price %d", item.Price, lastPrice)
+		}
+	}
+}
+
+func TestCursor_WithFilter(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Filter to Fruit category only (Apple, Banana = 2 items, fits in one page with limit=2)
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Category": {Value: categoryFruit, Operator: metadata.OpEq},
+		},
+	}
+	ctx1 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx1)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("Expected 2 fruit items, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info")
+	}
+	if cursorInfo.HasMore {
+		t.Error("Expected has_more=false when all filtered items fit in one page")
+	}
+}
+
+func TestCursor_OffsetIgnoredInCursorMode(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	// Set offset=2 but also use cursor mode — offset should be ignored
+	opts := &metadata.QueryOptions{Limit: 2}
+	ctx1 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx1)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info in cursor mode")
+	}
+}
+
+func TestCursor_OffsetModeWhenConfigured(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	offsetMeta := &metadata.TypeMetadata{
+		TypeID:           "offset_product_id",
+		TypeName:         "TestQueryProduct",
+		TableName:        "query_products",
+		URLParamUUID:     "productId",
+		PKField:          "ID",
+		ModelType:        reflect.TypeOf(TestQueryProduct{}),
+		FilterableFields: []string{"Name", "Category", "Price", "InStock"},
+		SortableFields:   []string{"Name", "Price", "CreatedAt"},
+		DefaultLimit:     2,
+		MaxLimit:         100,
+		Pagination:       metadata.OffsetPagination,
+	}
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(offsetMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{Limit: 2, Offset: 1}
+	ctx1 := context.WithValue(ctxWithQueryMeta(offsetMeta), metadata.QueryOptionsKey, opts)
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx1)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items with offset pagination, got %d", len(items))
+	}
+	if cursorInfo != nil {
+		t.Error("Expected nil cursor info in offset mode")
+	}
+}
+
+func TestCursor_CountTotalWithCursor(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(testCursorProductMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	opts := &metadata.QueryOptions{CountTotal: true}
+	ctx1 := context.WithValue(ctxWithQueryMeta(testCursorProductMeta), metadata.QueryOptionsKey, opts)
+
+	items, count, _, cursorInfo, err := wrapper.GetAll(ctx1)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items (page size), got %d", len(items))
+	}
+	if count != 5 {
+		t.Errorf("Expected total count 5, got %d", count)
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info")
+	}
+	if !cursorInfo.HasMore {
+		t.Error("Expected has_more=true")
+	}
+}
+
+func TestCursor_ExactlyOnePage(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	// Limit = 5, exactly 5 items: N+1 fetch gets 5, no extra → has_more=false
+	exactMeta := &metadata.TypeMetadata{
+		TypeID:           "exact_product_id",
+		TypeName:         "TestQueryProduct",
+		TableName:        "query_products",
+		URLParamUUID:     "productId",
+		PKField:          "ID",
+		ModelType:        reflect.TypeOf(TestQueryProduct{}),
+		FilterableFields: []string{"Name", "Category", "Price", "InStock"},
+		SortableFields:   []string{"Name", "Price", "CreatedAt"},
+		DefaultLimit:     5,
+		MaxLimit:         100,
+		Pagination:       metadata.CursorPagination,
+	}
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(exactMeta)
+	seedQueryProducts(t, wrapper, ctx) // 5 items
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 5 {
+		t.Errorf("Expected 5 items, got %d", len(items))
+	}
+	if cursorInfo == nil {
+		t.Fatal("Expected cursor info")
+	}
+	if cursorInfo.HasMore {
+		t.Error("Expected has_more=false when items exactly fill page")
+	}
+}
+
+func TestCursor_NoPaginationMode(t *testing.T) {
+	db, cleanup := setupQueryTestDB(t)
+	defer cleanup()
+
+	// NoPagination mode — should return all items with no cursor info
+	noPagMeta := &metadata.TypeMetadata{
+		TypeID:           "nopag_product_id",
+		TypeName:         "TestQueryProduct",
+		TableName:        "query_products",
+		URLParamUUID:     "productId",
+		PKField:          "ID",
+		ModelType:        reflect.TypeOf(TestQueryProduct{}),
+		FilterableFields: []string{"Name", "Category", "Price", "InStock"},
+		SortableFields:   []string{"Name", "Price", "CreatedAt"},
+		Pagination:       metadata.NoPagination,
+	}
+
+	wrapper := &datastore.Wrapper[TestQueryProduct]{Store: db}
+	ctx := ctxWithQueryMeta(noPagMeta)
+	seedQueryProducts(t, wrapper, ctx)
+
+	items, _, _, cursorInfo, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(items) != 5 {
+		t.Errorf("Expected all 5 items with no pagination, got %d", len(items))
+	}
+	if cursorInfo != nil {
+		t.Error("Expected nil cursor info with no pagination mode")
 	}
 }

--- a/datastore/schema.go
+++ b/datastore/schema.go
@@ -29,6 +29,21 @@ func ColumnName(tType reflect.Type, goName string) (string, error) {
 	return "", fmt.Errorf("field %s not found on type %s", goName, tType.Name())
 }
 
+// FieldName resolves a SQL column name back to its Go struct field name using Bun's schema.
+func FieldName(tType reflect.Type, colName string) (string, error) {
+	store, err := Get()
+	if err != nil {
+		return "", err
+	}
+	table := store.GetDB().Table(tType)
+	for _, field := range table.Fields {
+		if field.Name == colName {
+			return field.GoName, nil
+		}
+	}
+	return "", fmt.Errorf("column %s not found on type %s", colName, tType.Name())
+}
+
 // TableName returns the SQL table name for a model type using Bun's schema.
 func TableName(tType reflect.Type) string {
 	store, err := Get()

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -49,8 +49,8 @@ type preFetchResult[T any] struct {
 // GetAll retrieves all items of type T from the datastore
 // Filters from context are applied automatically
 // Relations can be loaded via ?include= query parameter (parsed into QueryOptions.Include)
-// Returns items, total count (0 if not requested), sums (nil if not requested), and error
-func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, error) {
+// Returns items, total count (0 if not requested), sums (nil if not requested), cursor info (nil if not cursor mode), and error
+func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, *metadata.CursorInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, w.Store.GetTimeout())
 	defer cancel()
 
@@ -60,25 +60,25 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64,
 	// Get metadata from context
 	meta, err := metadata.FromContext(ctx)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	// Apply parent filters and JOINs from metadata
 	query, err = w.applyParentFiltersWithMeta(ctx, query, meta)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	// Apply ownership filter for type T
 	query, err = w.applyOwnershipFilterWithMeta(ctx, query, meta)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	// Apply tenant filter
 	query, err = w.applyTenantFilter(ctx, query, meta)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
 	// Get query options from context (optional)
@@ -93,15 +93,27 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64,
 	if opts != nil && (opts.CountTotal || len(opts.Sums) > 0) {
 		totalCount, sums, err = w.computeAggregates(ctx, query, opts, meta)
 		if err != nil {
-			return nil, 0, nil, err
+			return nil, 0, nil, nil, err
 		}
 	}
 
 	// Apply sorting from query options (or default sort)
 	query = w.applyQuerySorting(query, opts, meta)
 
-	// Apply pagination AFTER aggregates
-	query = w.applyQueryPagination(query, opts, meta)
+	// Determine if cursor pagination is active
+	cursorMode := meta.Pagination == metadata.CursorPagination &&
+		(opts == nil || (opts.After != "" || opts.Before != "" || opts.Offset == 0))
+
+	// Apply cursor WHERE clause for keyset pagination
+	if cursorMode && opts != nil {
+		query, err = w.applyCursorWhere(query, opts, meta)
+		if err != nil {
+			return nil, 0, nil, nil, err
+		}
+	}
+
+	// Apply pagination AFTER aggregates (uses N+1 for cursor mode)
+	requestedLimit := w.applyQueryPagination(query, opts, meta)
 
 	// Apply relation includes from query options
 	query = w.applyRelationIncludes(ctx, query, opts, meta)
@@ -109,16 +121,31 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64,
 	if err := query.Scan(ctx); err != nil {
 		// Pass through context errors unchanged
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, 0, nil, err
+			return nil, 0, nil, nil, err
 		}
 		// Check for connection issues
 		if errors.Is(err, sql.ErrConnDone) {
-			return nil, 0, nil, apperrors.ErrUnavailable
+			return nil, 0, nil, nil, apperrors.ErrUnavailable
 		}
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 
-	return items, totalCount, sums, nil
+	// Build cursor info for cursor pagination
+	var cursorInfo *metadata.CursorInfo
+	if cursorMode && requestedLimit > 0 {
+		cursorInfo = w.buildCursorInfo(items, opts, meta, requestedLimit)
+		// Trim N+1 extra item
+		if len(items) > requestedLimit {
+			items = items[:requestedLimit]
+		}
+	}
+
+	// For backward pagination, reverse the results to restore natural order
+	if cursorMode && opts != nil && opts.Before != "" {
+		slices.Reverse(items)
+	}
+
+	return items, totalCount, sums, cursorInfo, nil
 }
 
 // Get retrieves a single item of type T by ID from the datastore
@@ -1178,10 +1205,15 @@ func applyFilter(query *bun.SelectQuery, tableName, colName, operator string, va
 	}
 }
 
-// applyQuerySorting applies sorting from QueryOptions to the query
-// Falls back to metadata.DefaultSort if no sort specified
-// Only fields in metadata.SortableFields are allowed (others silently ignored)
+// applyQuerySorting applies sorting from QueryOptions to the query.
+// Falls back to metadata.DefaultSort if no sort specified.
+// Only fields in metadata.SortableFields are allowed (others silently ignored).
+// Always appends the PK as a final tie-breaker to guarantee deterministic ordering.
+// For backward cursor pagination (?before=), all sort directions are reversed.
 func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) *bun.SelectQuery {
+	hasPKSort := false
+	reverseDir := opts != nil && opts.Before != "" && meta.Pagination == metadata.CursorPagination
+
 	// Use sort from options if provided
 	if opts != nil && len(opts.Sort) > 0 {
 		for _, sort := range opts.Sort {
@@ -1189,27 +1221,41 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 				continue // skip invalid sort fields
 			}
 
+			if sort.Field == meta.PKField {
+				hasPKSort = true
+			}
+
 			colName, err := ColumnName(meta.ModelType, sort.Field)
 			if err != nil {
 				continue
 			}
 
-			if sort.Desc {
+			desc := sort.Desc
+			if reverseDir {
+				desc = !desc
+			}
+
+			if desc {
 				query = query.OrderExpr("?TableAlias.? DESC", bun.Ident(colName))
 			} else {
 				query = query.OrderExpr("?TableAlias.? ASC", bun.Ident(colName))
 			}
 		}
-		return query
-	}
-
-	// Fall back to default sort from metadata
-	if meta.DefaultSort != "" {
+	} else if meta.DefaultSort != "" {
+		// Fall back to default sort from metadata
 		field := meta.DefaultSort
 		desc := false
 		if strings.HasPrefix(field, "-") {
 			desc = true
 			field = field[1:]
+		}
+
+		if field == meta.PKField {
+			hasPKSort = true
+		}
+
+		if reverseDir {
+			desc = !desc
 		}
 
 		colName, err := ColumnName(meta.ModelType, field)
@@ -1222,12 +1268,27 @@ func (w *Wrapper[T]) applyQuerySorting(query *bun.SelectQuery, opts *metadata.Qu
 		}
 	}
 
+	// Always append PK as final tie-breaker for deterministic ordering
+	if !hasPKSort && meta.PKField != "" {
+		pkCol, err := ColumnName(meta.ModelType, meta.PKField)
+		if err == nil {
+			desc := reverseDir // normally ASC, reversed for backward
+			if desc {
+				query = query.OrderExpr("?TableAlias.? DESC", bun.Ident(pkCol))
+			} else {
+				query = query.OrderExpr("?TableAlias.? ASC", bun.Ident(pkCol))
+			}
+		}
+	}
+
 	return query
 }
 
-// applyQueryPagination applies limit/offset from QueryOptions to the query
-// Uses metadata defaults if not specified in options
-func (w *Wrapper[T]) applyQueryPagination(query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) *bun.SelectQuery {
+// applyQueryPagination applies limit/offset from QueryOptions to the query.
+// Uses metadata defaults if not specified in options.
+// For cursor mode, fetches limit+1 items (N+1 trick) to detect has_more.
+// Returns the requested limit (before N+1 adjustment) so the caller can trim.
+func (w *Wrapper[T]) applyQueryPagination(query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) int {
 	limit := meta.DefaultLimit
 	offset := 0
 
@@ -1245,15 +1306,241 @@ func (w *Wrapper[T]) applyQueryPagination(query *bun.SelectQuery, opts *metadata
 		limit = meta.MaxLimit
 	}
 
-	if limit > 0 {
-		query = query.Limit(limit)
+	requestedLimit := limit
+
+	// N+1 trick for cursor mode: fetch one extra to detect has_more
+	cursorMode := meta.Pagination == metadata.CursorPagination &&
+		(opts == nil || (opts.After != "" || opts.Before != "" || opts.Offset == 0))
+	if cursorMode && limit > 0 {
+		_ = query.Limit(limit + 1)
+	} else if limit > 0 {
+		_ = query.Limit(limit)
 	}
 
 	if offset > 0 {
-		query = query.Offset(offset)
+		_ = query.Offset(offset)
 	}
 
-	return query
+	return requestedLimit
+}
+
+// applyCursorWhere adds a keyset WHERE clause for cursor-based pagination.
+// It builds a disjunctive condition that respects per-column sort direction,
+// which is necessary because SQL row-value comparison applies a single
+// comparison direction uniformly and cannot handle mixed ASC/DESC sorts.
+//
+// For columns (A DESC, B ASC, PK ASC) with cursor values (a, b, pk),
+// the forward ("after") condition expands to:
+//
+//	(A < a) OR (A = a AND B > b) OR (A = a AND B = b AND PK > pk)
+func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.QueryOptions, meta *metadata.TypeMetadata) (*bun.SelectQuery, error) {
+	cursorStr := opts.After
+	backward := opts.Before != ""
+	if backward {
+		cursorStr = opts.Before
+	}
+
+	if cursorStr == "" {
+		return query, nil
+	}
+
+	cursor, err := metadata.DecodeCursor(cursorStr)
+	if err != nil {
+		return nil, err
+	}
+
+	sortCols, err := w.effectiveSortColumns(opts, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cursor.Values) != len(sortCols) {
+		return nil, fmt.Errorf("invalid cursor: expected %d sort values, got %d", len(sortCols), len(cursor.Values))
+	}
+
+	pkCol, err := ColumnName(meta.ModelType, meta.PKField)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor: cannot resolve PK column: %w", err)
+	}
+
+	// Build per-column operators based on effective sort direction.
+	// applyQuerySorting already reverses directions for "before", so the
+	// effective directions here account for backward navigation.
+	type colInfo struct {
+		expr string // e.g. ?TableAlias."price"
+		val  any
+		op   string // ">" for ASC, "<" for DESC
+	}
+
+	cols := make([]colInfo, 0, len(sortCols)+1)
+	for i, sc := range sortCols {
+		op := ">"
+		if sc.desc {
+			op = "<"
+		}
+		if backward {
+			// Sort is reversed by applyQuerySorting, so flip the operator
+			if op == ">" {
+				op = "<"
+			} else {
+				op = ">"
+			}
+		}
+		cols = append(cols, colInfo{
+			expr: fmt.Sprintf("?TableAlias.%q", sc.col),
+			val:  cursor.Values[i],
+			op:   op,
+		})
+	}
+
+	// PK tie-breaker: normally ASC (>), reversed for backward (<)
+	pkOp := ">"
+	if backward {
+		pkOp = "<"
+	}
+	cols = append(cols, colInfo{
+		expr: fmt.Sprintf("?TableAlias.%q", pkCol),
+		val:  cursor.PK,
+		op:   pkOp,
+	})
+
+	// Build disjunctive normal form:
+	// (c0 op v0) OR (c0 = v0 AND c1 op v1) OR ... OR (c0 = v0 AND ... AND cN op vN)
+	var orClauses []string
+	var allVals []any
+
+	for i := range cols {
+		var andParts []string
+		// Equality prefix for all columns before i
+		for j := 0; j < i; j++ {
+			andParts = append(andParts, cols[j].expr+" = ?")
+			allVals = append(allVals, cols[j].val)
+		}
+		// Comparison for column i
+		andParts = append(andParts, cols[i].expr+" "+cols[i].op+" ?")
+		allVals = append(allVals, cols[i].val)
+
+		orClauses = append(orClauses, "("+strings.Join(andParts, " AND ")+")")
+	}
+
+	whereExpr := "(" + strings.Join(orClauses, " OR ") + ")"
+	query = query.Where(whereExpr, allVals...)
+
+	return query, nil
+}
+
+// sortColumn holds a resolved sort column name and direction
+type sortColumn struct {
+	col  string
+	desc bool
+}
+
+// effectiveSortColumns returns the resolved column names and directions for the current sort,
+// excluding the PK tie-breaker (which is handled separately).
+func (w *Wrapper[T]) effectiveSortColumns(opts *metadata.QueryOptions, meta *metadata.TypeMetadata) ([]sortColumn, error) {
+	var cols []sortColumn
+
+	if opts != nil && len(opts.Sort) > 0 {
+		for _, sort := range opts.Sort {
+			if !slices.Contains(meta.SortableFields, sort.Field) {
+				continue
+			}
+			if sort.Field == meta.PKField {
+				continue // PK is handled as tie-breaker
+			}
+			colName, err := ColumnName(meta.ModelType, sort.Field)
+			if err != nil {
+				continue
+			}
+			cols = append(cols, sortColumn{col: colName, desc: sort.Desc})
+		}
+	} else if meta.DefaultSort != "" {
+		field := meta.DefaultSort
+		desc := false
+		if strings.HasPrefix(field, "-") {
+			desc = true
+			field = field[1:]
+		}
+		if field != meta.PKField {
+			colName, err := ColumnName(meta.ModelType, field)
+			if err == nil {
+				cols = append(cols, sortColumn{col: colName, desc: desc})
+			}
+		}
+	}
+
+	return cols, nil
+}
+
+// buildCursorInfo generates CursorInfo from the fetched items.
+// Uses N+1 detection: if len(items) > requestedLimit, there are more items.
+func (w *Wrapper[T]) buildCursorInfo(items []*T, opts *metadata.QueryOptions, meta *metadata.TypeMetadata, requestedLimit int) *metadata.CursorInfo {
+	info := &metadata.CursorInfo{}
+
+	hasMore := len(items) > requestedLimit
+	info.HasMore = hasMore
+
+	// Trim to view for cursor generation (don't modify the slice yet, caller does that)
+	viewItems := items
+	if len(viewItems) > requestedLimit {
+		viewItems = viewItems[:requestedLimit]
+	}
+
+	if len(viewItems) == 0 {
+		return info
+	}
+
+	sortCols, _ := w.effectiveSortColumns(opts, meta)
+
+	// Build next cursor from the last item
+	if hasMore || (opts != nil && opts.Before != "") {
+		last := viewItems[len(viewItems)-1]
+		if cursor, err := w.buildCursorFromItem(last, sortCols, meta); err == nil {
+			info.NextCursor = cursor
+		}
+	}
+
+	// Build prev cursor from the first item (only if we came from a cursor)
+	if opts != nil && (opts.After != "" || opts.Before != "") {
+		first := viewItems[0]
+		if cursor, err := w.buildCursorFromItem(first, sortCols, meta); err == nil {
+			info.PrevCursor = cursor
+		}
+	}
+
+	return info
+}
+
+// buildCursorFromItem extracts sort field values and PK from an item to create a cursor.
+func (w *Wrapper[T]) buildCursorFromItem(item *T, sortCols []sortColumn, meta *metadata.TypeMetadata) (string, error) {
+	v := reflect.ValueOf(item).Elem()
+
+	// Collect sort field values using the Go field name (not column name)
+	var values []any
+	for _, sc := range sortCols {
+		// Reverse-lookup: column name → Go field name
+		goField, err := FieldName(meta.ModelType, sc.col)
+		if err != nil {
+			continue
+		}
+		field := v.FieldByName(goField)
+		if !field.IsValid() {
+			continue
+		}
+		values = append(values, field.Interface())
+	}
+
+	// Get PK value
+	pkField := v.FieldByName(meta.PKField)
+	if !pkField.IsValid() {
+		return "", fmt.Errorf("PK field %s not found", meta.PKField)
+	}
+
+	cursor := metadata.Cursor{
+		Values: values,
+		PK:     pkField.Interface(),
+	}
+	return metadata.EncodeCursor(cursor)
 }
 
 // runValidation executes the validator function if one is configured in metadata

--- a/datastore/wrapper_test.go
+++ b/datastore/wrapper_test.go
@@ -147,7 +147,7 @@ func TestWrapper_GetAll(t *testing.T) {
 	}
 
 	// Get all users
-	retrieved, _, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -278,7 +278,7 @@ func TestWrapper_GetAll_Empty(t *testing.T) {
 	wrapper := &datastore.Wrapper[TestUser]{Store: server}
 	ctx := ctxWithMeta(testUserMeta)
 
-	retrieved, _, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -296,7 +296,7 @@ func TestWrapper_GetAll_NoMetadata(t *testing.T) {
 	// Use a context without metadata
 	ctx := context.Background()
 
-	_, _, _, err := wrapper.GetAll(ctx)
+	_, _, _, _, err := wrapper.GetAll(ctx)
 	if err == nil {
 		t.Error("Expected error when metadata is missing from context")
 	}
@@ -350,7 +350,7 @@ func TestWrapper_GetAll_WithRelations(t *testing.T) {
 
 	// Get all with relations (even though we don't have any relations in this test model)
 	// This tests that the relations parameter is properly handled
-	retrieved, _, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users with relations:", err)
 	}
@@ -401,7 +401,7 @@ func TestWrapper_Create_UpdateDelete_Lifecycle(t *testing.T) {
 	}
 
 	// GetAll
-	all, _, _, err := wrapper.GetAll(ctx)
+	all, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -556,7 +556,7 @@ func TestOwnership_SingleField_GetAll(t *testing.T) {
 	ctxWithOwnership := context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctxWithOwnership = context.WithValue(ctxWithOwnership, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, _, err := wrapper.GetAll(ctxWithOwnership)
+	retrieved, _, _, _, err := wrapper.GetAll(ctxWithOwnership)
 	if err != nil {
 		t.Fatal("Failed to get blogs:", err)
 	}
@@ -650,7 +650,7 @@ func TestOwnership_MultipleFields_GetAll(t *testing.T) {
 	ctxAlice := context.WithValue(ctxPost, metadata.OwnershipEnforcedKey, true)
 	ctxAlice = context.WithValue(ctxAlice, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, _, err := postWrapper.GetAll(ctxAlice)
+	retrieved, _, _, _, err := postWrapper.GetAll(ctxAlice)
 	if err != nil {
 		t.Fatal("Failed to get posts:", err)
 	}
@@ -698,7 +698,7 @@ func TestOwnership_BypassScope_Admin(t *testing.T) {
 	}
 	ctxCharlie = context.WithValue(ctxCharlie, metadata.AuthInfoKey, authInfo)
 
-	retrieved, _, _, err := wrapper.GetAll(ctxCharlie)
+	retrieved, _, _, _, err := wrapper.GetAll(ctxCharlie)
 	if err != nil {
 		t.Fatal("Failed to get articles:", err)
 	}
@@ -740,7 +740,7 @@ func TestOwnership_BypassScope_Moderator(t *testing.T) {
 	}
 	ctxDiana = context.WithValue(ctxDiana, metadata.AuthInfoKey, authInfoDiana)
 
-	retrieved, _, _, err := wrapper.GetAll(ctxDiana)
+	retrieved, _, _, _, err := wrapper.GetAll(ctxDiana)
 	if err != nil {
 		t.Fatal("Failed to get articles:", err)
 	}
@@ -799,7 +799,7 @@ func TestOwnership_NoOwnershipContext_GetAll(t *testing.T) {
 	}
 
 	// GetAll without ownership enforcement - should get all
-	retrieved, _, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all blogs:", err)
 	}
@@ -834,7 +834,7 @@ func TestOwnership_TypeWithoutOwnershipConfig(t *testing.T) {
 	ctxAlice := context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctxAlice = context.WithValue(ctxAlice, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, _, err := wrapper.GetAll(ctxAlice)
+	retrieved, _, _, _, err := wrapper.GetAll(ctxAlice)
 	if err != nil {
 		t.Fatal("Failed to get all users:", err)
 	}
@@ -1751,7 +1751,7 @@ func TestWrapper_UUID_GetAll(t *testing.T) {
 	}
 
 	// Get all blogs
-	blogs, count, _, err := wrapper.GetAll(ctx)
+	blogs, count, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get all blogs:", err)
 	}
@@ -2201,7 +2201,7 @@ func TestInclude_GetAllWithRelation(t *testing.T) {
 	getCtx = context.WithValue(getCtx, metadata.OwnershipEnforcedKey, true)
 	getCtx = context.WithValue(getCtx, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, _, err := authorWrapper.GetAll(getCtx)
+	retrieved, _, _, _, err := authorWrapper.GetAll(getCtx)
 	if err != nil {
 		t.Fatal("Failed to get all authors with include:", err)
 	}
@@ -2865,7 +2865,7 @@ func TestWrapper_BatchCreate_Success(t *testing.T) {
 	}
 
 	// Verify items are in the database
-	all, _, _, err := wrapper.GetAll(ctx)
+	all, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3001,7 +3001,7 @@ func TestWrapper_BatchDelete_Success(t *testing.T) {
 	}
 
 	// Verify only one remains
-	all, _, _, err := wrapper.GetAll(ctx)
+	all, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3089,7 +3089,7 @@ func TestWrapper_BatchCreate_Transactional(t *testing.T) {
 	}
 
 	// Verify transaction was rolled back - no items should be in database
-	all, _, _, err := wrapper.GetAll(ctx)
+	all, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3384,7 +3384,7 @@ func TestWrapper_BatchDelete_Transactional(t *testing.T) {
 	}
 
 	// Verify both users still exist (transaction rolled back)
-	all, _, _, err := wrapper.GetAll(ctx)
+	all, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3519,7 +3519,7 @@ func TestParentOwnership_FiltersByParentOwner(t *testing.T) {
 	taskCtx = context.WithValue(taskCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Bob should see empty results (parent ownership filtered)
-	tasks, _, _, err := taskWrapper.GetAll(taskCtx)
+	tasks, _, _, _, err := taskWrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3540,7 +3540,7 @@ func TestParentOwnership_FiltersByParentOwner(t *testing.T) {
 	aliceCtx = context.WithValue(aliceCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Alice should see her tasks
-	tasks, _, _, err = taskWrapper.GetAll(aliceCtx)
+	tasks, _, _, _, err = taskWrapper.GetAll(aliceCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3584,7 +3584,7 @@ func TestParentOwnership_AdminBypass(t *testing.T) {
 	// No ParentOwnershipKey set - admin bypasses ownership checks
 
 	// Admin should see all tasks
-	tasks, _, _, err := taskWrapper.GetAll(adminCtx)
+	tasks, _, _, _, err := taskWrapper.GetAll(adminCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3650,7 +3650,7 @@ func TestParentOwnership_NoOwnershipFields(t *testing.T) {
 	taskCtx = context.WithValue(taskCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
 	// Should see task because parent has no ownership fields to filter on
-	tasks, _, _, err := taskWrapper.GetAll(taskCtx)
+	tasks, _, _, _, err := taskWrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -3716,7 +3716,7 @@ func TestParentOwnership_MultipleOwnershipFields(t *testing.T) {
 	})
 	aliceCtx = context.WithValue(aliceCtx, metadata.ParentOwnershipKey, []*metadata.TypeMetadata{projectMeta})
 
-	tasks, _, _, err := taskWrapper.GetAll(aliceCtx)
+	tasks, _, _, _, err := taskWrapper.GetAll(aliceCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4022,7 +4022,7 @@ func TestRelationFilter_ParentField_OneLevel(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, siteMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	sites, _, _, err := siteWrapper.GetAll(ctx)
+	sites, _, _, _, err := siteWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4070,7 +4070,7 @@ func TestRelationFilter_ParentField_TwoLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, siteMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	sites, _, _, err := siteWrapper.GetAll(ctx)
+	sites, _, _, _, err := siteWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4105,7 +4105,7 @@ func TestRelationFilter_ParentField_ThreeLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, billMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	bills, _, _, err := billWrapper.GetAll(ctx)
+	bills, _, _, _, err := billWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4139,7 +4139,7 @@ func TestRelationFilter_ParentField_FourLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, lineItemMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	lineItems, _, _, err := lineItemWrapper.GetAll(ctx)
+	lineItems, _, _, _, err := lineItemWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4175,7 +4175,7 @@ func TestRelationFilter_ChildField_OneLevel(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4210,7 +4210,7 @@ func TestRelationFilter_ChildField_TwoLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4245,7 +4245,7 @@ func TestRelationFilter_ChildField_ThreeLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4280,7 +4280,7 @@ func TestRelationFilter_ChildField_FourLevels(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4316,7 +4316,7 @@ func TestRelationFilter_ChildField_MultipleMatches_NoDuplicates(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4624,7 +4624,7 @@ func TestRelationFilter_Security_UnauthorizedFilterPath_Ignored(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4654,7 +4654,7 @@ func TestRelationFilter_Security_NonExistentRelation_Ignored(t *testing.T) {
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll should not error on non-existent relation:", err)
 	}
@@ -4684,7 +4684,7 @@ func TestRelationFilter_Security_InvalidFieldInValidRelation_Ignored(t *testing.
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll should not error on invalid field:", err)
 	}
@@ -4747,7 +4747,7 @@ func TestRelationFilter_Security_OwnershipStillEnforced(t *testing.T) {
 	ctx = context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctx = context.WithValue(ctx, metadata.OwnershipUserIDKey, "alice")
 
-	sites, _, _, err := siteWrapper.GetAll(ctx)
+	sites, _, _, _, err := siteWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4793,7 +4793,7 @@ func TestRelationFilter_Security_CantBypassParentOwnershipViaChildFilter(t *test
 	ctx = context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
 	ctx = context.WithValue(ctx, metadata.OwnershipUserIDKey, "bob@example.com")
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4834,7 +4834,7 @@ func TestRelationFilter_CombinedFilterAndInclude(t *testing.T) {
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
 	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
 
-	users, _, _, err := userWrapper.GetAll(ctx)
+	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -4989,7 +4989,7 @@ func TestTenant_GetAll_FiltersByTenant(t *testing.T) {
 
 	// GetAll with tenant scoping for org-a
 	tenantCtx := ctxWithTenant(ctx, "org-a")
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5020,7 +5020,7 @@ func TestTenant_GetAll_CrossTenant_ReturnsEmpty(t *testing.T) {
 
 	// GetAll as org-b should see nothing
 	tenantCtx := ctxWithTenant(ctx, "org-b")
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5157,7 +5157,7 @@ func TestTenant_IsTenantTable_GetAll_FiltersByPK(t *testing.T) {
 
 	// GetAll as org-a should only return org-a
 	tenantCtx := ctxWithTenant(ctx, "org-a")
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get orgs:", err)
 	}
@@ -5248,7 +5248,7 @@ func TestTenant_WithOwnership_BothFiltersApply(t *testing.T) {
 	tenantCtx = context.WithValue(tenantCtx, metadata.OwnershipEnforcedKey, true)
 	tenantCtx = context.WithValue(tenantCtx, metadata.OwnershipUserIDKey, "alice")
 
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5295,7 +5295,7 @@ func TestTenant_WithOwnership_AdminBypassOwnershipNotTenant(t *testing.T) {
 		Scopes:   []string{"admin"},
 	})
 
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5358,7 +5358,7 @@ func TestTenant_ParentChain_FiltersByParentTenant(t *testing.T) {
 	// Set parent tenant context (normally set by auth middleware)
 	taskCtx = context.WithValue(taskCtx, metadata.ParentTenantKey, []*metadata.TypeMetadata{projectMeta})
 
-	tasks, _, _, err := taskWrapper.GetAll(taskCtx)
+	tasks, _, _, _, err := taskWrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -5373,7 +5373,7 @@ func TestTenant_ParentChain_FiltersByParentTenant(t *testing.T) {
 	taskCtxB = ctxWithTenant(taskCtxB, "org-b")
 	taskCtxB = context.WithValue(taskCtxB, metadata.ParentTenantKey, []*metadata.TypeMetadata{projectMeta})
 
-	tasks, _, _, err = taskWrapper.GetAll(taskCtxB)
+	tasks, _, _, _, err = taskWrapper.GetAll(taskCtxB)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}
@@ -5434,7 +5434,7 @@ func TestTenant_NoTenantContext_NoFiltering(t *testing.T) {
 	}
 
 	// GetAll without tenant context — should return all (global route behavior)
-	retrieved, _, _, err := wrapper.GetAll(ctx)
+	retrieved, _, _, _, err := wrapper.GetAll(ctx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5464,7 +5464,7 @@ func TestTenant_EnforcedButEmpty_ReturnsError(t *testing.T) {
 	tenantCtx := context.WithValue(ctx, metadata.TenantScopedKey, true)
 	tenantCtx = context.WithValue(tenantCtx, metadata.TenantIDValueKey, "")
 
-	_, _, _, err = wrapper.GetAll(tenantCtx)
+	_, _, _, _, err = wrapper.GetAll(tenantCtx)
 	if err == nil {
 		t.Error("Expected error when tenant scoped but tenant ID is empty")
 	}
@@ -5503,7 +5503,7 @@ func TestTenant_WithQueryFilters_BothApply(t *testing.T) {
 	}
 	tenantCtx = context.WithValue(tenantCtx, metadata.QueryOptionsKey, opts)
 
-	retrieved, _, _, err := wrapper.GetAll(tenantCtx)
+	retrieved, _, _, _, err := wrapper.GetAll(tenantCtx)
 	if err != nil {
 		t.Fatal("Failed to get projects:", err)
 	}
@@ -5657,7 +5657,7 @@ func TestTenant_ParentTenantFilter_SkipsParentWithNoTenantField(t *testing.T) {
 	taskCtx = ctxWithTenant(taskCtx, "org-a")
 	taskCtx = context.WithValue(taskCtx, metadata.ParentTenantKey, []*metadata.TypeMetadata{projectMeta})
 
-	results, _, _, err := wrapper.GetAll(taskCtx)
+	results, _, _, _, err := wrapper.GetAll(taskCtx)
 	if err != nil {
 		t.Fatal("Failed to get tasks:", err)
 	}
@@ -5673,7 +5673,7 @@ func TestTenant_ParentTenantFilter_SkipsParentWithNoTenantField(t *testing.T) {
 	crossCtx = ctxWithTenant(crossCtx, "org-b")
 	crossCtx = context.WithValue(crossCtx, metadata.ParentTenantKey, []*metadata.TypeMetadata{projectMeta})
 
-	crossResults, _, _, err := wrapper.GetAll(crossCtx)
+	crossResults, _, _, _, err := wrapper.GetAll(crossCtx)
 	if err != nil {
 		t.Fatal("Failed to get tasks:", err)
 	}

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -218,18 +218,18 @@ func customUpdateMe(ctx context.Context, svc *service.Common[User], _ *metadata.
 }
 
 // Custom handler: GetAll tasks filtered by current user
-func customGetMyTasks(ctx context.Context, svc *service.Common[Task], _ *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, error) {
+func customGetMyTasks(ctx context.Context, svc *service.Common[Task], _ *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*Task, int, map[string]float64, *metadata.CursorInfo, error) {
 	if auth == nil {
-		return nil, 0, nil, fmt.Errorf("not authenticated")
+		return nil, 0, nil, nil, fmt.Errorf("not authenticated")
 	}
 	// Get all tasks for current user
 	tasks := []*Task{} // Initialize as empty slice, not nil
 	err := db.GetDB().NewSelect().Model(&tasks).Where("owner_id = ?", auth.UserID).Order("priority DESC", "created_at DESC").Scan(ctx)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 	_ = svc
-	return tasks, len(tasks), nil, nil
+	return tasks, len(tasks), nil, nil, nil
 }
 
 // Custom handler: Create task with auto-set owner

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -112,9 +112,15 @@ func main() {
 	fmt.Println("  nin  - Not in list:         filter[Category][nin]=Electronics,Books")
 	fmt.Println("  bt   - Between:             filter[Price][bt]=50,150")
 	fmt.Println("  nbt  - Not between:         filter[Price][nbt]=50,150")
+	fmt.Println("\nPagination (cursor-based by default):")
+	fmt.Println("  limit=10               Limit results (max 100)")
+	fmt.Println("  after=<cursor>         Next page (cursor from pagination.next_cursor)")
+	fmt.Println("  before=<cursor>        Previous page (cursor from pagination.prev_cursor)")
+	fmt.Println("  offset=20              Switch to offset pagination")
+	fmt.Println("  count=true             Include total_count in pagination")
 	fmt.Println("\nAggregation:")
 	fmt.Println("  sum  - Sum numeric fields:  sum=Price,Stock")
-	fmt.Println("         Returns X-Sum-Price and X-Sum-Stock headers")
+	fmt.Println("         Returns sums in response body (res.body.sums.Price)")
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -48,8 +48,14 @@ curl 'http://localhost:8080/users?filter[Name][like]=John%'
 # Sort by name descending
 curl 'http://localhost:8080/users?sort=-Name'
 
-# Pagination with total count
-curl 'http://localhost:8080/users?limit=10&offset=0&count=true'
+# Cursor pagination (default) with total count
+curl 'http://localhost:8080/users?limit=10&count=true'
+
+# Next page using cursor from previous response
+curl 'http://localhost:8080/users?limit=10&after=<next_cursor>'
+
+# Offset pagination (opt-in)
+curl 'http://localhost:8080/users?limit=10&offset=20&count=true'
 
 # Combined
 curl 'http://localhost:8080/users?filter[Name][like]=J%&sort=-Name&limit=10&count=true'

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -108,12 +108,14 @@ func main() {
 	fmt.Println("  filter[Email]=value    Filter by email")
 	fmt.Println("  sort=Name,-Email       Sort by fields (- prefix for descending)")
 	fmt.Println("  limit=10               Limit results (max 100)")
-	fmt.Println("  offset=20              Skip results for pagination")
-	fmt.Println("  count=true             Include X-Total-Count header")
+	fmt.Println("  after=<cursor>         Next page (cursor from pagination.next_cursor)")
+	fmt.Println("  before=<cursor>        Previous page (cursor from pagination.prev_cursor)")
+	fmt.Println("  offset=20              Skip results (switches to offset pagination)")
+	fmt.Println("  count=true             Include total_count in pagination")
 	fmt.Println("\nExamples:")
 	fmt.Println("  curl 'http://localhost:8080/users?filter[Name]=Alice'")
 	fmt.Println("  curl 'http://localhost:8080/users?sort=-CreatedAt&limit=10'")
-	fmt.Println("  curl 'http://localhost:8080/users?limit=10&offset=20&count=true'")
+	fmt.Println("  curl 'http://localhost:8080/users?limit=10&count=true'")
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"

--- a/handler/batch_test.go
+++ b/handler/batch_test.go
@@ -72,9 +72,15 @@ func TestBatchCreate_Success(t *testing.T) {
 		t.Errorf("Expected status 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var results []TestUser
-	if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+	var envelope handler.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	resultsRaw, _ := json.Marshal(envelope.Data)
+	var results []TestUser
+	if err := json.Unmarshal(resultsRaw, &results); err != nil {
+		t.Fatal("Failed to unmarshal data:", err)
 	}
 
 	if len(results) != 2 {
@@ -215,9 +221,15 @@ func TestBatchUpdate_Success(t *testing.T) {
 		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var results []TestUser
-	if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+	var envelope handler.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	resultsRaw, _ := json.Marshal(envelope.Data)
+	var results []TestUser
+	if err := json.Unmarshal(resultsRaw, &results); err != nil {
+		t.Fatal("Failed to unmarshal data:", err)
 	}
 
 	if len(results) != 2 {
@@ -389,9 +401,15 @@ func TestBatchCreate_CustomHandler(t *testing.T) {
 		t.Errorf("Expected status 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var results []TestUser
-	if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+	var envelope handler.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	resultsRaw, _ := json.Marshal(envelope.Data)
+	var results []TestUser
+	if err := json.Unmarshal(resultsRaw, &results); err != nil {
+		t.Fatal("Failed to unmarshal data:", err)
 	}
 
 	if len(results) != 1 {
@@ -677,9 +695,15 @@ func TestBatchPatch_Success(t *testing.T) {
 		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var results []TestUser
-	if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+	var envelope handler.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	resultsRaw, _ := json.Marshal(envelope.Data)
+	var results []TestUser
+	if err := json.Unmarshal(resultsRaw, &results); err != nil {
+		t.Fatal("Failed to unmarshal data:", err)
 	}
 
 	if len(results) != 2 {

--- a/handler/error_response_test.go
+++ b/handler/error_response_test.go
@@ -166,8 +166,8 @@ func TestErrorResponse_ValidationError(t *testing.T) {
 }
 
 func TestErrorResponse_DeadlineExceeded(t *testing.T) {
-	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-		return nil, 0, nil, context.DeadlineExceeded
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		return nil, 0, nil, nil, context.DeadlineExceeded
 	}
 
 	r := chi.NewRouter()
@@ -182,8 +182,8 @@ func TestErrorResponse_DeadlineExceeded(t *testing.T) {
 }
 
 func TestErrorResponse_ServiceUnavailable(t *testing.T) {
-	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-		return nil, 0, nil, apperrors.ErrUnavailable
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		return nil, 0, nil, nil, apperrors.ErrUnavailable
 	}
 
 	r := chi.NewRouter()
@@ -198,8 +198,8 @@ func TestErrorResponse_ServiceUnavailable(t *testing.T) {
 }
 
 func TestErrorResponse_InternalServerError(t *testing.T) {
-	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-		return nil, 0, nil, fmt.Errorf("unexpected database error")
+	getAllFunc := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		return nil, 0, nil, nil, fmt.Errorf("unexpected database error")
 	}
 
 	r := chi.NewRouter()

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -40,14 +40,14 @@ type CustomGetFunc[T any] func(
 ) (*T, error)
 
 // CustomGetAllFunc is the signature for custom GetAll handlers.
-// The custom function receives all parsed/validated inputs and returns items with count and sums.
+// The custom function receives all parsed/validated inputs and returns items with count, sums, and cursor info.
 // Query options are available via metadata.QueryOptionsFromContext(ctx) if needed.
 type CustomGetAllFunc[T any] func(
 	ctx context.Context,
 	svc *service.Common[T],
 	meta *metadata.TypeMetadata,
 	auth *metadata.AuthInfo,
-) ([]*T, int, map[string]float64, error)
+) ([]*T, int, map[string]float64, *metadata.CursorInfo, error)
 
 // CustomCreateFunc is the signature for custom Create handlers.
 // The custom function receives the decoded item and optional file data.
@@ -273,7 +273,7 @@ func setupRequest[T any](w http.ResponseWriter, r *http.Request, getFunc CustomG
 
 // StandardGetAll is the default GetAll implementation that calls svc.GetAll.
 // Use this when no custom logic is needed.
-func StandardGetAll[T any](ctx context.Context, svc *service.Common[T], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*T, int, map[string]float64, error) {
+func StandardGetAll[T any](ctx context.Context, svc *service.Common[T], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*T, int, map[string]float64, *metadata.CursorInfo, error) {
 	return svc.GetAll(ctx)
 }
 
@@ -311,7 +311,7 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 		opts := metadata.QueryOptionsFromContext(ctx)
 
 		// Call the provided function
-		items, totalCount, sums, err := getAllFunc(ctx, svc, meta, auth)
+		items, totalCount, sums, cursorInfo, err := getAllFunc(ctx, svc, meta, auth)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return // Client disconnected, no response needed
@@ -330,30 +330,50 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 			return
 		}
 
-		// Set pagination headers
-		if opts.CountTotal && totalCount > 0 {
-			w.Header().Set("X-Total-Count", strconv.Itoa(totalCount))
-		}
-		if opts.Limit > 0 {
-			w.Header().Set("X-Limit", strconv.Itoa(opts.Limit))
-		}
-		if opts.Offset > 0 {
-			w.Header().Set("X-Offset", strconv.Itoa(opts.Offset))
-		}
+		// Build response envelope
+		response := ListResponse{Data: items}
 
-		// Set sum headers
-		for field, value := range sums {
-			headerName := "X-Sum-" + field
-			if value == float64(int64(value)) {
-				w.Header().Set(headerName, strconv.FormatInt(int64(value), 10))
-			} else {
-				w.Header().Set(headerName, strconv.FormatFloat(value, 'f', -1, 64))
+		// Build pagination info
+		var pagination *PaginationInfo
+		if cursorInfo != nil {
+			// Cursor-based pagination
+			pagination = &PaginationInfo{
+				HasMore: &cursorInfo.HasMore,
 			}
+			if cursorInfo.NextCursor != "" {
+				pagination.NextCursor = &cursorInfo.NextCursor
+			}
+			if cursorInfo.PrevCursor != "" {
+				pagination.PrevCursor = &cursorInfo.PrevCursor
+			}
+			if opts != nil && opts.CountTotal && totalCount > 0 {
+				pagination.TotalCount = &totalCount
+			}
+		} else if opts != nil && (opts.Limit > 0 || opts.Offset > 0 || (opts.CountTotal && totalCount > 0)) {
+			// Offset-based pagination
+			pagination = &PaginationInfo{}
+			if opts.Limit > 0 {
+				limit := opts.Limit
+				pagination.Limit = &limit
+			}
+			if opts.Offset > 0 {
+				offset := opts.Offset
+				pagination.Offset = &offset
+			}
+			if opts.CountTotal && totalCount > 0 {
+				pagination.TotalCount = &totalCount
+			}
+		}
+		response.Pagination = pagination
+
+		// Include sums if any were requested
+		if len(sums) > 0 {
+			response.Sums = sums
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(items); err != nil {
+		if err := json.NewEncoder(w).Encode(response); err != nil {
 			slog.ErrorContext(ctx, "failed to encode response", "error", err)
 		}
 	}
@@ -697,7 +717,7 @@ func BatchPatch[T any](patchFunc CustomBatchPatchFunc[T]) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(results); err != nil {
+		if err := json.NewEncoder(w).Encode(BatchResponse{Data: results}); err != nil {
 			slog.ErrorContext(base.ctx, "failed to encode response", "error", err)
 		}
 	}
@@ -930,7 +950,7 @@ func BatchCreate[T any](createFunc CustomBatchCreateFunc[T]) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(results); err != nil {
+		if err := json.NewEncoder(w).Encode(BatchResponse{Data: results}); err != nil {
 			slog.ErrorContext(setup.ctx, "failed to encode response", "error", err)
 		}
 	}
@@ -952,7 +972,7 @@ func BatchUpdate[T any](updateFunc CustomBatchUpdateFunc[T]) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(results); err != nil {
+		if err := json.NewEncoder(w).Encode(BatchResponse{Data: results}); err != nil {
 			slog.ErrorContext(setup.ctx, "failed to encode response", "error", err)
 		}
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -215,13 +215,17 @@ func TestHandler_GetAll(t *testing.T) {
 				t.Errorf("Expected status %d, got %d", tt.expectedCode, w.Code)
 			}
 
-			var result []TestUser
-			if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			var envelope handler.ListResponse
+			if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
 				t.Fatal("Failed to decode response:", err)
 			}
 
-			if len(result) != tt.expectedCount {
-				t.Errorf("Expected %d users, got %d", tt.expectedCount, len(result))
+			items, ok := envelope.Data.([]interface{})
+			if !ok {
+				t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+			}
+			if len(items) != tt.expectedCount {
+				t.Errorf("Expected %d users, got %d", tt.expectedCount, len(items))
 			}
 		})
 	}
@@ -728,13 +732,17 @@ func TestHandler_GetAllWithRelations(t *testing.T) {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
 	}
 
-	var result []TestUser
-	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
 		t.Fatal("Failed to decode response:", err)
 	}
 
-	if len(result) != 1 {
-		t.Errorf("Expected 1 user, got %d", len(result))
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 1 {
+		t.Errorf("Expected 1 user, got %d", len(items))
 	}
 }
 
@@ -893,10 +901,12 @@ func TestHandler_GetAll_QueryParams(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		queryString   string
-		expectedCount int
-		checkHeaders  map[string]string
+		name           string
+		queryString    string
+		expectedCount  int
+		expectedLimit  *int
+		expectedOffset *int
+		expectedTotal  *int
 	}{
 		{
 			name:          "no query params",
@@ -912,19 +922,20 @@ func TestHandler_GetAll_QueryParams(t *testing.T) {
 			name:          "limit",
 			queryString:   "limit=2",
 			expectedCount: 2,
-			checkHeaders:  map[string]string{"X-Limit": "2"},
+			expectedLimit: intPtr(2),
 		},
 		{
-			name:          "offset",
-			queryString:   "offset=1&sort=Name",
-			expectedCount: 2,
-			checkHeaders:  map[string]string{"X-Offset": "1"},
+			name:           "offset",
+			queryString:    "offset=1&sort=Name",
+			expectedCount:  2,
+			expectedOffset: intPtr(1),
 		},
 		{
 			name:          "count",
 			queryString:   "count=true&limit=1",
 			expectedCount: 1,
-			checkHeaders:  map[string]string{"X-Total-Count": "3"},
+			expectedLimit: intPtr(1),
+			expectedTotal: intPtr(3),
 		},
 	}
 
@@ -948,25 +959,51 @@ func TestHandler_GetAll_QueryParams(t *testing.T) {
 				return
 			}
 
-			var results []TestUser
-			if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+			var envelope handler.ListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 				t.Fatal("Failed to unmarshal response:", err)
 			}
 
-			if len(results) != tt.expectedCount {
-				t.Errorf("Expected %d results, got %d", tt.expectedCount, len(results))
+			items, ok := envelope.Data.([]interface{})
+			if !ok {
+				t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+			}
+			if len(items) != tt.expectedCount {
+				t.Errorf("Expected %d results, got %d", tt.expectedCount, len(items))
 			}
 
-			// Check headers if specified
-			for header, expected := range tt.checkHeaders {
-				actual := w.Header().Get(header)
-				if actual != expected {
-					t.Errorf("Expected header %s=%s, got %s", header, expected, actual)
+			if tt.expectedLimit != nil || tt.expectedOffset != nil || tt.expectedTotal != nil {
+				if envelope.Pagination == nil {
+					t.Fatal("Expected pagination to be present")
+				}
+				if tt.expectedLimit != nil {
+					if envelope.Pagination.Limit == nil || *envelope.Pagination.Limit != *tt.expectedLimit {
+						t.Errorf("Expected limit=%d, got %v", *tt.expectedLimit, envelope.Pagination.Limit)
+					}
+				}
+				if tt.expectedOffset != nil {
+					if envelope.Pagination.Offset == nil || *envelope.Pagination.Offset != *tt.expectedOffset {
+						t.Errorf("Expected offset=%d, got %v", *tt.expectedOffset, envelope.Pagination.Offset)
+					}
+				}
+				if tt.expectedTotal != nil {
+					if envelope.Pagination.TotalCount == nil || *envelope.Pagination.TotalCount != *tt.expectedTotal {
+						t.Errorf("Expected total_count=%d, got %v", *tt.expectedTotal, envelope.Pagination.TotalCount)
+					}
+				}
+			}
+
+			// Pagination headers should NOT be set
+			for _, h := range []string{"X-Total-Count", "X-Limit", "X-Offset"} {
+				if v := w.Header().Get(h); v != "" {
+					t.Errorf("Header %s should not be set, got %s", h, v)
 				}
 			}
 		})
 	}
 }
+
+func intPtr(i int) *int { return &i }
 
 // TestHandler_GetAll_FilterOperators tests filter operator parsing (filter[field][op]=value)
 func TestHandler_GetAll_FilterOperators(t *testing.T) {
@@ -1063,20 +1100,28 @@ func TestHandler_GetAll_FilterOperators(t *testing.T) {
 				return
 			}
 
-			var results []TestUser
-			if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+			var envelope handler.ListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 				t.Fatal("Failed to unmarshal response:", err)
 			}
 
-			if len(results) != tt.expectedCount {
-				t.Errorf("Expected %d results, got %d", tt.expectedCount, len(results))
+			items, ok := envelope.Data.([]interface{})
+			if !ok {
+				t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+			}
+
+			if len(items) != tt.expectedCount {
+				t.Errorf("Expected %d results, got %d", tt.expectedCount, len(items))
 			}
 
 			// Check specific names if provided
 			if len(tt.checkNames) > 0 {
 				names := make(map[string]bool)
-				for _, r := range results {
-					names[r.Name] = true
+				for _, item := range items {
+					m, _ := item.(map[string]interface{})
+					if name, ok := m["name"].(string); ok {
+						names[name] = true
+					}
 				}
 				for _, expected := range tt.checkNames {
 					if !names[expected] {
@@ -1972,11 +2017,11 @@ func TestCustomGetAll(t *testing.T) {
 	}()
 
 	// Custom function that filters to only return users with ID > 201
-	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
 		// Get all, then filter
-		all, _, _, err := svc.GetAll(ctx)
+		all, _, _, _, err := svc.GetAll(ctx)
 		if err != nil {
-			return nil, 0, nil, err
+			return nil, 0, nil, nil, err
 		}
 		var filtered []*TestUser
 		for _, u := range all {
@@ -1984,7 +2029,7 @@ func TestCustomGetAll(t *testing.T) {
 				filtered = append(filtered, u)
 			}
 		}
-		return filtered, len(filtered), nil, nil
+		return filtered, len(filtered), nil, nil, nil
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/users", nil)
@@ -1999,14 +2044,19 @@ func TestCustomGetAll(t *testing.T) {
 		return
 	}
 
-	var result []*TestUser
-	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+	var envelope handler.ListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("Failed to decode response: %v", err)
 	}
 
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+
 	// Should only have users 202 and 203
-	if len(result) != 2 {
-		t.Errorf("Expected 2 users, got %d", len(result))
+	if len(items) != 2 {
+		t.Errorf("Expected 2 users, got %d", len(items))
 	}
 }
 
@@ -2788,7 +2838,7 @@ type TestSumProduct struct {
 	InStock       bool    `bun:"in_stock,notnull" json:"in_stock"`
 }
 
-func TestHandler_GetAll_SumHeaders(t *testing.T) {
+func TestHandler_GetAll_Sums(t *testing.T) {
 	// Setup: create sum_products table
 	db, _ := datastore.Get()
 	_, err := db.GetDB().NewCreateTable().Model((*TestSumProduct)(nil)).IfNotExists().Exec(context.Background())
@@ -2829,68 +2879,51 @@ func TestHandler_GetAll_SumHeaders(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		queryString     string
-		expectedHeaders map[string]string
+		name          string
+		queryString   string
+		expectedSums  map[string]float64
+		expectedTotal *int
 	}{
 		{
-			name:        "single integer sum",
-			queryString: "sum=Price",
-			expectedHeaders: map[string]string{
-				"X-Sum-Price": "180", // 100 + 50 + 30
-			},
+			name:         "single integer sum",
+			queryString:  "sum=Price",
+			expectedSums: map[string]float64{"Price": 180},
 		},
 		{
-			name:        "single float sum",
-			queryString: "sum=Rating",
-			expectedHeaders: map[string]string{
-				"X-Sum-Rating": "12.5", // 4.5 + 3.8 + 4.2
-			},
+			name:         "single float sum",
+			queryString:  "sum=Rating",
+			expectedSums: map[string]float64{"Rating": 12.5},
 		},
 		{
-			name:        "multiple sums",
-			queryString: "sum=Price,Rating",
-			expectedHeaders: map[string]string{
-				"X-Sum-Price":  "180",
-				"X-Sum-Rating": "12.5",
-			},
+			name:         "multiple sums",
+			queryString:  "sum=Price,Rating",
+			expectedSums: map[string]float64{"Price": 180, "Rating": 12.5},
 		},
 		{
-			name:        "non-numeric field returns 0",
-			queryString: "sum=Name",
-			expectedHeaders: map[string]string{
-				"X-Sum-Name": "0",
-			},
+			name:         "non-numeric field returns 0",
+			queryString:  "sum=Name",
+			expectedSums: map[string]float64{"Name": 0},
 		},
 		{
-			name:        "bool field sums true values",
-			queryString: "sum=InStock",
-			expectedHeaders: map[string]string{
-				"X-Sum-InStock": "2", // Apple=true(1) + Banana=true(1) + Carrot=false(0) = 2
-			},
+			name:         "bool field sums true values",
+			queryString:  "sum=InStock",
+			expectedSums: map[string]float64{"InStock": 2},
 		},
 		{
-			name:        "mixed valid and invalid",
-			queryString: "sum=Price,Name",
-			expectedHeaders: map[string]string{
-				"X-Sum-Price": "180",
-				"X-Sum-Name":  "0",
-			},
+			name:         "mixed valid and invalid",
+			queryString:  "sum=Price,Name",
+			expectedSums: map[string]float64{"Price": 180, "Name": 0},
 		},
 		{
-			name:        "sum with count combined",
-			queryString: "sum=Price&count=true",
-			expectedHeaders: map[string]string{
-				"X-Sum-Price":   "180",
-				"X-Total-Count": "3",
-			},
+			name:          "sum with count combined",
+			queryString:   "sum=Price&count=true",
+			expectedSums:  map[string]float64{"Price": 180},
+			expectedTotal: intPtr(3),
 		},
 		{
-			name:        "sum with filter",
-			queryString: "sum=Price&filter[InStock]=true",
-			expectedHeaders: map[string]string{
-				"X-Sum-Price": "150", // Only Apple(100) + Banana(50)
-			},
+			name:         "sum with filter",
+			queryString:  "sum=Price&filter[InStock]=true",
+			expectedSums: map[string]float64{"Price": 150},
 		},
 	}
 
@@ -2914,11 +2947,34 @@ func TestHandler_GetAll_SumHeaders(t *testing.T) {
 				return
 			}
 
-			// Check expected headers
-			for header, expected := range tt.expectedHeaders {
-				actual := w.Header().Get(header)
+			var envelope handler.ListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+				t.Fatal("Failed to unmarshal response:", err)
+			}
+
+			for field, expected := range tt.expectedSums {
+				actual, ok := envelope.Sums[field]
+				if !ok {
+					t.Errorf("Expected sum for %s, not found in envelope", field)
+					continue
+				}
 				if actual != expected {
-					t.Errorf("Expected header %s=%s, got %s", header, expected, actual)
+					t.Errorf("Expected sum %s=%v, got %v", field, expected, actual)
+				}
+			}
+
+			if tt.expectedTotal != nil {
+				if envelope.Pagination == nil || envelope.Pagination.TotalCount == nil {
+					t.Errorf("Expected total_count=%d, but pagination is nil", *tt.expectedTotal)
+				} else if *envelope.Pagination.TotalCount != *tt.expectedTotal {
+					t.Errorf("Expected total_count=%d, got %d", *tt.expectedTotal, *envelope.Pagination.TotalCount)
+				}
+			}
+
+			// Sum headers should NOT be set
+			for field := range tt.expectedSums {
+				if h := w.Header().Get("X-Sum-" + field); h != "" {
+					t.Errorf("X-Sum-%s header should not be set, got %s", field, h)
 				}
 			}
 		})
@@ -2934,31 +2990,31 @@ func TestHandler_GetAll_ErrorPaths(t *testing.T) {
 	}{
 		{
 			name: "context canceled",
-			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-				return nil, 0, nil, context.Canceled
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+				return nil, 0, nil, nil, context.Canceled
 			},
 			expectedCode: http.StatusOK, // No response written when context is canceled
 		},
 		{
 			name: "context deadline exceeded",
-			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-				return nil, 0, nil, context.DeadlineExceeded
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+				return nil, 0, nil, nil, context.DeadlineExceeded
 			},
 			expectedCode: http.StatusGatewayTimeout,
 			expectedBody: "Gateway Timeout",
 		},
 		{
 			name: "service unavailable",
-			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-				return nil, 0, nil, apperrors.ErrUnavailable
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+				return nil, 0, nil, nil, apperrors.ErrUnavailable
 			},
 			expectedCode: http.StatusServiceUnavailable,
 			expectedBody: "Service Unavailable",
 		},
 		{
 			name: "generic error",
-			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, error) {
-				return nil, 0, nil, fmt.Errorf("some internal error")
+			getAllFunc: func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+				return nil, 0, nil, nil, fmt.Errorf("some internal error")
 			},
 			expectedCode: http.StatusInternalServerError,
 			expectedBody: "Internal Server Error",

--- a/handler/response.go
+++ b/handler/response.go
@@ -1,0 +1,31 @@
+package handler
+
+// ListResponse is the envelope returned by GetAll endpoints.
+// Data contains the result items. Pagination and Sums are omitted when empty.
+type ListResponse struct {
+	Data       any                `json:"data"`
+	Pagination *PaginationInfo    `json:"pagination,omitempty"`
+	Sums       map[string]float64 `json:"sums,omitempty"`
+}
+
+// PaginationInfo contains pagination metadata in the response envelope.
+// For offset mode: Limit, Offset, and TotalCount are populated.
+// For cursor mode: NextCursor, PrevCursor, HasMore, and TotalCount are populated.
+type PaginationInfo struct {
+	// Offset pagination fields
+	Limit  *int `json:"limit,omitempty"`
+	Offset *int `json:"offset,omitempty"`
+
+	// Cursor pagination fields
+	NextCursor *string `json:"next_cursor,omitempty"`
+	PrevCursor *string `json:"prev_cursor,omitempty"`
+	HasMore    *bool   `json:"has_more,omitempty"`
+
+	// Common field
+	TotalCount *int `json:"total_count,omitempty"`
+}
+
+// BatchResponse is the envelope returned by batch create/update/patch endpoints.
+type BatchResponse struct {
+	Data any `json:"data"`
+}

--- a/handler/response_test.go
+++ b/handler/response_test.go
@@ -1,0 +1,514 @@
+//nolint:staticcheck,errcheck,gosec // Test code - string context keys and unchecked test cleanup are acceptable
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+	"github.com/sjgoldie/go-restgen/handler"
+	"github.com/sjgoldie/go-restgen/metadata"
+	"github.com/sjgoldie/go-restgen/service"
+)
+
+func TestGetAll_ReturnsEnvelope(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@test.com"},
+		{Name: "Bob", Email: "bob@test.com"},
+	}
+	for _, u := range users {
+		_, err := db.GetDB().NewInsert().Model(&u).Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert test user:", err)
+		}
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items, got %d", len(items))
+	}
+}
+
+func TestGetAll_EnvelopeWithOffsetPagination(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@test.com"},
+		{Name: "Bob", Email: "bob@test.com"},
+		{Name: "Charlie", Email: "charlie@test.com"},
+	}
+	for _, u := range users {
+		_, err := db.GetDB().NewInsert().Model(&u).Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert test user:", err)
+		}
+	}
+
+	paginatedMeta := &metadata.TypeMetadata{
+		TypeID:       "test_paginated_id",
+		TypeName:     "TestUser",
+		TableName:    "users",
+		URLParamUUID: "id",
+		PKField:      "ID",
+		ModelType:    reflect.TypeOf(TestUser{}),
+		DefaultLimit: 10,
+		MaxLimit:     100,
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(paginatedMeta))
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users?limit=2&offset=1&count=true", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items, got %d", len(items))
+	}
+
+	if envelope.Pagination == nil {
+		t.Fatal("Expected pagination to be present")
+	}
+	if envelope.Pagination.Limit == nil || *envelope.Pagination.Limit != 2 {
+		t.Errorf("Expected limit=2, got %v", envelope.Pagination.Limit)
+	}
+	if envelope.Pagination.Offset == nil || *envelope.Pagination.Offset != 1 {
+		t.Errorf("Expected offset=1, got %v", envelope.Pagination.Offset)
+	}
+	if envelope.Pagination.TotalCount == nil || *envelope.Pagination.TotalCount != 3 {
+		t.Errorf("Expected total_count=3, got %v", envelope.Pagination.TotalCount)
+	}
+
+	// Headers should NOT be set — all metadata is in the envelope
+	if h := w.Header().Get("X-Total-Count"); h != "" {
+		t.Errorf("X-Total-Count header should not be set, got %s", h)
+	}
+	if h := w.Header().Get("X-Limit"); h != "" {
+		t.Errorf("X-Limit header should not be set, got %s", h)
+	}
+	if h := w.Header().Get("X-Offset"); h != "" {
+		t.Errorf("X-Offset header should not be set, got %s", h)
+	}
+}
+
+func TestGetAll_EnvelopeWithSums(t *testing.T) {
+	db, _ := datastore.Get()
+	_, err := db.GetDB().NewCreateTable().Model((*TestSumProduct)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create sum_products table:", err)
+	}
+	defer db.GetDB().NewDropTable().Model((*TestSumProduct)(nil)).IfExists().Exec(context.Background())
+
+	_, _ = db.GetDB().NewDelete().Model((*TestSumProduct)(nil)).Where("1=1").Exec(context.Background())
+	_, _ = db.GetDB().Exec("DELETE FROM sqlite_sequence WHERE name = 'sum_products'")
+
+	products := []TestSumProduct{
+		{Name: "Apple", Price: 100, Rating: 4.5, InStock: true},
+		{Name: "Banana", Price: 50, Rating: 3.8, InStock: true},
+	}
+	for _, p := range products {
+		_, err := db.GetDB().NewInsert().Model(&p).Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert test product:", err)
+		}
+	}
+
+	sumMeta := &metadata.TypeMetadata{
+		TypeID:         "test_sum_envelope_id",
+		TypeName:       "TestSumProduct",
+		TableName:      "sum_products",
+		URLParamUUID:   "id",
+		PKField:        "ID",
+		ModelType:      reflect.TypeOf(TestSumProduct{}),
+		SummableFields: []string{"Price", "Rating"},
+		DefaultLimit:   10,
+		MaxLimit:       100,
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(sumMeta))
+	r.Get("/products", handler.GetAll[TestSumProduct](handler.StandardGetAll[TestSumProduct]))
+
+	req := httptest.NewRequest(http.MethodGet, "/products?sum=Price,Rating&count=true", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	if envelope.Sums == nil {
+		t.Fatal("Expected sums to be present")
+	}
+	if envelope.Sums["Price"] != 150 {
+		t.Errorf("Expected Price sum=150, got %v", envelope.Sums["Price"])
+	}
+	if envelope.Sums["Rating"] != 8.3 {
+		t.Errorf("Expected Rating sum=8.3, got %v", envelope.Sums["Rating"])
+	}
+
+	if envelope.Pagination == nil || envelope.Pagination.TotalCount == nil || *envelope.Pagination.TotalCount != 2 {
+		t.Errorf("Expected total_count=2 in pagination")
+	}
+
+	// Sum headers should NOT be set
+	if h := w.Header().Get("X-Sum-Price"); h != "" {
+		t.Errorf("X-Sum-Price header should not be set, got %s", h)
+	}
+	if h := w.Header().Get("X-Sum-Rating"); h != "" {
+		t.Errorf("X-Sum-Rating header should not be set, got %s", h)
+	}
+}
+
+func TestGetAll_EnvelopeEmptyResult(t *testing.T) {
+	cleanTable(t)
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 0 {
+		t.Errorf("Expected 0 items, got %d", len(items))
+	}
+}
+
+func TestGetAll_EnvelopeNoPaginationWhenNotRequested(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	_, err := db.GetDB().NewInsert().Model(&TestUser{Name: "Alice", Email: "alice@test.com"}).Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert test user:", err)
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	// No pagination params
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	if envelope.Pagination != nil {
+		t.Errorf("Expected no pagination when no pagination params requested, got %+v", envelope.Pagination)
+	}
+	if envelope.Sums != nil {
+		t.Errorf("Expected no sums when not requested, got %+v", envelope.Sums)
+	}
+}
+
+func TestGetAll_CustomGetAllReturnsEnvelope(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@test.com"},
+		{Name: "Bob", Email: "bob@test.com"},
+	}
+	for _, u := range users {
+		db.GetDB().NewInsert().Model(&u).Exec(context.Background())
+	}
+
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		return []*TestUser{{ID: 1, Name: "Custom"}}, 1, nil, nil, nil
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](customGetAll))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 1 {
+		t.Errorf("Expected 1 item, got %d", len(items))
+	}
+}
+
+func TestGetAll_EnvelopeWithCursorPagination(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@test.com"},
+		{Name: "Bob", Email: "bob@test.com"},
+	}
+	for _, u := range users {
+		db.GetDB().NewInsert().Model(&u).Exec(context.Background())
+	}
+
+	nextCursor := "abc123"
+	prevCursor := "xyz789"
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		items, _, _, _, err := svc.GetAll(ctx)
+		if err != nil {
+			return nil, 0, nil, nil, err
+		}
+		cursor := &metadata.CursorInfo{
+			NextCursor: nextCursor,
+			PrevCursor: prevCursor,
+			HasMore:    true,
+		}
+		return items, 0, nil, cursor, nil
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](customGetAll))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	items, ok := envelope.Data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected data to be an array, got %T", envelope.Data)
+	}
+	if len(items) != 2 {
+		t.Errorf("Expected 2 items, got %d", len(items))
+	}
+
+	if envelope.Pagination == nil {
+		t.Fatal("Expected pagination to be present")
+	}
+	if envelope.Pagination.HasMore == nil || !*envelope.Pagination.HasMore {
+		t.Error("Expected has_more=true")
+	}
+	if envelope.Pagination.NextCursor == nil || *envelope.Pagination.NextCursor != nextCursor {
+		t.Errorf("Expected next_cursor=%q, got %v", nextCursor, envelope.Pagination.NextCursor)
+	}
+	if envelope.Pagination.PrevCursor == nil || *envelope.Pagination.PrevCursor != prevCursor {
+		t.Errorf("Expected prev_cursor=%q, got %v", prevCursor, envelope.Pagination.PrevCursor)
+	}
+	if envelope.Pagination.Limit != nil {
+		t.Error("Expected limit to be nil for cursor pagination")
+	}
+	if envelope.Pagination.Offset != nil {
+		t.Error("Expected offset to be nil for cursor pagination")
+	}
+}
+
+func TestGetAll_EnvelopeWithCursorPaginationAndCount(t *testing.T) {
+	cleanTable(t)
+
+	db, _ := datastore.Get()
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@test.com"},
+		{Name: "Bob", Email: "bob@test.com"},
+		{Name: "Charlie", Email: "charlie@test.com"},
+	}
+	for _, u := range users {
+		db.GetDB().NewInsert().Model(&u).Exec(context.Background())
+	}
+
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		cursor := &metadata.CursorInfo{
+			NextCursor: "next123",
+			HasMore:    true,
+		}
+		return []*TestUser{{ID: 1, Name: "Alice"}}, 3, nil, cursor, nil
+	}
+
+	paginatedMeta := &metadata.TypeMetadata{
+		TypeID:       "test_cursor_count_id",
+		TypeName:     "TestUser",
+		TableName:    "users",
+		URLParamUUID: "id",
+		PKField:      "ID",
+		ModelType:    reflect.TypeOf(TestUser{}),
+		DefaultLimit: 10,
+		MaxLimit:     100,
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(paginatedMeta))
+	r.Get("/users", handler.GetAll[TestUser](customGetAll))
+
+	req := httptest.NewRequest(http.MethodGet, "/users?count=true", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	if envelope.Pagination == nil {
+		t.Fatal("Expected pagination to be present")
+	}
+	if envelope.Pagination.HasMore == nil || !*envelope.Pagination.HasMore {
+		t.Error("Expected has_more=true")
+	}
+	if envelope.Pagination.NextCursor == nil || *envelope.Pagination.NextCursor != "next123" {
+		t.Errorf("Expected next_cursor=next123, got %v", envelope.Pagination.NextCursor)
+	}
+	if envelope.Pagination.TotalCount == nil || *envelope.Pagination.TotalCount != 3 {
+		t.Errorf("Expected total_count=3, got %v", envelope.Pagination.TotalCount)
+	}
+}
+
+func TestGetAll_EnvelopeCursorNoPrevOnFirstPage(t *testing.T) {
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		cursor := &metadata.CursorInfo{
+			NextCursor: "next_page",
+			PrevCursor: "",
+			HasMore:    true,
+		}
+		return []*TestUser{{ID: 1, Name: "Alice"}}, 0, nil, cursor, nil
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](customGetAll))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	if envelope.Pagination == nil {
+		t.Fatal("Expected pagination to be present")
+	}
+	if envelope.Pagination.PrevCursor != nil {
+		t.Error("Expected prev_cursor to be nil on first page")
+	}
+	if envelope.Pagination.NextCursor == nil || *envelope.Pagination.NextCursor != "next_page" {
+		t.Errorf("Expected next_cursor=next_page, got %v", envelope.Pagination.NextCursor)
+	}
+}
+
+func TestGetAll_EnvelopeCursorLastPage(t *testing.T) {
+	customGetAll := func(ctx context.Context, svc *service.Common[TestUser], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*TestUser, int, map[string]float64, *metadata.CursorInfo, error) {
+		cursor := &metadata.CursorInfo{
+			NextCursor: "",
+			PrevCursor: "prev_page",
+			HasMore:    false,
+		}
+		return []*TestUser{{ID: 3, Name: "Charlie"}}, 0, nil, cursor, nil
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(userMeta))
+	r.Get("/users", handler.GetAll[TestUser](customGetAll))
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var envelope handler.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode envelope: %v", err)
+	}
+
+	if envelope.Pagination == nil {
+		t.Fatal("Expected pagination to be present")
+	}
+	if envelope.Pagination.HasMore == nil || *envelope.Pagination.HasMore {
+		t.Error("Expected has_more=false on last page")
+	}
+	if envelope.Pagination.NextCursor != nil {
+		t.Error("Expected next_cursor to be nil on last page")
+	}
+	if envelope.Pagination.PrevCursor == nil || *envelope.Pagination.PrevCursor != "prev_page" {
+		t.Errorf("Expected prev_cursor=prev_page, got %v", envelope.Pagination.PrevCursor)
+	}
+}

--- a/metadata/cursor.go
+++ b/metadata/cursor.go
@@ -1,0 +1,55 @@
+package metadata
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// CursorInfo holds pagination cursors returned alongside list results.
+// For cursor-based pagination, NextCursor and PrevCursor are populated.
+// HasMore indicates whether there are more items beyond the current page.
+type CursorInfo struct {
+	NextCursor string // opaque cursor for the next page (empty if no next page)
+	PrevCursor string // opaque cursor for the previous page (empty if no previous page)
+	HasMore    bool   // true if there are more items beyond the current page
+}
+
+// Cursor holds the encoded position for cursor-based pagination.
+// It contains the sort field values and primary key value of the last/first item
+// in the current page, enabling efficient keyset pagination.
+type Cursor struct {
+	// Values holds the sort column values in the same order as the ORDER BY clause.
+	Values []any `json:"v"`
+	// PK holds the primary key value used as the tie-breaker.
+	PK any `json:"pk"`
+}
+
+// EncodeCursor serialises a Cursor to a URL-safe, opaque base64 string.
+func EncodeCursor(c Cursor) (string, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encoding cursor: %w", err)
+	}
+	return base64.URLEncoding.EncodeToString(data), nil
+}
+
+// DecodeCursor deserialises a base64 cursor string back into a Cursor.
+// Returns an error for invalid base64, malformed JSON, or missing fields.
+func DecodeCursor(encoded string) (Cursor, error) {
+	data, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return Cursor{}, fmt.Errorf("invalid cursor: bad encoding")
+	}
+
+	var c Cursor
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Cursor{}, fmt.Errorf("invalid cursor: malformed data")
+	}
+
+	if c.PK == nil {
+		return Cursor{}, fmt.Errorf("invalid cursor: missing primary key")
+	}
+
+	return c, nil
+}

--- a/metadata/cursor_test.go
+++ b/metadata/cursor_test.go
@@ -1,0 +1,183 @@
+package metadata
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestEncodeCursor_RoundTrip(t *testing.T) {
+	original := Cursor{
+		Values: []any{float64(42), "hello"},
+		PK:     float64(7),
+	}
+
+	encoded, err := EncodeCursor(original)
+	if err != nil {
+		t.Fatalf("EncodeCursor failed: %v", err)
+	}
+
+	if encoded == "" {
+		t.Fatal("EncodeCursor returned empty string")
+	}
+
+	decoded, err := DecodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("DecodeCursor failed: %v", err)
+	}
+
+	if len(decoded.Values) != 2 {
+		t.Fatalf("Expected 2 values, got %d", len(decoded.Values))
+	}
+
+	if decoded.Values[0].(float64) != 42 {
+		t.Errorf("Expected first value 42, got %v", decoded.Values[0])
+	}
+	if decoded.Values[1].(string) != "hello" {
+		t.Errorf("Expected second value 'hello', got %v", decoded.Values[1])
+	}
+	if decoded.PK.(float64) != 7 {
+		t.Errorf("Expected PK 7, got %v", decoded.PK)
+	}
+}
+
+func TestEncodeCursor_EmptyValues(t *testing.T) {
+	original := Cursor{
+		Values: []any{},
+		PK:     float64(1),
+	}
+
+	encoded, err := EncodeCursor(original)
+	if err != nil {
+		t.Fatalf("EncodeCursor failed: %v", err)
+	}
+
+	decoded, err := DecodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("DecodeCursor failed: %v", err)
+	}
+
+	if len(decoded.Values) != 0 {
+		t.Errorf("Expected 0 values, got %d", len(decoded.Values))
+	}
+	if decoded.PK.(float64) != 1 {
+		t.Errorf("Expected PK 1, got %v", decoded.PK)
+	}
+}
+
+func TestDecodeCursor_InvalidBase64(t *testing.T) {
+	_, err := DecodeCursor("not-valid-base64!!!")
+	if err == nil {
+		t.Error("Expected error for invalid base64")
+	}
+}
+
+func TestDecodeCursor_MalformedJSON(t *testing.T) {
+	// Valid base64 but not valid JSON
+	_, err := DecodeCursor("bm90LWpzb24=") // "not-json" in base64
+	if err == nil {
+		t.Error("Expected error for malformed JSON")
+	}
+}
+
+func TestDecodeCursor_MissingPK(t *testing.T) {
+	// Valid base64 JSON but missing pk field
+	_, err := DecodeCursor("eyJ2IjpbMV19") // {"v":[1]} in base64
+	if err == nil {
+		t.Error("Expected error for missing PK")
+	}
+}
+
+func TestDecodeCursor_EmptyString(t *testing.T) {
+	_, err := DecodeCursor("")
+	if err == nil {
+		t.Error("Expected error for empty cursor string")
+	}
+}
+
+func TestDecodeCursor_StringPK(t *testing.T) {
+	original := Cursor{
+		Values: []any{"some-sort-value"},
+		PK:     "uuid-pk-value",
+	}
+
+	encoded, err := EncodeCursor(original)
+	if err != nil {
+		t.Fatalf("EncodeCursor failed: %v", err)
+	}
+
+	decoded, err := DecodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("DecodeCursor failed: %v", err)
+	}
+
+	if decoded.PK.(string) != "uuid-pk-value" {
+		t.Errorf("Expected PK 'uuid-pk-value', got %v", decoded.PK)
+	}
+}
+
+func TestDecodeCursor_NilValues(t *testing.T) {
+	original := Cursor{
+		PK: float64(1),
+	}
+
+	encoded, err := EncodeCursor(original)
+	if err != nil {
+		t.Fatalf("EncodeCursor failed: %v", err)
+	}
+
+	decoded, err := DecodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("DecodeCursor failed: %v", err)
+	}
+
+	if decoded.Values != nil {
+		t.Errorf("Expected nil values, got %v", decoded.Values)
+	}
+}
+
+func TestParseQueryOptions_CursorParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          url.Values
+		expectedAfter  string
+		expectedBefore string
+	}{
+		{
+			name:           "after cursor",
+			query:          url.Values{"after": {"abc123"}},
+			expectedAfter:  "abc123",
+			expectedBefore: "",
+		},
+		{
+			name:           "before cursor",
+			query:          url.Values{"before": {"xyz789"}},
+			expectedAfter:  "",
+			expectedBefore: "xyz789",
+		},
+		{
+			name:           "no cursors",
+			query:          url.Values{},
+			expectedAfter:  "",
+			expectedBefore: "",
+		},
+		{
+			name:           "cursor with other params",
+			query:          url.Values{"after": {"cursor1"}, "limit": {"20"}, "sort": {"name"}},
+			expectedAfter:  "cursor1",
+			expectedBefore: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ParseQueryOptions(tt.query)
+
+			if opts.After != tt.expectedAfter {
+				t.Errorf("After: expected %q, got %q", tt.expectedAfter, opts.After)
+			}
+			if opts.Before != tt.expectedBefore {
+				t.Errorf("Before: expected %q, got %q", tt.expectedBefore, opts.Before)
+			}
+		})
+	}
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -118,6 +118,19 @@ type parentTenantKeyType string
 // Value is []*TypeMetadata - list of parent types in the chain that require tenant checks
 const ParentTenantKey parentTenantKeyType = "restgen_parent_tenant"
 
+// PaginationMode controls whether cursor-based or offset-based pagination is used.
+// Zero value means no pagination mode configured.
+type PaginationMode int
+
+const (
+	// NoPagination means pagination is not configured (zero value).
+	NoPagination PaginationMode = iota
+	// CursorPagination uses cursor-based (keyset) pagination.
+	CursorPagination
+	// OffsetPagination uses traditional offset-based pagination.
+	OffsetPagination
+)
+
 // DefaultMaxBodySize is the default maximum size for JSON request bodies (1 MB).
 const DefaultMaxBodySize int64 = 1 << 20
 
@@ -152,12 +165,13 @@ type TypeMetadata struct {
 	ParentFKField string // Field name on parent that holds this object's ID (e.g., "AuthorID")
 
 	// Query options for GetAll
-	FilterableFields []string // Field names allowed for filtering (empty = no filtering)
-	SortableFields   []string // Field names allowed for sorting (empty = no sorting)
-	SummableFields   []string // Field names allowed for sum aggregation (empty = no sums)
-	DefaultSort      string   // Default sort field (prefix with - for descending)
-	DefaultLimit     int      // Default page size (0 = no limit)
-	MaxLimit         int      // Maximum allowed limit (0 = no max)
+	FilterableFields []string       // Field names allowed for filtering (empty = no filtering)
+	SortableFields   []string       // Field names allowed for sorting (empty = no sorting)
+	SummableFields   []string       // Field names allowed for sum aggregation (empty = no sums)
+	DefaultSort      string         // Default sort field (prefix with - for descending)
+	DefaultLimit     int            // Default page size (0 = no limit)
+	MaxLimit         int            // Maximum allowed limit (0 = no max)
+	Pagination       PaginationMode // Pagination strategy (CursorPagination or OffsetPagination)
 
 	// Validation
 	Validator any // ValidatorFunc[T] stored as any for type erasure
@@ -196,6 +210,7 @@ func (m *TypeMetadata) Clone() *TypeMetadata {
 		DefaultSort:     m.DefaultSort,
 		DefaultLimit:    m.DefaultLimit,
 		MaxLimit:        m.MaxLimit,
+		Pagination:      m.Pagination,
 		Validator:       m.Validator,
 		Auditor:         m.Auditor,
 		IsFileResource:  m.IsFileResource,
@@ -245,6 +260,8 @@ type QueryOptions struct {
 	Sort       []SortField            // ordered list of sort fields
 	Limit      int                    // 0 means use default
 	Offset     int                    // 0 means start from beginning
+	After      string                 // cursor for forward pagination (next page)
+	Before     string                 // cursor for backward pagination (previous page)
 	CountTotal bool                   // whether to return total count
 	Include    []string               // relation names to include via ?include=
 	Sums       []string               // field names to compute sum aggregates via ?sum=
@@ -391,6 +408,10 @@ func ParseQueryOptions(query url.Values) *QueryOptions {
 			opts.Offset = offset
 		}
 	}
+
+	// Parse cursor pagination
+	opts.After = query.Get("after")
+	opts.Before = query.Get("before")
 
 	// Parse count flag
 	if countStr := query.Get("count"); countStr == "true" || countStr == "1" {

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -440,10 +440,13 @@ func TestAuth_Ownership_List(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var posts []AuthTestPost
-	if err := json.Unmarshal(w.Body.Bytes(), &posts); err != nil {
+	var envelope struct {
+		Data []AuthTestPost `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+	posts := envelope.Data
 
 	// Should only see user1's post
 	if len(posts) != 1 {
@@ -487,10 +490,13 @@ func TestAuth_Ownership_BypassScope(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var posts []AuthTestPost
-	if err := json.Unmarshal(w.Body.Bytes(), &posts); err != nil {
+	var envelope struct {
+		Data []AuthTestPost `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+	posts := envelope.Data
 
 	// Admin should see all posts
 	if len(posts) != 2 {
@@ -1859,10 +1865,13 @@ func TestAuth_Issue28_ParentOwnershipFiltering(t *testing.T) {
 				t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
 			}
 
-			var tasks []OwnershipTestTask
-			if err := json.Unmarshal(w.Body.Bytes(), &tasks); err != nil {
+			var envelope struct {
+				Data []OwnershipTestTask `json:"data"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 				t.Fatalf("failed to parse response: %v", err)
 			}
+			tasks := envelope.Data
 
 			if len(tasks) != tt.expectedTasks {
 				t.Errorf("expected %d tasks, got %d", tt.expectedTasks, len(tasks))
@@ -2047,10 +2056,13 @@ func TestTenantAuth_List_FiltersByTenant(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var projects []TenantTestProject
-	if err := json.Unmarshal(w.Body.Bytes(), &projects); err != nil {
+	var envelope struct {
+		Data []TenantTestProject `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
+	projects := envelope.Data
 
 	if len(projects) != 1 {
 		t.Errorf("expected 1 project for org-a, got %d", len(projects))
@@ -2187,10 +2199,13 @@ func TestTenantAuth_IsTenantTable_ViewOwnOrg(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var orgs []TenantTestOrg
-	if err := json.Unmarshal(w.Body.Bytes(), &orgs); err != nil {
+	var envelope struct {
+		Data []TenantTestOrg `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
+	orgs := envelope.Data
 
 	if len(orgs) != 1 {
 		t.Errorf("expected 1 org (own), got %d", len(orgs))
@@ -2270,10 +2285,13 @@ func TestTenantAuth_ChildInheritsTenantScope(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var tasks []TenantTestTask
-	if err := json.Unmarshal(w.Body.Bytes(), &tasks); err != nil {
+	var envelope struct {
+		Data []TenantTestTask `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
+	tasks := envelope.Data
 
 	if len(tasks) != 1 {
 		t.Errorf("expected 1 task for org-a, got %d", len(tasks))
@@ -2287,10 +2305,13 @@ func TestTenantAuth_ChildInheritsTenantScope(t *testing.T) {
 	// Parent project belongs to org-b — should be blocked
 	// Either 404 (parent not found) or empty results
 	if w2.Code == http.StatusOK {
-		var crossTasks []TenantTestTask
-		if err := json.Unmarshal(w2.Body.Bytes(), &crossTasks); err != nil {
+		var crossEnvelope struct {
+			Data []TenantTestTask `json:"data"`
+		}
+		if err := json.Unmarshal(w2.Body.Bytes(), &crossEnvelope); err != nil {
 			t.Fatalf("failed to unmarshal cross-tenant tasks: %v", err)
 		}
+		crossTasks := crossEnvelope.Data
 		if len(crossTasks) != 0 {
 			t.Errorf("expected 0 tasks for cross-tenant parent, got %d", len(crossTasks))
 		}
@@ -2326,10 +2347,13 @@ func TestTenantAuth_WithOwnership_BothEnforced(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var projects []TenantTestProject
-	if err := json.Unmarshal(w.Body.Bytes(), &projects); err != nil {
+	var envelope struct {
+		Data []TenantTestProject `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to parse: %v", err)
 	}
+	projects := envelope.Data
 
 	if len(projects) != 1 {
 		t.Errorf("expected 1 project (alice in org-a), got %d", len(projects))

--- a/router/batch_test.go
+++ b/router/batch_test.go
@@ -195,11 +195,13 @@ func TestBatch_CustomBatchUpdate(t *testing.T) {
 	}
 
 	// Get the created ID from response
-	var created []BatchTestItem
-	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+	var envelope struct {
+		Data []BatchTestItem `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal(err)
 	}
-	itemID := created[0].ID
+	itemID := envelope.Data[0].ID
 
 	// Now update
 	updateBody := fmt.Sprintf(`[{"id": %d, "name": "Updated", "value": 2}]`, itemID)
@@ -244,11 +246,13 @@ func TestBatch_CustomBatchDelete(t *testing.T) {
 	}
 
 	// Get the created ID from response
-	var created []BatchTestItem
-	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+	var envelope struct {
+		Data []BatchTestItem `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatal(err)
 	}
-	itemID := created[0].ID
+	itemID := envelope.Data[0].ID
 
 	// Now delete
 	deleteBody := fmt.Sprintf(`[{"id": %d}]`, itemID)

--- a/router/builder.go
+++ b/router/builder.go
@@ -682,6 +682,9 @@ func mergeQueryConfigs(meta *metadata.TypeMetadata, queryConfigs []QueryConfig) 
 		if qc.DefaultLimit > 0 {
 			result.DefaultLimit = qc.DefaultLimit
 		}
+		if qc.Pagination != metadata.NoPagination {
+			result.Pagination = qc.Pagination
+		}
 		if qc.MaxLimit > 0 {
 			result.MaxLimit = qc.MaxLimit
 		}

--- a/router/builder_internal_test.go
+++ b/router/builder_internal_test.go
@@ -189,6 +189,69 @@ func TestMergeQueryConfigs(t *testing.T) {
 			t.Error("original metadata was mutated")
 		}
 	})
+
+	t.Run("cursor pagination mode is applied from config", func(t *testing.T) {
+		original := &metadata.TypeMetadata{
+			TypeID: "test",
+		}
+
+		configs := []QueryConfig{
+			{
+				DefaultLimit: 20,
+				MaxLimit:     100,
+				Pagination:   CursorMode,
+			},
+		}
+
+		result := mergeQueryConfigs(original, configs)
+
+		if result.Pagination != metadata.CursorPagination {
+			t.Errorf("expected CursorPagination, got %d", result.Pagination)
+		}
+		if result.DefaultLimit != 20 {
+			t.Errorf("expected DefaultLimit 20, got %d", result.DefaultLimit)
+		}
+	})
+
+	t.Run("offset pagination mode is applied from config", func(t *testing.T) {
+		original := &metadata.TypeMetadata{
+			TypeID: "test",
+		}
+
+		configs := []QueryConfig{
+			{
+				DefaultLimit: 20,
+				MaxLimit:     100,
+				Pagination:   OffsetMode,
+			},
+		}
+
+		result := mergeQueryConfigs(original, configs)
+
+		if result.Pagination != metadata.OffsetPagination {
+			t.Errorf("expected OffsetPagination, got %d", result.Pagination)
+		}
+	})
+
+	t.Run("pagination mode not overridden when config has NoPagination", func(t *testing.T) {
+		original := &metadata.TypeMetadata{
+			TypeID:     "test",
+			Pagination: metadata.CursorPagination,
+		}
+
+		configs := []QueryConfig{
+			{
+				// Only setting filters, no pagination mode
+				FilterableFields: []string{"Name"},
+			},
+		}
+
+		result := mergeQueryConfigs(original, configs)
+
+		if result.Pagination != metadata.CursorPagination {
+			t.Errorf("expected original CursorPagination preserved, got %d", result.Pagination)
+		}
+	})
 }
 
 func TestRegisterChildAuthConfig(t *testing.T) {

--- a/router/builder_test.go
+++ b/router/builder_test.go
@@ -165,10 +165,13 @@ func TestBuilder_BasicRoutes(t *testing.T) {
 			path:           "/users",
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, body []byte) {
-				var users []*TestUser
-				if err := json.Unmarshal(body, &users); err != nil {
+				var envelope struct {
+					Data []*TestUser `json:"data"`
+				}
+				if err := json.Unmarshal(body, &envelope); err != nil {
 					t.Fatalf("failed to unmarshal response: %v", err)
 				}
+				users := envelope.Data
 				if len(users) != 1 {
 					t.Errorf("expected 1 user, got %d", len(users))
 				}
@@ -261,10 +264,13 @@ func TestBuilder_NestedRoutes(t *testing.T) {
 			path:           "/users/1/posts",
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, body []byte) {
-				var posts []*TestPost
-				if err := json.Unmarshal(body, &posts); err != nil {
+				var envelope struct {
+					Data []*TestPost `json:"data"`
+				}
+				if err := json.Unmarshal(body, &envelope); err != nil {
 					t.Fatalf("failed to unmarshal response: %v", err)
 				}
+				posts := envelope.Data
 				if len(posts) != 1 {
 					t.Errorf("expected 1 post, got %d", len(posts))
 				}
@@ -360,10 +366,13 @@ func TestBuilder_ThreeLevels(t *testing.T) {
 		t.Errorf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
 	}
 
-	var comments []*TestComment
-	if err := json.Unmarshal(w.Body.Bytes(), &comments); err != nil {
+	var envelope struct {
+		Data []*TestComment `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+	comments := envelope.Data
 
 	if len(comments) != 1 {
 		t.Errorf("expected 1 comment, got %d", len(comments))
@@ -498,8 +507,11 @@ func TestMultiReg_SameModelRootAndNested(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 2 {
 			t.Errorf("expected 2 items from root, got %d", len(items))
 		}
@@ -515,8 +527,11 @@ func TestMultiReg_SameModelRootAndNested(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("expected 1 item from nested, got %d", len(items))
 		}
@@ -605,8 +620,11 @@ func TestMultiReg_SameModelDifferentParents(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("expected 1 item for project, got %d", len(items))
 		}
@@ -624,8 +642,11 @@ func TestMultiReg_SameModelDifferentParents(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("expected 1 item for user, got %d", len(items))
 		}
@@ -708,8 +729,11 @@ func TestMultiReg_DifferentOwnershipPerRegistration(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 2 {
 			t.Errorf("expected 2 items from root (no ownership), got %d", len(items))
 		}
@@ -725,8 +749,11 @@ func TestMultiReg_DifferentOwnershipPerRegistration(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("expected 1 item for alice (ownership filtered), got %d", len(items))
 		}
@@ -789,8 +816,11 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("admin should see project item, got %d items", len(items))
 		}
@@ -825,8 +855,11 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		// Admin should see 0 items (ownership enforced, admin_user != charlie)
 		if len(items) != 0 {
 			t.Errorf("admin should NOT bypass user items (no moderator scope), got %d items", len(items))
@@ -862,8 +895,11 @@ func TestMultiReg_DifferentBypassScopesPerRegistration(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var items []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &items)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		items := envelope.Data
 		if len(items) != 1 {
 			t.Errorf("moderator should see user item, got %d items", len(items))
 		}
@@ -913,8 +949,11 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var result []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &result)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		result := envelope.Data
 		if len(result) != 1 {
 			t.Errorf("expected 1 item filtered by title, got %d", len(result))
 		}
@@ -932,8 +971,11 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var result []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &result)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		result := envelope.Data
 		if len(result) != 3 {
 			t.Errorf("expected 3 items, got %d", len(result))
 		}
@@ -957,8 +999,11 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var result []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &result)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		result := envelope.Data
 		if len(result) != 2 {
 			t.Errorf("expected 2 items with limit=2, got %d", len(result))
 		}
@@ -974,8 +1019,11 @@ func TestBuilder_QueryConfigOptions(t *testing.T) {
 			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 		}
 
-		var result []MultiRegItem
-		json.Unmarshal(w.Body.Bytes(), &result)
+		var envelope struct {
+			Data []MultiRegItem `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &envelope)
+		result := envelope.Data
 		// Should return all 3 items (invalid filter ignored)
 		if len(result) != 3 {
 			t.Errorf("expected 3 items (invalid filter ignored), got %d", len(result))
@@ -1017,18 +1065,20 @@ func TestBuilder_ParentValidation(t *testing.T) {
 		t.Errorf("expected status 200, got %d", w.Code)
 	}
 
-	var posts []*TestPost
-	if err := json.Unmarshal(w.Body.Bytes(), &posts); err != nil {
+	var envelope struct {
+		Data []*TestPost `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 
 	// Should only get User1's post
-	if len(posts) != 1 {
-		t.Errorf("expected 1 post for user1, got %d", len(posts))
+	if len(envelope.Data) != 1 {
+		t.Errorf("expected 1 post for user1, got %d", len(envelope.Data))
 	}
 
-	if len(posts) > 0 && posts[0].Title != "User1's Post" {
-		t.Errorf("expected 'User1's Post', got %q", posts[0].Title)
+	if len(envelope.Data) > 0 && envelope.Data[0].Title != "User1's Post" {
+		t.Errorf("expected 'User1's Post', got %q", envelope.Data[0].Title)
 	}
 
 	// Verify User2's post with User1's ID returns 404
@@ -1303,7 +1353,7 @@ func TestBuilder_CustomHandlers(t *testing.T) {
 			customGetCalled = true
 			return svc.Get(ctx, id)
 		}),
-		router.WithCustomGetAll(func(ctx context.Context, svc *service.Common[MultiRegItem], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*MultiRegItem, int, map[string]float64, error) {
+		router.WithCustomGetAll(func(ctx context.Context, svc *service.Common[MultiRegItem], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*MultiRegItem, int, map[string]float64, *metadata.CursorInfo, error) {
 			customGetAllCalled = true
 			return svc.GetAll(ctx)
 		}),

--- a/router/custom_test.go
+++ b/router/custom_test.go
@@ -33,8 +33,8 @@ func TestWithCustomGet(t *testing.T) {
 }
 
 func TestWithCustomGetAll(t *testing.T) {
-	customFunc := func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
-		return []*CustomTestModel{{ID: 1, Name: "test"}}, 1, nil, nil
+	customFunc := func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, *metadata.CursorInfo, error) {
+		return []*CustomTestModel{{ID: 1, Name: "test"}}, 1, nil, nil, nil
 	}
 
 	config := WithCustomGetAll(customFunc)
@@ -95,8 +95,8 @@ func TestCustomConfigTypesInSwitch(t *testing.T) {
 		return nil, nil
 	})
 
-	getAllConfig := WithCustomGetAll(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
-		return nil, 0, nil, nil
+	getAllConfig := WithCustomGetAll(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, *metadata.CursorInfo, error) {
+		return nil, 0, nil, nil, nil
 	})
 
 	createConfig := WithCustomCreate(func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, item CustomTestModel, _ io.Reader, _ filestore.FileMetadata) (*CustomTestModel, error) {
@@ -154,8 +154,8 @@ func TestCustomFuncTypesMatchHandler(t *testing.T) {
 		return nil, nil
 	}
 
-	var _ handler.CustomGetAllFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, error) {
-		return nil, 0, nil, nil
+	var _ handler.CustomGetAllFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo) ([]*CustomTestModel, int, map[string]float64, *metadata.CursorInfo, error) {
+		return nil, 0, nil, nil, nil
 	}
 
 	var _ handler.CustomCreateFunc[CustomTestModel] = func(ctx context.Context, svc *service.Common[CustomTestModel], meta *metadata.TypeMetadata, auth *metadata.AuthInfo, item CustomTestModel, _ io.Reader, _ filestore.FileMetadata) (*CustomTestModel, error) {

--- a/router/query.go
+++ b/router/query.go
@@ -1,13 +1,26 @@
 package router
 
+import "github.com/sjgoldie/go-restgen/metadata"
+
+// PaginationMode is an alias for metadata.PaginationMode for use in router options.
+type PaginationMode = metadata.PaginationMode
+
+const (
+	// CursorMode uses cursor-based (keyset) pagination. This is the default.
+	CursorMode = metadata.CursorPagination
+	// OffsetMode uses traditional offset-based pagination.
+	OffsetMode = metadata.OffsetPagination
+)
+
 // QueryConfig defines query parameter configuration for GetAll endpoints
 type QueryConfig struct {
-	FilterableFields []string // Field names allowed for filtering
-	SortableFields   []string // Field names allowed for sorting
-	SummableFields   []string // Field names allowed for sum aggregation
-	DefaultSort      string   // Default sort field (prefix with - for descending)
-	DefaultLimit     int      // Default page size (0 = no limit)
-	MaxLimit         int      // Maximum allowed limit (0 = no max)
+	FilterableFields []string       // Field names allowed for filtering
+	SortableFields   []string       // Field names allowed for sorting
+	SummableFields   []string       // Field names allowed for sum aggregation
+	DefaultSort      string         // Default sort field (prefix with - for descending)
+	DefaultLimit     int            // Default page size (0 = no limit)
+	MaxLimit         int            // Maximum allowed limit (0 = no max)
+	Pagination       PaginationMode // Pagination mode (CursorMode or OffsetMode)
 }
 
 // WithQuery returns a QueryConfig with all query options configured
@@ -29,11 +42,17 @@ func WithSorts(fields ...string) QueryConfig {
 	}
 }
 
-// WithPagination returns a QueryConfig with pagination settings
-func WithPagination(defaultLimit, maxLimit int) QueryConfig {
+// WithPagination returns a QueryConfig with pagination settings.
+// Defaults to cursor-based pagination. Pass OffsetMode for offset-based pagination.
+func WithPagination(defaultLimit, maxLimit int, mode ...PaginationMode) QueryConfig {
+	m := CursorMode
+	if len(mode) > 0 {
+		m = mode[0]
+	}
 	return QueryConfig{
 		DefaultLimit: defaultLimit,
 		MaxLimit:     maxLimit,
+		Pagination:   m,
 	}
 }
 

--- a/router/query_test.go
+++ b/router/query_test.go
@@ -37,14 +37,41 @@ func TestWithSorts(t *testing.T) {
 }
 
 func TestWithPagination(t *testing.T) {
-	config := WithPagination(20, 100)
+	t.Run("defaults to cursor mode", func(t *testing.T) {
+		config := WithPagination(20, 100)
 
-	if config.DefaultLimit != 20 {
-		t.Errorf("expected default limit 20, got %d", config.DefaultLimit)
-	}
-	if config.MaxLimit != 100 {
-		t.Errorf("expected max limit 100, got %d", config.MaxLimit)
-	}
+		if config.DefaultLimit != 20 {
+			t.Errorf("expected default limit 20, got %d", config.DefaultLimit)
+		}
+		if config.MaxLimit != 100 {
+			t.Errorf("expected max limit 100, got %d", config.MaxLimit)
+		}
+		if config.Pagination != CursorMode {
+			t.Errorf("expected CursorMode, got %d", config.Pagination)
+		}
+	})
+
+	t.Run("explicit offset mode", func(t *testing.T) {
+		config := WithPagination(20, 100, OffsetMode)
+
+		if config.DefaultLimit != 20 {
+			t.Errorf("expected default limit 20, got %d", config.DefaultLimit)
+		}
+		if config.MaxLimit != 100 {
+			t.Errorf("expected max limit 100, got %d", config.MaxLimit)
+		}
+		if config.Pagination != OffsetMode {
+			t.Errorf("expected OffsetMode, got %d", config.Pagination)
+		}
+	})
+
+	t.Run("explicit cursor mode", func(t *testing.T) {
+		config := WithPagination(20, 100, CursorMode)
+
+		if config.Pagination != CursorMode {
+			t.Errorf("expected CursorMode, got %d", config.Pagination)
+		}
+	})
 }
 
 func TestWithDefaultSort(t *testing.T) {
@@ -74,6 +101,7 @@ func TestWithQuery(t *testing.T) {
 		DefaultSort:      "-CreatedAt",
 		DefaultLimit:     25,
 		MaxLimit:         50,
+		Pagination:       CursorMode,
 	}
 
 	config := WithQuery(input)
@@ -92,6 +120,9 @@ func TestWithQuery(t *testing.T) {
 	}
 	if config.MaxLimit != 50 {
 		t.Errorf("expected max limit 50, got %d", config.MaxLimit)
+	}
+	if config.Pagination != CursorMode {
+		t.Errorf("expected CursorMode, got %d", config.Pagination)
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sjgoldie/go-restgen/datastore"
 	"github.com/sjgoldie/go-restgen/filestore"
+	"github.com/sjgoldie/go-restgen/metadata"
 )
 
 // Common provides generic CRUD operations for any model type
@@ -25,8 +26,8 @@ type DownloadResult struct {
 }
 
 // GetAll retrieves all items of type T
-// Returns items, total count (0 if not requested), sums (nil if not requested), and error
-func (s *Common[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, error) {
+// Returns items, total count (0 if not requested), sums (nil if not requested), cursor info (nil if not cursor mode), and error
+func (s *Common[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64, *metadata.CursorInfo, error) {
 	return s.store.GetAll(ctx)
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -164,7 +164,7 @@ func TestService_GetAll(t *testing.T) {
 				t.Fatal("Failed to create service:", err)
 			}
 
-			items, _, _, err := svc.GetAll(ctxWithMeta(testModelMeta))
+			items, _, _, _, err := svc.GetAll(ctxWithMeta(testModelMeta))
 			if err != nil {
 				t.Fatal("GetAll failed:", err)
 			}
@@ -1132,7 +1132,7 @@ func TestService_BatchDelete(t *testing.T) {
 	}
 
 	// Verify they're gone
-	all, _, _, err := svc.GetAll(ctx)
+	all, _, _, _, err := svc.GetAll(ctx)
 	if err != nil {
 		t.Fatal("GetAll failed:", err)
 	}


### PR DESCRIPTION
## Summary

- **Response envelope**: All list endpoints now return `{data, pagination, sums}` and batch endpoints return `{data}` instead of raw arrays. Single-item responses remain unwrapped.
- **Cursor-based pagination**: Default pagination mode using keyset/cursor approach with `?after=` and `?before=` parameters for efficient forward/backward navigation. N+1 fetch detects `has_more`. Offset pagination available via `router.OffsetMode`.
- **Breaking API changes**: Sums moved from `X-Sum-*` headers to response body `sums` object. Total count moved from `X-Total-Count` header to `pagination.total_count`. `CustomGetAllFunc` signature gains `*metadata.CursorInfo` return value. `WithPagination` defaults to `CursorMode`.

### Key implementation details

- Cursor encoding: base64 URL-safe JSON containing sort field values + PK for keyset positioning
- Direction-aware WHERE clauses: disjunctive normal form handles mixed ASC/DESC sort columns correctly
- PK tie-breaker appended to all sorts for deterministic ordering
- Backward pagination: sort reversed internally, results reversed back to natural order
- `FieldName()` added to `schema.go` as inverse of `ColumnName()`

### Files changed

- **New**: `handler/response.go`, `metadata/cursor.go` + tests
- **Modified**: handler, datastore, service, router, metadata packages
- **Bruno tests**: 85 existing tests updated for envelope format, 13 new cursor pagination tests
- **Docs**: README, AGENT.md, skill files all updated

## Test plan

- [x] All unit tests pass (8 packages, 80%+ coverage)
- [x] All benchmarks pass (18 benchmarks)
- [x] All Bruno integration tests pass (16 suites, ~300 tests)
- [x] Cursor pagination tested: forward, backward, with filters, with DESC sort, with count, with sums, invalid cursor, empty results
- [x] golangci-lint clean (dupl, errcheck, gocritic, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)