### PR TITLE
feat: child existence/count filters and include_count (#99)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -531,6 +531,9 @@ Built-in support on GetAll endpoints:
 |-----------|---------|-------------|
 | Filter | `?filter[status]=active` | Exact match |
 | Filter ops | `?filter[age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
+| Child field filter | `?filter[Orders.Status][eq]=active` | Filter by child/grandchild field value (uses EXISTS subquery). Dot notation for nested chains. |
+| Exists filter | `?filter[Orders][exists]=true` | Filter by existence of child relations. `true` = has children, `false` = has none. |
+| Count filter | `?filter[Orders][count_gt]=5` | Filter by child relation count. Operators: count_eq, count_neq, count_gt, count_gte, count_lt, count_lte |
 | Sort | `?sort=name,-created_at` | `-` prefix for descending |
 | Limit | `?limit=10` | Max results per page |
 | After | `?after=<cursor>` | Next page (cursor from `pagination.next_cursor`) |
@@ -538,6 +541,7 @@ Built-in support on GetAll endpoints:
 | Offset | `?offset=20` | Skip results (switches to offset pagination) |
 | Count | `?count=true` | Include `total_count` in `pagination` |
 | Include | `?include=Posts` or `?include=Posts.Comments` | Load relations (requires WithRelationName on child route). Dot notation for nested. |
+| Include count | `?include_count=Orders` or `?include_count=Orders,Items` | Include per-item child relation counts in response envelope. Comma-separated for multiple. |
 | Sum | `?sum=Price,Stock` | Sum fields, returns in `sums` object in response body (requires WithSums). Works with any DB-numeric type including `decimal.Decimal`. Bool fields return count of `true` values. DB validates types — non-numeric columns return a database error. |
 
 **Response envelope (GetAll):**
@@ -545,11 +549,13 @@ Built-in support on GetAll endpoints:
 {
   "data": [...],
   "pagination": {"has_more": true, "next_cursor": "...", "prev_cursor": "...", "total_count": 42},
-  "sums": {"Price": 1500.0, "Stock": 200.0}
+  "sums": {"Price": 1500.0, "Stock": 200.0},
+  "counts": {"Orders": {"1": 3, "2": 0}, "Items": {"1": 12, "2": 5}}
 }
 ```
 Cursor mode fields: `has_more`, `next_cursor`, `prev_cursor`, `total_count` (if `count=true`).
 Offset mode fields: `limit`, `offset`, `total_count` (if `count=true`).
+`counts` maps relation name → item PK → count (only present when `?include_count=` is used).
 Batch responses use `{"data": [...]}` envelope.
 Single-item responses (Get, Create, Update, Patch, Delete) return the raw object (no envelope).
 
@@ -558,6 +564,15 @@ Single-item responses (Get, Create, Update, Patch, Delete) return the raw object
 - `nin` - Not in list: `?filter[Status][nin]=deleted,archived`
 - `bt` - Between (inclusive): `?filter[Age][bt]=18,65`
 - `nbt` - Not between: `?filter[Price][nbt]=100,500`
+
+**Child relation filters:**
+- Child field: `?filter[Orders.Status][eq]=shipped` — parents WHERE EXISTS child with Status=shipped
+- Multi-level: `?filter[Orders.Items.SKU][eq]=ABC` — parents with grandchild matching
+- Exists: `?filter[Orders][exists]=true` — parents that have at least one Order
+- Count: `?filter[Orders][count_gt]=5` — parents with more than 5 Orders
+- Count operators: `count_eq`, `count_neq`, `count_gt`, `count_gte`, `count_lt`, `count_lte`
+- All relation filters require the child route to use `WithRelationName` (same as includes)
+- Auth: relation filters respect AllowedIncludes — unauthorized relations are silently skipped
 
 **Nested includes (dot notation):**
 - Child direction: `?include=Posts.Comments` — each level needs `WithRelationName` on its route

--- a/README.md
+++ b/README.md
@@ -924,6 +924,36 @@ GET /users?filter[Status]=active&filter[Role]=admin
 | `bt` | Between (inclusive) | `filter[Age][bt]=18,65` |
 | `nbt` | Not between | `filter[Price][nbt]=100,500` |
 
+**Child Relation Filters:**
+
+Filter parent resources based on child relation existence or count. Requires `WithRelationName` on the child route and the relation must be in `AllowedIncludes`.
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `exists` | Has/doesn't have children | `filter[Comments][exists]=true` |
+| `count_eq` | Exact child count | `filter[Comments][count_eq]=3` |
+| `count_neq` | Child count not equal | `filter[Comments][count_neq]=0` |
+| `count_gt` | Child count greater than | `filter[Comments][count_gt]=5` |
+| `count_gte` | Child count greater than or equal | `filter[Comments][count_gte]=1` |
+| `count_lt` | Child count less than | `filter[Comments][count_lt]=10` |
+| `count_lte` | Child count less than or equal | `filter[Comments][count_lte]=2` |
+
+```bash
+# Posts that have at least one comment
+GET /posts?filter[Comments][exists]=true
+
+# Posts with no comments
+GET /posts?filter[Comments][exists]=false
+
+# Posts with more than 5 comments
+GET /posts?filter[Comments][count_gt]=5
+
+# Combine with field filters
+GET /posts?filter[Status]=published&filter[Comments][count_gte]=1
+```
+
+Relation filters use correlated subqueries, so they respect tenant scoping and parent filtering automatically. Unauthorized relations are silently ignored (the filter is skipped and the broader result set is returned).
+
 ### Sorting
 
 Sort results using the `sort` query parameter:
@@ -1042,6 +1072,37 @@ GET /products?filter[Category]=Electronics&sum=Price,Stock&count=true
 ```
 
 Fields not listed in `WithSums` are silently ignored (returns 0). Bool fields return the count of `true` values. The database validates types — summing a non-numeric column (e.g. a string) returns a database error.
+
+### Relation Counts
+
+Request child relation counts per item using the `include_count` query parameter. The relation must be registered with `WithRelationName` and authorized via `AllowedIncludes`.
+
+```bash
+# Count comments per post
+GET /posts?include_count=Comments
+
+# Multiple relations
+GET /posts?include_count=Comments,Tags
+
+# Combine with filters and pagination
+GET /posts?filter[Status]=published&include_count=Comments&limit=10
+```
+
+**Response body** includes counts alongside data:
+```json
+{
+  "data": [
+    {"id": 1, "title": "First Post"},
+    {"id": 2, "title": "Second Post"}
+  ],
+  "counts": {
+    "Comments": {"1": 5, "2": 0},
+    "Tags": {"1": 3, "2": 1}
+  }
+}
+```
+
+The `counts` object maps relation name to a map of item primary key (as string) to count. Unauthorized relations are silently excluded from the response.
 
 See the [query example](./examples/query) for a complete working example with all filter operators, sorting, pagination, and sum aggregation.
 
@@ -2563,6 +2624,7 @@ go-restgen builds on these excellent projects:
 - [x] PATCH endpoint for partial updates (field-level, no deep patch)
 - [x] Custom join columns via `WithJoinOn` for non-FK relationships
 - [x] Multi-tenant data isolation with `WithTenantScope` and `IsTenantTable`
+- [x] Child relation filters (`exists`, `count_*`) and `include_count` for relation counts
 - [ ] MySQL support
 - [ ] OpenAPI/Swagger generation
 - [ ] Standalone examples (separate go.mod per example to avoid polluting main module)

--- a/bruno/relations-example/25-create-extra-comment-admin.bru
+++ b/bruno/relations-example/25-create-extra-comment-admin.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create Extra Comment on Alice's Post (as Admin)
+  type: http
+  seq: 25
+}
+
+post {
+  url: {{baseUrl}}/posts/{{alicePostId}}/comments
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+body:json {
+  {
+    "text": "Admin's comment on Alice's post"
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.owner_id: eq admin
+}
+
+docs {
+  Adds a second comment to Alice's post so we have varying comment counts:
+  Alice's post = 2 comments, Bob's post = 1 comment
+}

--- a/bruno/relations-example/26-create-post-no-comments.bru
+++ b/bruno/relations-example/26-create-post-no-comments.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Create Post With No Comments (as Admin)
+  type: http
+  seq: 26
+}
+
+post {
+  url: {{baseUrl}}/posts
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+body:json {
+  {
+    "author_id": {{aliceUserId}},
+    "title": "Empty Post",
+    "content": "This post has no comments",
+    "published": true
+  }
+}
+
+assert {
+  res.status: eq 201
+  res.body.id: isDefined
+  res.body.title: eq Empty Post
+}
+
+script:post-response {
+  bru.setVar("emptyPostId", res.body.id);
+}
+
+docs {
+  Creates a post with no comments for exists=false and count_eq=0 testing.
+}

--- a/bruno/relations-example/27-filter-exists-true.bru
+++ b/bruno/relations-example/27-filter-exists-true.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Filter Exists True - Posts with Comments
+  type: http
+  seq: 27
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][exists]=true
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 2
+}
+
+tests {
+  test("Only posts with comments returned", function() {
+    const titles = res.body.data.map(p => p.title).sort();
+    expect(titles).to.include("Alice's First Post");
+    expect(titles).to.include("Bob's First Post");
+    expect(titles).to.not.include("Empty Post");
+  });
+}
+
+docs {
+  Admin filters posts by existence of Comments relation.
+  Alice's post (2 comments) and Bob's post (1 comment) match.
+  Empty post (0 comments) is excluded.
+}

--- a/bruno/relations-example/28-filter-exists-false.bru
+++ b/bruno/relations-example/28-filter-exists-false.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Filter Exists False - Posts without Comments
+  type: http
+  seq: 28
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][exists]=false
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Only posts without comments returned", function() {
+    expect(res.body.data[0].title).to.equal("Empty Post");
+  });
+}
+
+docs {
+  Admin filters posts that have NO comments.
+  Only the Empty Post matches.
+}

--- a/bruno/relations-example/29-filter-count-gt.bru
+++ b/bruno/relations-example/29-filter-count-gt.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Filter Count GT - Posts with more than 1 comment
+  type: http
+  seq: 29
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][count_gt]=1
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Only Alice's post has more than 1 comment", function() {
+    expect(res.body.data[0].title).to.equal("Alice's First Post");
+  });
+}
+
+docs {
+  Admin filters posts where comment count > 1.
+  Alice's post has 2 comments. Bob's has 1. Empty has 0.
+}

--- a/bruno/relations-example/30-filter-count-eq-one.bru
+++ b/bruno/relations-example/30-filter-count-eq-one.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Filter Count EQ - Posts with exactly 1 comment
+  type: http
+  seq: 30
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][count_eq]=1
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Only Bob's post has exactly 1 comment", function() {
+    expect(res.body.data[0].title).to.equal("Bob's First Post");
+  });
+}
+
+docs {
+  Admin filters posts where comment count = 1.
+  Bob's post has exactly 1 comment.
+}

--- a/bruno/relations-example/31-filter-count-eq-zero.bru
+++ b/bruno/relations-example/31-filter-count-eq-zero.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Filter Count EQ Zero - Posts with no comments
+  type: http
+  seq: 31
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][count_eq]=0
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Only Empty Post has 0 comments", function() {
+    expect(res.body.data[0].title).to.equal("Empty Post");
+  });
+}
+
+docs {
+  Admin filters posts where comment count = 0.
+  Equivalent to exists=false but using count operator.
+}

--- a/bruno/relations-example/32-include-count-comments.bru
+++ b/bruno/relations-example/32-include-count-comments.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Include Count - Comments per Post
+  type: http
+  seq: 32
+}
+
+get {
+  url: {{baseUrl}}/posts?include_count=Comments
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+  res.body.counts: isDefined
+  res.body.counts.Comments: isDefined
+}
+
+tests {
+  test("Comment counts are correct per post", function() {
+    const counts = res.body.counts.Comments;
+    const alicePostId = String(bru.getVar("alicePostId"));
+    const bobPostId = String(bru.getVar("bobPostId"));
+
+    expect(counts[alicePostId]).to.equal(2);
+    expect(counts[bobPostId]).to.equal(1);
+  });
+
+  test("Post with zero comments is omitted from counts", function() {
+    const counts = res.body.counts.Comments;
+    const emptyPostId = String(bru.getVar("emptyPostId"));
+    expect(counts[emptyPostId]).to.be.undefined;
+  });
+}
+
+docs {
+  Admin requests comment counts per post via include_count.
+  Counts are returned in the response envelope under counts.Comments.
+  Posts with zero comments are omitted from the counts map.
+}

--- a/bruno/relations-example/33-filter-exists-ownership.bru
+++ b/bruno/relations-example/33-filter-exists-ownership.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Security - Exists Filter with Ownership
+  type: http
+  seq: 33
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][exists]=true
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Ownership still enforced - Alice only sees her own posts", function() {
+    expect(res.body.data[0].title).to.equal("Alice's First Post");
+    expect(res.body.data[0].owner_id).to.equal("alice");
+  });
+
+  test("Bob's post is not visible despite having comments", function() {
+    const titles = res.body.data.map(p => p.title);
+    expect(titles).to.not.include("Bob's First Post");
+  });
+}
+
+docs {
+  Alice filters posts by exists=true on Comments.
+  Ownership on Posts is still enforced: Alice only sees her own posts.
+  Bob's post (which also has comments) is not returned.
+}

--- a/bruno/relations-example/34-filter-count-ownership.bru
+++ b/bruno/relations-example/34-filter-count-ownership.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Security - Count Filter with Ownership
+  type: http
+  seq: 34
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][count_gt]=0
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:bob:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 1
+}
+
+tests {
+  test("Ownership still enforced - Bob only sees his own posts", function() {
+    expect(res.body.data[0].title).to.equal("Bob's First Post");
+    expect(res.body.data[0].owner_id).to.equal("bob");
+  });
+
+  test("Alice's posts not visible despite matching filter", function() {
+    const ownerIds = res.body.data.map(p => p.owner_id);
+    expect(ownerIds).to.not.include("alice");
+  });
+}
+
+docs {
+  Bob filters posts by count_gt=0 on Comments.
+  Ownership on Posts is enforced: Bob only sees his own posts.
+  Alice's post (which also has comments) is not returned.
+}

--- a/bruno/relations-example/35-include-count-ownership.bru
+++ b/bruno/relations-example/35-include-count-ownership.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Security - Include Count with Ownership
+  type: http
+  seq: 35
+}
+
+get {
+  url: {{baseUrl}}/posts?include_count=Comments
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:alice:user
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.counts: isDefined
+  res.body.counts.Comments: isDefined
+}
+
+tests {
+  test("Only Alice's posts returned (ownership enforced)", function() {
+    expect(res.body.data.every(p => p.owner_id === "alice")).to.be.true;
+  });
+
+  test("Counts only include Alice's posts", function() {
+    const counts = res.body.counts.Comments;
+    const alicePostId = String(bru.getVar("alicePostId"));
+    expect(counts[alicePostId]).to.equal(2);
+
+    const bobPostId = String(bru.getVar("bobPostId"));
+    expect(counts[bobPostId]).to.be.undefined;
+  });
+}
+
+docs {
+  Alice requests include_count=Comments. Ownership enforced:
+  Only her posts are returned, and counts only cover her posts.
+  Bob's post and its counts are not leaked.
+}

--- a/bruno/relations-example/36-filter-nonexistent-relation.bru
+++ b/bruno/relations-example/36-filter-nonexistent-relation.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Security - Non-existent Relation Filter Ignored
+  type: http
+  seq: 36
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[FakeRelation][exists]=true
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 3
+}
+
+tests {
+  test("All posts returned - invalid relation filter silently ignored", function() {
+    expect(res.body.data.length).to.equal(3);
+  });
+}
+
+docs {
+  Filtering on a non-existent relation is silently ignored.
+  The filter is skipped and all results are returned (no error).
+}

--- a/bruno/relations-example/37-filter-count-lte.bru
+++ b/bruno/relations-example/37-filter-count-lte.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Filter Count LTE - Posts with at most 1 comment
+  type: http
+  seq: 37
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][count_lte]=1
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 2
+}
+
+tests {
+  test("Posts with 0 or 1 comments returned", function() {
+    const titles = res.body.data.map(p => p.title).sort();
+    expect(titles).to.include("Bob's First Post");
+    expect(titles).to.include("Empty Post");
+    expect(titles).to.not.include("Alice's First Post");
+  });
+}
+
+docs {
+  Admin filters posts where comment count <= 1.
+  Bob's post (1 comment) and Empty Post (0 comments) match.
+  Alice's post (2 comments) is excluded.
+}

--- a/bruno/relations-example/38-include-count-with-exists-filter.bru
+++ b/bruno/relations-example/38-include-count-with-exists-filter.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Combined - Include Count with Exists Filter
+  type: http
+  seq: 38
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][exists]=true&include_count=Comments
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: user:admin:user,admin
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isArray
+  res.body.data: length 2
+  res.body.counts: isDefined
+  res.body.counts.Comments: isDefined
+}
+
+tests {
+  test("Exists filter applied - only posts with comments", function() {
+    const titles = res.body.data.map(p => p.title).sort();
+    expect(titles).to.include("Alice's First Post");
+    expect(titles).to.include("Bob's First Post");
+  });
+
+  test("Counts reflect the filtered results", function() {
+    const counts = res.body.counts.Comments;
+    const alicePostId = String(bru.getVar("alicePostId"));
+    const bobPostId = String(bru.getVar("bobPostId"));
+    expect(counts[alicePostId]).to.equal(2);
+    expect(counts[bobPostId]).to.equal(1);
+  });
+}
+
+docs {
+  Combines exists filter with include_count on the same relation.
+  Filter narrows results, then counts are computed for the filtered set.
+}

--- a/bruno/relations-example/39-filter-exists-no-auth.bru
+++ b/bruno/relations-example/39-filter-exists-no-auth.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Security - Exists Filter without Auth Returns 401
+  type: http
+  seq: 39
+}
+
+get {
+  url: {{baseUrl}}/posts?filter[Comments][exists]=true
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 401
+}
+
+docs {
+  Posts endpoint requires auth (AllWithOwnershipUnless).
+  Unauthenticated requests get 401 before any relation filter is evaluated.
+}

--- a/cmd/install-skill/skill/SKILL.md
+++ b/cmd/install-skill/skill/SKILL.md
@@ -97,6 +97,39 @@ BlogID int `bun:"blog_id,notnull,skipupdate" json:"blog_id"`
 Blog  *Blog `bun:"rel:belongs-to,join:blog_id=id" json:"-"`
 ```
 
+## Child Relation Filters and Counts
+
+Filter parent resources by child relation existence or count, and request per-item child counts. Relations must be registered with `WithRelationName` and authorized via `AllowedIncludes`.
+
+```bash
+# Posts that have comments
+GET /posts?filter[Comments][exists]=true
+
+# Posts with no comments
+GET /posts?filter[Comments][exists]=false
+
+# Posts with more than 5 comments
+GET /posts?filter[Comments][count_gt]=5
+
+# Count operators: count_eq, count_neq, count_gt, count_gte, count_lt, count_lte
+
+# Get per-item comment counts in the response
+GET /posts?include_count=Comments
+
+# Combine filter and count
+GET /posts?filter[Comments][exists]=true&include_count=Comments
+```
+
+Response with `include_count`:
+```json
+{
+  "data": [...],
+  "counts": {"Comments": {"1": 5, "2": 3}}
+}
+```
+
+Unauthorized relations are silently skipped (filter ignored, count excluded).
+
 ## Custom Endpoints (Anything Funcs)
 
 ```go

--- a/cmd/install-skill/skill/patterns.md
+++ b/cmd/install-skill/skill/patterns.md
@@ -298,6 +298,9 @@ router.WithAudit(func(ac metadata.AuditContext[T]) any {
 |-----------|---------|-------------|
 | Filter | `?filter[Status]=active` | Exact match |
 | Filter ops | `?filter[Age][gt]=18` | Operators: eq, neq, gt, gte, lt, lte, like, in, nin, bt, nbt |
+| Relation exists | `?filter[Comments][exists]=true` | Filter by child existence (true/false) |
+| Relation count | `?filter[Comments][count_gt]=5` | Filter by child count (count_eq, count_neq, count_gt, count_gte, count_lt, count_lte) |
+| Include count | `?include_count=Comments` | Return per-item child counts in `counts` object |
 | Sort | `?sort=Name,-CreatedAt` | `-` prefix for descending |
 | Limit | `?limit=10` | Max results per page |
 | After | `?after=<cursor>` | Next page (cursor from `pagination.next_cursor`) |
@@ -307,11 +310,13 @@ router.WithAudit(func(ac metadata.AuditContext[T]) any {
 | Include | `?include=Posts.Comments` | Load relations (dot notation for nested) |
 | Sum | `?sum=Price,Stock` | Returns in `sums` object in response body |
 
-**Response envelope (GetAll):** `{"data": [...], "pagination": {...}, "sums": {...}}`.
+**Response envelope (GetAll):** `{"data": [...], "pagination": {...}, "sums": {...}, "counts": {...}}`.
 Cursor mode: `has_more`, `next_cursor`, `prev_cursor`, `total_count`. Offset mode: `limit`, `offset`, `total_count`.
 Batch responses: `{"data": [...]}`. Single-item responses: raw object (no envelope).
 
 **Nested includes:** child direction needs `WithRelationName` at each level. Parent direction (e.g., `?include=Author`) auto-derived from `rel:belongs-to` tags. Auth is cumulative AND, ownership is cumulative OR.
+
+**Relation filters and counts:** `filter[Relation][exists]` and `filter[Relation][count_*]` use correlated subqueries and require the relation to be in `AllowedIncludes`. `include_count` returns `counts: {"Relation": {"pk": count}}` in the response. Unauthorized relations are silently skipped.
 
 ## Error Handling
 

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -255,39 +256,1195 @@ func TestMatchesParentName(t *testing.T) {
 	}
 }
 
-func TestBuildFilterCondition(t *testing.T) {
+type filterTestItem struct {
+	bun.BaseModel `bun:"table:filter_items"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+	Status        string `bun:"status"`
+	Amount        int    `bun:"amount"`
+	Category      string `bun:"category"`
+}
+
+func TestApplyFilter_WithTableName(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := db.GetDB().NewCreateTable().Model((*filterTestItem)(nil)).IfNotExists().Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items := []filterTestItem{
+		{Name: "alice", Status: "active", Amount: 100, Category: "A"},
+		{Name: "bob", Status: "inactive", Amount: 50, Category: "B"},
+		{Name: "charlie", Status: "active", Amount: 200, Category: "A"},
+		{Name: "diana", Status: "pending", Amount: 75, Category: "C"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&items).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
-		name     string
-		table    string
-		col      string
-		operator string
-		vals     []interface{}
-		wantSQL  string
-		wantArgs int
+		name      string
+		col       string
+		operator  string
+		vals      []interface{}
+		wantCount int
 	}{
-		{"eq", "users", "name", "eq", []interface{}{"alice"}, "users.name = ?", 1},
-		{"empty op defaults to eq", "users", "name", "", []interface{}{"bob"}, "users.name = ?", 1},
-		{"neq", "users", "status", "neq", []interface{}{"inactive"}, "users.status != ?", 1},
-		{"gt", "orders", "amount", "gt", []interface{}{100}, "orders.amount > ?", 1},
-		{"gte", "orders", "amount", "gte", []interface{}{100}, "orders.amount >= ?", 1},
-		{"lt", "orders", "amount", "lt", []interface{}{50}, "orders.amount < ?", 1},
-		{"lte", "orders", "amount", "lte", []interface{}{50}, "orders.amount <= ?", 1},
-		{"like", "users", "email", "like", []interface{}{"%@test.com"}, "users.email LIKE ?", 1},
-		{"in", "users", "role", "in", []interface{}{"admin", "user"}, "users.role IN (?, ?)", 2},
-		{"nin", "users", "role", "nin", []interface{}{"banned"}, "users.role NOT IN (?)", 1},
-		{"bt", "orders", "price", "bt", []interface{}{10, 100}, "orders.price BETWEEN ? AND ?", 2},
-		{"nbt", "orders", "price", "nbt", []interface{}{0, 5}, "orders.price NOT BETWEEN ? AND ?", 2},
+		{"eq", "name", metadata.OpEq, []interface{}{"alice"}, 1},
+		{"empty op defaults to eq", "name", "", []interface{}{"bob"}, 1},
+		{"neq", "status", metadata.OpNeq, []interface{}{"active"}, 2},
+		{"gt", "amount", metadata.OpGt, []interface{}{75}, 2},
+		{"gte", "amount", metadata.OpGte, []interface{}{75}, 3},
+		{"lt", "amount", metadata.OpLt, []interface{}{100}, 2},
+		{"lte", "amount", metadata.OpLte, []interface{}{100}, 3},
+		{"like", "name", metadata.OpLike, []interface{}{"a%"}, 1},
+		{"in", "category", metadata.OpIn, []interface{}{"A", "B"}, 3},
+		{"nin", "category", metadata.OpNin, []interface{}{"A"}, 2},
+		{"bt", "amount", metadata.OpBt, []interface{}{50, 100}, 3},
+		{"nbt", "amount", metadata.OpNbt, []interface{}{50, 100}, 1},
+		{"empty vals is no-op", "name", metadata.OpEq, []interface{}{}, 4},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql, args := buildFilterCondition(tt.table, tt.col, tt.operator, tt.vals)
-			if sql != tt.wantSQL {
-				t.Errorf("sql = %q, want %q", sql, tt.wantSQL)
+			query := db.GetDB().NewSelect().Table("filter_items")
+			result := applyFilter(query, "filter_items", tt.col, tt.operator, tt.vals)
+
+			count, err := result.Count(ctx)
+			if err != nil {
+				t.Fatalf("query failed: %v", err)
 			}
-			if len(args) != tt.wantArgs {
-				t.Errorf("args count = %d, want %d", len(args), tt.wantArgs)
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
 			}
 		})
 	}
+}
+
+type existsTestParent struct {
+	bun.BaseModel `bun:"table:exists_parents"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+}
+
+type existsTestChild struct {
+	bun.BaseModel `bun:"table:exists_children"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	ParentID      int    `bun:"parent_id"`
+	Status        string `bun:"status"`
+}
+
+type existsTestGrandchild struct {
+	bun.BaseModel `bun:"table:exists_grandchildren"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	ChildID       int    `bun:"child_id"`
+	Value         string `bun:"value"`
+}
+
+type existsChainFixture struct {
+	ctx            context.Context
+	wrapper        *Wrapper[existsTestParent]
+	parentMeta     *metadata.TypeMetadata
+	childMeta      *metadata.TypeMetadata
+	grandchildMeta *metadata.TypeMetadata
+}
+
+func setupExistsChainFixture(t *testing.T, db *SQLite) existsChainFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*existsTestParent)(nil),
+		(*existsTestChild)(nil),
+		(*existsTestGrandchild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*existsTestParent)(nil), (*existsTestChild)(nil), (*existsTestGrandchild)(nil))
+
+	parents := []existsTestParent{
+		{Name: "has-children"},
+		{Name: "no-children"},
+		{Name: "has-grandchildren"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []existsTestChild{
+		{ParentID: 1, Status: "active"},
+		{ParentID: 1, Status: "inactive"},
+		{ParentID: 3, Status: "active"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grandchildren := []existsTestGrandchild{
+		{ChildID: 3, Value: "deep"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&grandchildren).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return existsChainFixture{
+		ctx:     ctx,
+		wrapper: &Wrapper[existsTestParent]{Store: db},
+		parentMeta: &metadata.TypeMetadata{
+			ModelType: reflect.TypeOf(existsTestParent{}),
+			TableName: "exists_parents",
+		},
+		childMeta: &metadata.TypeMetadata{
+			ModelType:     reflect.TypeOf(existsTestChild{}),
+			TableName:     "exists_children",
+			ForeignKeyCol: "parent_id",
+		},
+		grandchildMeta: &metadata.TypeMetadata{
+			ModelType:     reflect.TypeOf(existsTestGrandchild{}),
+			TableName:     "exists_grandchildren",
+			ForeignKeyCol: "child_id",
+		},
+	}
+}
+
+func TestBuildExistsChain(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	f := setupExistsChainFixture(t, db)
+	ctx := f.ctx
+	wrapper := f.wrapper
+	parentMeta := f.parentMeta
+	childMeta := f.childMeta
+	grandchildMeta := f.grandchildMeta
+
+	t.Run("empty chain returns nil", func(t *testing.T) {
+		result := wrapper.buildExistsChain(parentMeta, nil, nil)
+		if result != nil {
+			t.Error("expected nil for empty chain")
+		}
+	})
+
+	t.Run("single level without inner filter", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, nil)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 2 {
+			t.Errorf("got %d results, want 2 (parents with children)", len(results))
+		}
+	})
+
+	t.Run("single level with inner filter", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_children", "status", metadata.OpEq, []interface{}{"inactive"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1", len(results))
+			return
+		}
+		if results[0].Name != "has-children" {
+			t.Errorf("got name %q, want %q", results[0].Name, "has-children")
+		}
+	})
+
+	t.Run("two level chain without inner filter", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, nil)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (only parent with grandchildren)", len(results))
+			return
+		}
+		if results[0].Name != "has-grandchildren" {
+			t.Errorf("got name %q, want %q", results[0].Name, "has-grandchildren")
+		}
+	})
+
+	t.Run("two level chain with inner filter", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_grandchildren", "value", metadata.OpEq, []interface{}{"deep"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1", len(results))
+		}
+	})
+
+	t.Run("two level chain with non-matching filter", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_grandchildren", "value", metadata.OpEq, []interface{}{"nonexistent"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 0 {
+			t.Errorf("got %d results, want 0", len(results))
+		}
+	})
+
+	t.Run("NOT EXISTS", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, nil)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("NOT EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (parent with no children)", len(results))
+			return
+		}
+		if results[0].Name != "no-children" {
+			t.Errorf("got name %q, want %q", results[0].Name, "no-children")
+		}
+	})
+
+	t.Run("inner filter with in operator", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_children", "status", metadata.OpIn, []interface{}{"active", "inactive"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 2 {
+			t.Errorf("got %d results, want 2", len(results))
+		}
+	})
+}
+
+func TestBuildExistsChain_CrossIsolation(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	f := setupExistsChainFixture(t, db)
+	ctx := f.ctx
+	wrapper := f.wrapper
+	parentMeta := f.parentMeta
+	childMeta := f.childMeta
+	grandchildMeta := f.grandchildMeta
+
+	t.Run("filter matches other parents children only", func(t *testing.T) {
+		// Parent 1 has active+inactive children, parent 3 has active only.
+		// Filtering for inactive must return parent 1 and exclude parent 3,
+		// even though inactive children exist in the table.
+		// A broken FK correlation (missing child.fk = parent.pk) would return both.
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_children", "status", metadata.OpEq, []interface{}{"inactive"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["has-grandchildren"] {
+			t.Error("has-grandchildren should be excluded: its children are all active")
+		}
+		if names["no-children"] {
+			t.Error("no-children should be excluded: it has no children at all")
+		}
+		if !names["has-children"] {
+			t.Error("has-children should be included: it has an inactive child")
+		}
+	})
+
+	t.Run("grandchildren dont leak to wrong parent", func(t *testing.T) {
+		// Grandchild exists under parent 3's child chain.
+		// Parent 1 has children but NO grandchildren.
+		// A broken nested FK correlation would let parent 1 match
+		// because grandchildren exist somewhere in the table.
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, nil)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["has-children"] {
+			t.Error("has-children should be excluded: its children have no grandchildren")
+		}
+		if names["no-children"] {
+			t.Error("no-children should be excluded: it has no children at all")
+		}
+		if !names["has-grandchildren"] {
+			t.Error("has-grandchildren should be included: it has grandchildren")
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want exactly 1", len(results))
+		}
+	})
+
+	t.Run("filtered grandchild doesnt leak", func(t *testing.T) {
+		// Grandchild with value="deep" exists under parent 3.
+		// Filtering grandchildren for value="deep" must NOT return parent 1,
+		// even though parent 1 has children (just not ones with grandchildren).
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "exists_grandchildren", "value", metadata.OpEq, []interface{}{"deep"})
+		})
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["has-children"] {
+			t.Error("data leak: has-children returned despite having no grandchildren with value=deep")
+		}
+		if names["no-children"] {
+			t.Error("data leak: no-children returned despite having no children at all")
+		}
+		if !names["has-grandchildren"] {
+			t.Error("has-grandchildren should be included")
+		}
+	})
+}
+
+func TestBuildCountChain(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*existsTestParent)(nil),
+		(*existsTestChild)(nil),
+		(*existsTestGrandchild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*existsTestParent)(nil), (*existsTestChild)(nil), (*existsTestGrandchild)(nil))
+
+	parents := []existsTestParent{
+		{Name: "has-two-children"},
+		{Name: "has-one-child"},
+		{Name: "no-children"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []existsTestChild{
+		{ParentID: 1, Status: "active"},
+		{ParentID: 1, Status: "inactive"},
+		{ParentID: 2, Status: "active"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grandchildren := []existsTestGrandchild{
+		{ChildID: 1, Value: "a"},
+		{ChildID: 1, Value: "b"},
+		{ChildID: 1, Value: "c"},
+		{ChildID: 3, Value: "d"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&grandchildren).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper := &Wrapper[existsTestParent]{Store: db}
+
+	parentMeta := &metadata.TypeMetadata{
+		ModelType: reflect.TypeOf(existsTestParent{}),
+		TableName: "exists_parents",
+	}
+
+	childMeta := &metadata.TypeMetadata{
+		ModelType:     reflect.TypeOf(existsTestChild{}),
+		TableName:     "exists_children",
+		ForeignKeyCol: "parent_id",
+	}
+
+	grandchildMeta := &metadata.TypeMetadata{
+		ModelType:     reflect.TypeOf(existsTestGrandchild{}),
+		TableName:     "exists_grandchildren",
+		ForeignKeyCol: "child_id",
+	}
+
+	t.Run("empty chain returns nil", func(t *testing.T) {
+		result := wrapper.buildCountChain(parentMeta, nil)
+		if result != nil {
+			t.Error("expected nil for empty chain")
+		}
+	})
+
+	t.Run("single level count", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		countSubq := wrapper.buildCountChain(parentMeta, chain)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("(?) > ?", countSubq, 1).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (parent with >1 children)", len(results))
+			return
+		}
+		if results[0].Name != "has-two-children" {
+			t.Errorf("got name %q, want %q", results[0].Name, "has-two-children")
+		}
+	})
+
+	t.Run("single level count eq zero", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta}
+		countSubq := wrapper.buildCountChain(parentMeta, chain)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("(?) = ?", countSubq, 0).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (parent with 0 children)", len(results))
+			return
+		}
+		if results[0].Name != "no-children" {
+			t.Errorf("got name %q, want %q", results[0].Name, "no-children")
+		}
+	})
+
+	t.Run("two level count", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		countSubq := wrapper.buildCountChain(parentMeta, chain)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("(?) >= ?", countSubq, 3).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (parent 1 has 3 grandchildren)", len(results))
+			return
+		}
+		if results[0].Name != "has-two-children" {
+			t.Errorf("got name %q, want %q", results[0].Name, "has-two-children")
+		}
+	})
+
+	t.Run("cross-parent count isolation", func(t *testing.T) {
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		countSubq := wrapper.buildCountChain(parentMeta, chain)
+
+		var results []existsTestParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("(?) = ?", countSubq, 1).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want 1 (parent 2 has 1 grandchild)", len(results))
+			return
+		}
+		if results[0].Name != "has-one-child" {
+			t.Errorf("got name %q, want %q", results[0].Name, "has-one-child")
+		}
+	})
+}
+
+func TestApplyRelationFilter_Exists(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*existsTestParent)(nil),
+		(*existsTestChild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*existsTestParent)(nil), (*existsTestChild)(nil))
+
+	parents := []existsTestParent{
+		{Name: "has-children"},
+		{Name: "no-children"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []existsTestChild{
+		{ParentID: 1, Status: "active"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper := &Wrapper[existsTestParent]{Store: db}
+
+	childMeta := &metadata.TypeMetadata{
+		ModelType:     reflect.TypeOf(existsTestChild{}),
+		TableName:     "exists_children",
+		ForeignKeyCol: "parent_id",
+	}
+
+	parentMeta := &metadata.TypeMetadata{
+		ModelType: reflect.TypeOf(existsTestParent{}),
+		TableName: "exists_parents",
+		ChildMeta: map[string]*metadata.TypeMetadata{"Children": childMeta},
+	}
+
+	t.Run("exists true", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "true", Operator: metadata.OpExists}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1", count)
+		}
+	})
+
+	t.Run("exists false", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "false", Operator: metadata.OpExists}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1", count)
+		}
+	})
+
+	t.Run("auth blocks unauthorized relation", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		allowed := metadata.AllowedIncludes{"Other": false}
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "true", Operator: metadata.OpExists}, allowed)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Errorf("got %d, want 2 (filter should be skipped)", count)
+		}
+	})
+
+	t.Run("auth allows authorized relation", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		allowed := metadata.AllowedIncludes{"Children": false}
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "true", Operator: metadata.OpExists}, allowed)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1", count)
+		}
+	})
+}
+
+func TestApplyRelationFilter_Count(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*existsTestParent)(nil),
+		(*existsTestChild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*existsTestParent)(nil), (*existsTestChild)(nil))
+
+	parents := []existsTestParent{
+		{Name: "three-children"},
+		{Name: "one-child"},
+		{Name: "no-children"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []existsTestChild{
+		{ParentID: 1, Status: "active"},
+		{ParentID: 1, Status: "active"},
+		{ParentID: 1, Status: "active"},
+		{ParentID: 2, Status: "active"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper := &Wrapper[existsTestParent]{Store: db}
+
+	childMeta := &metadata.TypeMetadata{
+		ModelType:     reflect.TypeOf(existsTestChild{}),
+		TableName:     "exists_children",
+		ForeignKeyCol: "parent_id",
+	}
+
+	parentMeta := &metadata.TypeMetadata{
+		ModelType: reflect.TypeOf(existsTestParent{}),
+		TableName: "exists_parents",
+		ChildMeta: map[string]*metadata.TypeMetadata{"Children": childMeta},
+	}
+
+	t.Run("count_gt", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "1", Operator: metadata.OpCountGt}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1 (only three-children has >1)", count)
+		}
+	})
+
+	t.Run("count_gte", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "1", Operator: metadata.OpCountGte}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Errorf("got %d, want 2 (three-children and one-child)", count)
+		}
+	})
+
+	t.Run("count_eq zero", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "0", Operator: metadata.OpCountEq}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1 (no-children)", count)
+		}
+	})
+
+	t.Run("count_lt", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "3", Operator: metadata.OpCountLt}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Errorf("got %d, want 2 (one-child=1, no-children=0)", count)
+		}
+	})
+
+	t.Run("invalid count value ignored", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyRelationFilter(ctx, query, parentMeta, "Children",
+			metadata.FilterValue{Value: "abc", Operator: metadata.OpCountGt}, nil)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 3 {
+			t.Errorf("got %d, want 3 (filter should be skipped for invalid value)", count)
+		}
+	})
+}
+
+func TestAllowedIncludes_ChildFieldFilter(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	if err := Initialize(db); err != nil {
+		t.Fatal(err)
+	}
+	defer Cleanup()
+
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*existsTestParent)(nil),
+		(*existsTestChild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*existsTestParent)(nil), (*existsTestChild)(nil))
+
+	parents := []existsTestParent{
+		{Name: "has-active"},
+		{Name: "has-inactive"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []existsTestChild{
+		{ParentID: 1, Status: "active"},
+		{ParentID: 2, Status: "inactive"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	childMeta := &metadata.TypeMetadata{
+		ModelType:        reflect.TypeOf(existsTestChild{}),
+		TableName:        "exists_children",
+		ForeignKeyCol:    "parent_id",
+		FilterableFields: []string{"Status"},
+	}
+
+	parentMeta := &metadata.TypeMetadata{
+		ModelType: reflect.TypeOf(existsTestParent{}),
+		TableName: "exists_parents",
+		PKField:   "ID",
+		ChildMeta: map[string]*metadata.TypeMetadata{"Children": childMeta},
+	}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Children.Status": {Value: "active", Operator: metadata.OpEq},
+		},
+	}
+
+	wrapper := &Wrapper[existsTestParent]{Store: db}
+
+	t.Run("no auth context allows filter", func(t *testing.T) {
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyQueryFilters(ctx, query, opts, parentMeta)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1 (filter should apply)", count)
+		}
+	})
+
+	t.Run("authorized relation allows filter", func(t *testing.T) {
+		allowed := metadata.AllowedIncludes{"Children": false}
+		authCtx := context.WithValue(ctx, metadata.AllowedIncludesKey, allowed)
+
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyQueryFilters(authCtx, query, opts, parentMeta)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("got %d, want 1 (filter should apply)", count)
+		}
+	})
+
+	t.Run("unauthorized relation blocks filter", func(t *testing.T) {
+		allowed := metadata.AllowedIncludes{"Other": false}
+		authCtx := context.WithValue(ctx, metadata.AllowedIncludesKey, allowed)
+
+		query := db.GetDB().NewSelect().Model(&[]existsTestParent{})
+		query = wrapper.applyQueryFilters(authCtx, query, opts, parentMeta)
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Errorf("got %d, want 2 (filter should be silently skipped)", count)
+		}
+	})
+}
+
+type tenantParent struct {
+	bun.BaseModel `bun:"table:tenant_parents"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	Name          string `bun:"name"`
+	TenantID      string `bun:"tenant_id"`
+}
+
+type tenantChild struct {
+	bun.BaseModel `bun:"table:tenant_children"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	ParentID      int    `bun:"parent_id"`
+	TenantID      string `bun:"tenant_id"`
+	Status        string `bun:"status"`
+}
+
+type tenantGrandchild struct {
+	bun.BaseModel `bun:"table:tenant_grandchildren"`
+	ID            int    `bun:"id,pk,autoincrement"`
+	ChildID       int    `bun:"child_id"`
+	TenantID      string `bun:"tenant_id"`
+	Value         string `bun:"value"`
+}
+
+type tenantChainFixture struct {
+	ctx            context.Context
+	wrapper        *Wrapper[tenantParent]
+	parentMeta     *metadata.TypeMetadata
+	childMeta      *metadata.TypeMetadata
+	grandchildMeta *metadata.TypeMetadata
+}
+
+func setupTenantChainFixture(t *testing.T, db *SQLite) tenantChainFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	for _, model := range []interface{}{
+		(*tenantParent)(nil),
+		(*tenantChild)(nil),
+		(*tenantGrandchild)(nil),
+	} {
+		_, err := db.GetDB().NewCreateTable().Model(model).IfNotExists().Exec(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.GetDB().RegisterModel((*tenantParent)(nil), (*tenantChild)(nil), (*tenantGrandchild)(nil))
+
+	// Tenant A: alice (has child), alex (no children)
+	// Tenant B: bob (has child), beth (child has wrong tenant_id=A)
+	parents := []tenantParent{
+		{Name: "alice", TenantID: "A"},
+		{Name: "alex", TenantID: "A"},
+		{Name: "bob", TenantID: "B"},
+		{Name: "beth", TenantID: "B"},
+	}
+	_, err := db.GetDB().NewInsert().Model(&parents).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	children := []tenantChild{
+		{ParentID: 1, TenantID: "A", Status: "active"},
+		{ParentID: 3, TenantID: "B", Status: "active"},
+		{ParentID: 4, TenantID: "A", Status: "active"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&children).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grandchildren := []tenantGrandchild{
+		{ChildID: 1, TenantID: "A", Value: "alpha"},
+		{ChildID: 2, TenantID: "B", Value: "bravo"},
+	}
+	_, err = db.GetDB().NewInsert().Model(&grandchildren).Exec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tenantChainFixture{
+		ctx:     ctx,
+		wrapper: &Wrapper[tenantParent]{Store: db},
+		parentMeta: &metadata.TypeMetadata{
+			ModelType: reflect.TypeOf(tenantParent{}),
+			TableName: "tenant_parents",
+		},
+		childMeta: &metadata.TypeMetadata{
+			ModelType:     reflect.TypeOf(tenantChild{}),
+			TableName:     "tenant_children",
+			ForeignKeyCol: "parent_id",
+		},
+		grandchildMeta: &metadata.TypeMetadata{
+			ModelType:     reflect.TypeOf(tenantGrandchild{}),
+			TableName:     "tenant_grandchildren",
+			ForeignKeyCol: "child_id",
+		},
+	}
+}
+
+func TestBuildExistsChain_TenantIsolation(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	f := setupTenantChainFixture(t, db)
+	ctx := f.ctx
+	wrapper := f.wrapper
+	parentMeta := f.parentMeta
+	childMeta := f.childMeta
+	grandchildMeta := f.grandchildMeta
+
+	t.Run("child tenant filter excludes cross-tenant data", func(t *testing.T) {
+		// Filter for children with tenant_id=B.
+		// bob has a child with tenant_id=B → included.
+		// beth has a child but with tenant_id=A → excluded (cross-tenant leak if not filtered).
+		// alice has a child with tenant_id=A → excluded.
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "tenant_children", "tenant_id", metadata.OpEq, []interface{}{"B"})
+		})
+
+		var results []tenantParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["alice"] {
+			t.Error("tenant leak: alice (tenant A) returned for tenant B child filter")
+		}
+		if names["alex"] {
+			t.Error("tenant leak: alex returned despite having no children")
+		}
+		if names["beth"] {
+			t.Error("tenant leak: beth returned despite her child having tenant_id=A, not B")
+		}
+		if !names["bob"] {
+			t.Error("bob should be included: has child with tenant_id=B")
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want exactly 1", len(results))
+		}
+	})
+
+	t.Run("child tenant filter for tenant A", func(t *testing.T) {
+		// Filter for children with tenant_id=A.
+		// alice has child with tenant_id=A → included.
+		// beth has child with tenant_id=A → also included (child has tenant A, even though beth is tenant B).
+		// This is correct behavior: the filter is on child tenant, not parent tenant.
+		// Real tenant enforcement needs conditions at EVERY chain level.
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "tenant_children", "tenant_id", metadata.OpEq, []interface{}{"A"})
+		})
+
+		var results []tenantParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if !names["alice"] {
+			t.Error("alice should be included: has child with tenant_id=A")
+		}
+		if !names["beth"] {
+			t.Error("beth should be included: has child with tenant_id=A (leaf-only filtering)")
+		}
+		if names["bob"] {
+			t.Error("bob should be excluded: child has tenant_id=B")
+		}
+		if names["alex"] {
+			t.Error("alex should be excluded: no children")
+		}
+	})
+
+	t.Run("grandchild tenant filter isolates across chain", func(t *testing.T) {
+		// Filter for grandchildren with tenant_id=B.
+		// Only bob's child has a grandchild with tenant_id=B → only bob returned.
+		// alice's child has a grandchild but with tenant_id=A → excluded.
+		chain := []*metadata.TypeMetadata{childMeta, grandchildMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return applyFilter(q, "tenant_grandchildren", "tenant_id", metadata.OpEq, []interface{}{"B"})
+		})
+
+		var results []tenantParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["alice"] {
+			t.Error("tenant leak: alice returned despite grandchild having tenant_id=A")
+		}
+		if names["beth"] {
+			t.Error("tenant leak: beth returned despite having no grandchildren")
+		}
+		if !names["bob"] {
+			t.Error("bob should be included: has grandchild with tenant_id=B")
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want exactly 1", len(results))
+		}
+	})
+
+	t.Run("combined FK and tenant filter prevents leak", func(t *testing.T) {
+		// Filter children: status=active AND tenant_id=B.
+		// All three children are active, but only child 2 (bob's) has tenant_id=B.
+		// beth's child is active but tenant_id=A → must be excluded.
+		chain := []*metadata.TypeMetadata{childMeta}
+		existsSubq := wrapper.buildExistsChain(parentMeta, chain, func(q *bun.SelectQuery) *bun.SelectQuery {
+			q = applyFilter(q, "tenant_children", "status", metadata.OpEq, []interface{}{"active"})
+			q = applyFilter(q, "tenant_children", "tenant_id", metadata.OpEq, []interface{}{"B"})
+			return q
+		})
+
+		var results []tenantParent
+		err := db.GetDB().NewSelect().
+			Model(&results).
+			Where("EXISTS (?)", existsSubq).
+			Scan(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+		if names["alice"] {
+			t.Error("tenant leak: alice returned for tenant B filter")
+		}
+		if names["beth"] {
+			t.Error("tenant leak: beth returned despite child having tenant_id=A")
+		}
+		if !names["bob"] {
+			t.Error("bob should be included: has active child with tenant_id=B")
+		}
+		if len(results) != 1 {
+			t.Errorf("got %d results, want exactly 1", len(results))
+		}
+	})
 }

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -33,6 +33,17 @@ var (
 		metadata.OpLike: "LIKE", metadata.OpIn: "IN", metadata.OpNin: "NOT IN",
 		metadata.OpBt: "BETWEEN", metadata.OpNbt: "NOT BETWEEN",
 	}
+	relationOps = map[string]bool{
+		metadata.OpExists:  true,
+		metadata.OpCountEq: true, metadata.OpCountNeq: true,
+		metadata.OpCountGt: true, metadata.OpCountGte: true,
+		metadata.OpCountLt: true, metadata.OpCountLte: true,
+	}
+	countFilterOps = map[string]string{
+		metadata.OpCountEq: "=", metadata.OpCountNeq: "!=",
+		metadata.OpCountGt: ">", metadata.OpCountGte: ">=",
+		metadata.OpCountLt: "<", metadata.OpCountLte: "<=",
+	}
 )
 
 // Wrapper is a generic struct that wraps a Store interface to provide CRUD operations
@@ -44,6 +55,32 @@ type Wrapper[T any] struct {
 type preFetchResult[T any] struct {
 	ids           []string
 	existingItems []*T
+}
+
+// defaultParentJoinCol returns the parent join column, defaulting to "id" if empty.
+func defaultParentJoinCol(col string) string {
+	if col == "" {
+		return "id"
+	}
+	return col
+}
+
+// derefType unwraps a pointer type to its element type.
+func derefType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Ptr {
+		return t.Elem()
+	}
+	return t
+}
+
+// isRelationAuthorized checks if a relation path is authorized in AllowedIncludes.
+// Returns true if allowedIncludes is nil (no auth configured) or the path is explicitly authorized.
+func isRelationAuthorized(allowedIncludes metadata.AllowedIncludes, relPath string) bool {
+	if allowedIncludes == nil {
+		return true
+	}
+	_, authorized := allowedIncludes[relPath]
+	return authorized
 }
 
 // GetAll retrieves all items of type T from the datastore
@@ -243,32 +280,10 @@ func (w *Wrapper[T]) Create(ctx context.Context, item T) (*T, error) {
 	}
 
 	if err != nil {
-		// Pass through context errors unchanged
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		// Check for connection issues
-		if errors.Is(err, sql.ErrConnDone) {
-			return nil, apperrors.ErrUnavailable
-		}
-		// Check for constraint violations
-		var pgErr pgdriver.Error
-		if errors.As(err, &pgErr) {
-			switch pgErr.Field('C') {
-			case "23505": // unique_violation
-				return nil, apperrors.ErrDuplicate
-			case "23503": // foreign_key_violation
-				return nil, apperrors.ErrInvalidReference
-			}
-		}
-		// SQLite constraint violations
-		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return nil, apperrors.ErrDuplicate
-		}
-		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
-			return nil, apperrors.ErrInvalidReference
-		}
-		return nil, err
+		return nil, w.translateError(err)
 	}
 
 	return &item, nil
@@ -332,27 +347,10 @@ func (w *Wrapper[T]) updateWithOp(ctx context.Context, id string, item T, op met
 	}
 
 	if err != nil {
-		// Pass through context errors unchanged
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		// Check for connection issues
-		if errors.Is(err, sql.ErrConnDone) {
-			return nil, apperrors.ErrUnavailable
-		}
-		// Check for not found
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, apperrors.ErrNotFound
-		}
-		// Check for foreign key violations
-		var pgErr pgdriver.Error
-		if errors.As(err, &pgErr) && pgErr.Field('C') == "23503" {
-			return nil, apperrors.ErrInvalidReference
-		}
-		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
-			return nil, apperrors.ErrInvalidReference
-		}
-		return nil, err
+		return nil, w.translateError(err)
 	}
 
 	return &item, nil
@@ -403,15 +401,10 @@ func (w *Wrapper[T]) Delete(ctx context.Context, id string) error {
 	}
 
 	if err != nil {
-		// Pass through context errors unchanged
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
-		// Check for connection issues
-		if errors.Is(err, sql.ErrConnDone) {
-			return apperrors.ErrUnavailable
-		}
-		return err
+		return w.translateError(err)
 	}
 
 	// Check if any rows were affected
@@ -583,15 +576,11 @@ func (w *Wrapper[T]) applyParentFiltersWithMeta(ctx context.Context, query *bun.
 
 	// Walk up the chain using ParentMeta pointers
 	for parentMeta != nil {
-		parentJoinCol := childMeta.ParentJoinCol
-		if parentJoinCol == "" {
-			parentJoinCol = "id"
-		}
 		joins = append(joins, joinInfo{
 			childType:     childMeta.ModelType,
 			childTable:    childMeta.TableName,
 			childFKCol:    childMeta.ForeignKeyCol,
-			parentJoinCol: parentJoinCol,
+			parentJoinCol: defaultParentJoinCol(childMeta.ParentJoinCol),
 			parentTable:   parentMeta.TableName,
 			parentURLUUID: parentMeta.URLParamUUID,
 			parentMeta:    parentMeta,
@@ -685,11 +674,7 @@ func (w *Wrapper[T]) applyParentOwnershipFilter(query *bun.SelectQuery, parentMe
 		return query
 	}
 
-	// Get the parent type for column name lookup
-	parentType := parentMeta.ModelType
-	if parentType.Kind() == reflect.Ptr {
-		parentType = parentType.Elem()
-	}
+	parentType := derefType(parentMeta.ModelType)
 
 	// Build WHERE clause for ownership: parent_table.ownership_field = userID
 	// For multiple fields, use OR logic (same as applyOwnershipFilterWithMeta)
@@ -743,11 +728,7 @@ func (w *Wrapper[T]) applyOwnershipFilterWithMeta(ctx context.Context, query *bu
 		}
 	}
 
-	// Get the model type for column name lookup
-	itemType := meta.ModelType
-	if itemType.Kind() == reflect.Ptr {
-		itemType = itemType.Elem()
-	}
+	itemType := derefType(meta.ModelType)
 
 	// Build OR conditions: WHERE (field1 = ? OR field2 = ? OR ...)
 	// Use ?TableAlias to properly qualify columns when JOINs are present
@@ -844,11 +825,7 @@ func (w *Wrapper[T]) applyTenantFilter(ctx context.Context, query *bun.SelectQue
 		query = query.Where("?TableAlias.? = ?", bun.Ident("id"), tenantID)
 	} else {
 		// WithTenantScope: filter by the named tenant field
-		itemType := meta.ModelType
-		if itemType.Kind() == reflect.Ptr {
-			itemType = itemType.Elem()
-		}
-		colName, err := ColumnName(itemType, meta.TenantField)
+		colName, err := ColumnName(derefType(meta.ModelType), meta.TenantField)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get column name for tenant field: %w", err)
 		}
@@ -864,12 +841,7 @@ func (w *Wrapper[T]) applyParentTenantFilter(query *bun.SelectQuery, parentMeta 
 		return query
 	}
 
-	parentType := parentMeta.ModelType
-	if parentType.Kind() == reflect.Ptr {
-		parentType = parentType.Elem()
-	}
-
-	colName, err := ColumnName(parentType, parentMeta.TenantField)
+	colName, err := ColumnName(derefType(parentMeta.ModelType), parentMeta.TenantField)
 	if err != nil {
 		return query
 	}
@@ -1041,22 +1013,16 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 
 	switch {
 	case hasCount && hasSums:
-		// Both count and sums - combine into one query
-		selectParts := []string{"COUNT(*) AS count"}
+		aggQuery = aggQuery.ColumnExpr("COUNT(*) AS count")
 		for field, colName := range validSumFields {
-			selectParts = append(selectParts, fmt.Sprintf("COALESCE(SUM(%s), 0) AS sum_%s", colName, field))
+			aggQuery = aggQuery.ColumnExpr("COALESCE(SUM(?), 0) AS ?", bun.Ident(colName), bun.Ident("sum_"+field))
 		}
-		aggQuery = aggQuery.ColumnExpr(strings.Join(selectParts, ", "))
 	case hasCount:
-		// Count only
 		aggQuery = aggQuery.ColumnExpr("COUNT(*) AS count")
 	case hasSums:
-		// Sums only
-		selectParts := []string{}
 		for field, colName := range validSumFields {
-			selectParts = append(selectParts, fmt.Sprintf("COALESCE(SUM(%s), 0) AS sum_%s", colName, field))
+			aggQuery = aggQuery.ColumnExpr("COALESCE(SUM(?), 0) AS ?", bun.Ident(colName), bun.Ident("sum_"+field))
 		}
-		aggQuery = aggQuery.ColumnExpr(strings.Join(selectParts, ", "))
 	default:
 		// No valid aggregates - return early
 		return 0, sums, nil
@@ -1107,6 +1073,7 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 // applyQueryFilters applies filters from QueryOptions to the query
 // Only fields in metadata.FilterableFields are allowed (others silently ignored)
 // Supports relation paths like "Account.Status" or "Account.User.Email"
+// Supports relation-level operators: exists, count_eq, count_neq, count_gt, count_gte, count_lt, count_lte
 //
 // Single-value operators (eq, neq, gt, gte, lt, lte, like): use first value if multiple provided
 // Multi-value operators (in, nin): use all values
@@ -1116,14 +1083,25 @@ func (w *Wrapper[T]) applyQueryFilters(ctx context.Context, query *bun.SelectQue
 		return query
 	}
 
+	allowedIncludes := metadata.AllowedIncludesFromContext(ctx)
+
 	for field, filter := range opts.Filters {
+		// Relation-level operators (exists, count_*) — the entire field key is a relation path
+		if relationOps[filter.Operator] {
+			query = w.applyRelationFilter(ctx, query, meta, field, filter, allowedIncludes)
+			continue
+		}
+
 		path := parseRelationPath(field)
 
-		// Relation path filter
+		// Relation path filter (child or parent field)
 		if len(path.relations) > 0 {
 			firstRel := path.relations[0]
 			if meta.ChildMeta != nil {
 				if _, isChild := meta.ChildMeta[firstRel]; isChild {
+					if !isRelationAuthorized(allowedIncludes, strings.Join(path.relations, ".")) {
+						continue
+					}
 					query = w.applyChildFieldFilter(ctx, query, meta, path, filter)
 					continue
 				}
@@ -1193,15 +1171,21 @@ func applyFilter(query *bun.SelectQuery, tableName, colName, operator string, va
 	case metadata.OpNin:
 		return query.Where(tblCol+" NOT IN (?)", append(args, bun.In(vals))...)
 	case metadata.OpBt:
+		if len(vals) < 2 {
+			return query
+		}
 		return query.Where(tblCol+" BETWEEN ? AND ?", append(args, vals[0], vals[1])...)
 	case metadata.OpNbt:
+		if len(vals) < 2 {
+			return query
+		}
 		return query.Where(tblCol+" NOT BETWEEN ? AND ?", append(args, vals[0], vals[1])...)
 	default:
 		op := filterOps[operator]
 		if op == "" {
 			op = "="
 		}
-		return query.Where(fmt.Sprintf("%s %s ?", tblCol, op), append(args, vals[0])...)
+		return query.Where(tblCol+" "+op+" ?", append(args, vals[0])...)
 	}
 }
 
@@ -1367,9 +1351,9 @@ func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.Que
 	// applyQuerySorting already reverses directions for "before", so the
 	// effective directions here account for backward navigation.
 	type colInfo struct {
-		expr string // e.g. ?TableAlias."price"
-		val  any
-		op   string // ">" for ASC, "<" for DESC
+		col string // column name, will be wrapped in bun.Ident
+		val any
+		op  string // ">" for ASC, "<" for DESC
 	}
 
 	cols := make([]colInfo, 0, len(sortCols)+1)
@@ -1379,7 +1363,6 @@ func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.Que
 			op = "<"
 		}
 		if backward {
-			// Sort is reversed by applyQuerySorting, so flip the operator
 			if op == ">" {
 				op = "<"
 			} else {
@@ -1387,9 +1370,9 @@ func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.Que
 			}
 		}
 		cols = append(cols, colInfo{
-			expr: fmt.Sprintf("?TableAlias.%q", sc.col),
-			val:  cursor.Values[i],
-			op:   op,
+			col: sc.col,
+			val: cursor.Values[i],
+			op:  op,
 		})
 	}
 
@@ -1399,9 +1382,9 @@ func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.Que
 		pkOp = "<"
 	}
 	cols = append(cols, colInfo{
-		expr: fmt.Sprintf("?TableAlias.%q", pkCol),
-		val:  cursor.PK,
-		op:   pkOp,
+		col: pkCol,
+		val: cursor.PK,
+		op:  pkOp,
 	})
 
 	// Build disjunctive normal form:
@@ -1411,14 +1394,12 @@ func (w *Wrapper[T]) applyCursorWhere(query *bun.SelectQuery, opts *metadata.Que
 
 	for i := range cols {
 		var andParts []string
-		// Equality prefix for all columns before i
 		for j := 0; j < i; j++ {
-			andParts = append(andParts, cols[j].expr+" = ?")
-			allVals = append(allVals, cols[j].val)
+			andParts = append(andParts, "?TableAlias.? = ?")
+			allVals = append(allVals, bun.Ident(cols[j].col), cols[j].val)
 		}
-		// Comparison for column i
-		andParts = append(andParts, cols[i].expr+" "+cols[i].op+" ?")
-		allVals = append(allVals, cols[i].val)
+		andParts = append(andParts, "?TableAlias.? "+cols[i].op+" ?")
+		allVals = append(allVals, bun.Ident(cols[i].col), cols[i].val)
 
 		orClauses = append(orClauses, "("+strings.Join(andParts, " AND ")+")")
 	}
@@ -1778,19 +1759,9 @@ func (w *Wrapper[T]) applyNestedInclude(ctx context.Context, query *bun.SelectQu
 // applyNestedChildInclude handles nested child includes like "Accounts.Sites.Bills"
 // Applies ownership filtering at each level that has it configured
 func (w *Wrapper[T]) applyNestedChildInclude(ctx context.Context, query *bun.SelectQuery, meta *metadata.TypeMetadata, parts []string, applyOwnership bool) *bun.SelectQuery {
-	// Build chain of metadata for each level
-	chain := make([]*metadata.TypeMetadata, 0, len(parts))
-	currentMeta := meta
-	for _, part := range parts {
-		if currentMeta.ChildMeta == nil {
-			return query
-		}
-		childMeta, exists := currentMeta.ChildMeta[part]
-		if !exists {
-			return query
-		}
-		chain = append(chain, childMeta)
-		currentMeta = childMeta
+	chain := w.resolveChildChain(meta, parts)
+	if len(chain) == 0 {
+		return query
 	}
 
 	// Add .Relation() for each level, applying ownership where configured
@@ -1835,12 +1806,8 @@ func (w *Wrapper[T]) applyNestedParentInclude(ctx context.Context, query *bun.Se
 // getRelationNameForParent finds the belongs-to relation field name on the child
 // that references the parent type, using Bun's schema
 func (w *Wrapper[T]) getRelationNameForParent(childMeta, parentMeta *metadata.TypeMetadata) string {
-	parentType := parentMeta.ModelType
-	if parentType.Kind() == reflect.Ptr {
-		parentType = parentType.Elem()
-	}
+	parentType := derefType(parentMeta.ModelType)
 
-	// Use Bun's schema to find belongs-to relation pointing to parent type
 	table := w.Store.GetDB().Table(childMeta.ModelType)
 	for name, rel := range table.Relations {
 		if rel.Type == schema.BelongsToRelation && rel.JoinTable.Type == parentType {
@@ -2189,10 +2156,7 @@ func (w *Wrapper[T]) buildParentJoins(query *bun.SelectQuery, baseMeta *metadata
 }
 
 func (w *Wrapper[T]) joinParentFromBase(query *bun.SelectQuery, child, parent *metadata.TypeMetadata, fkOnChild bool) *bun.SelectQuery {
-	parentJoinCol := child.ParentJoinCol
-	if parentJoinCol == "" {
-		parentJoinCol = "id"
-	}
+	parentJoinCol := defaultParentJoinCol(child.ParentJoinCol)
 	if fkOnChild {
 		return query.Join("JOIN ? ON ?TableAlias.? = ?.?",
 			bun.Ident(parent.TableName), bun.Ident(child.ForeignKeyCol),
@@ -2204,10 +2168,7 @@ func (w *Wrapper[T]) joinParentFromBase(query *bun.SelectQuery, child, parent *m
 }
 
 func (w *Wrapper[T]) joinParentFromTable(query *bun.SelectQuery, child, parent *metadata.TypeMetadata, fkOnChild bool) *bun.SelectQuery {
-	parentJoinCol := child.ParentJoinCol
-	if parentJoinCol == "" {
-		parentJoinCol = "id"
-	}
+	parentJoinCol := defaultParentJoinCol(child.ParentJoinCol)
 	if fkOnChild {
 		return query.Join("JOIN ? ON ?.? = ?.?",
 			bun.Ident(parent.TableName), bun.Ident(child.TableName),
@@ -2240,9 +2201,11 @@ func (w *Wrapper[T]) applyChildFieldFilter(ctx context.Context, query *bun.Selec
 		return query
 	}
 
-	condition, args := buildFilterCondition(targetMeta.TableName, colName, filter.Operator, vals)
-	existsSQL := w.wrapInExists(meta, childChain, condition)
-	return query.Where(existsSQL, args...)
+	existsSubq := w.buildExistsChain(meta, childChain, func(q *bun.SelectQuery) *bun.SelectQuery {
+		return applyFilter(q, targetMeta.TableName, colName, filter.Operator, vals)
+	})
+
+	return query.Where("EXISTS (?)", existsSubq)
 }
 
 // resolveChildChain walks down ChildMeta to resolve a relation path
@@ -2264,53 +2227,252 @@ func (w *Wrapper[T]) resolveChildChain(meta *metadata.TypeMetadata, relations []
 	return chain
 }
 
-// buildFilterCondition creates a SQL condition string and args for a filter
-func buildFilterCondition(table, col, operator string, vals []interface{}) (string, []interface{}) {
-	switch operator {
-	case metadata.OpIn:
-		placeholders := strings.Repeat("?, ", len(vals))
-		return fmt.Sprintf("%s.%s IN (%s)", table, col, placeholders[:len(placeholders)-2]), vals
-	case metadata.OpNin:
-		placeholders := strings.Repeat("?, ", len(vals))
-		return fmt.Sprintf("%s.%s NOT IN (%s)", table, col, placeholders[:len(placeholders)-2]), vals
-	case metadata.OpBt:
-		return fmt.Sprintf("%s.%s BETWEEN ? AND ?", table, col), vals[:2]
-	case metadata.OpNbt:
-		return fmt.Sprintf("%s.%s NOT BETWEEN ? AND ?", table, col), vals[:2]
-	default:
-		op := filterOps[operator]
-		if op == "" {
-			op = "="
+// applyRelationFilter applies existence or count-based filters on child relations.
+// The field key is the full relation path (e.g., "Orders" or "Orders.Items").
+func (w *Wrapper[T]) applyRelationFilter(ctx context.Context, query *bun.SelectQuery, meta *metadata.TypeMetadata, field string, filter metadata.FilterValue, allowedIncludes metadata.AllowedIncludes) *bun.SelectQuery {
+	if !isRelationAuthorized(allowedIncludes, field) {
+		return query
+	}
+
+	// Resolve the child chain
+	relations := strings.Split(field, ".")
+	childChain := w.resolveChildChain(meta, relations)
+	if len(childChain) == 0 {
+		return query
+	}
+
+	switch filter.Operator {
+	case metadata.OpExists:
+		existsSubq := w.buildExistsChain(meta, childChain, nil)
+		if existsSubq == nil {
+			return query
 		}
-		return fmt.Sprintf("%s.%s %s ?", table, col, op), vals[:1]
+		val := strings.ToLower(strings.TrimSpace(filter.Value))
+		if val == "false" || val == "0" {
+			return query.Where("NOT EXISTS (?)", existsSubq)
+		}
+		return query.Where("EXISTS (?)", existsSubq)
+
+	default:
+		op, ok := countFilterOps[filter.Operator]
+		if !ok {
+			return query
+		}
+		countVal, err := strconv.Atoi(filter.Value)
+		if err != nil {
+			slog.DebugContext(ctx, "count filter value is not an integer", "field", field, "value", filter.Value)
+			return query
+		}
+		countSubq := w.buildCountChain(meta, childChain)
+		if countSubq == nil {
+			return query
+		}
+		return query.Where("(?) "+op+" ?", countSubq, countVal)
 	}
 }
 
-// wrapInExists wraps a condition in nested EXISTS subqueries
-func (w *Wrapper[T]) wrapInExists(baseMeta *metadata.TypeMetadata, chain []*metadata.TypeMetadata, innerCondition string) string {
+// buildCountChain builds a correlated COUNT(*) subquery for a child relation chain.
+// For single-level chains, returns a direct COUNT. For multi-level chains, uses nested
+// subqueries to resolve intermediate IDs before counting at the leaf level.
+func (w *Wrapper[T]) buildCountChain(baseMeta *metadata.TypeMetadata, chain []*metadata.TypeMetadata) *bun.SelectQuery {
 	if len(chain) == 0 {
-		return innerCondition
+		return nil
 	}
 
-	// Pre-compute parent table for each child: base alias for first, chain element for rest
+	db := w.Store.GetDB()
+	baseAlias := db.Table(baseMeta.ModelType).Alias
+
+	leaf := chain[len(chain)-1]
+
+	if len(chain) == 1 {
+		return db.NewSelect().
+			Table(leaf.TableName).
+			ColumnExpr("COUNT(*)").
+			Where("?.? = ?.?",
+				bun.Ident(leaf.TableName), bun.Ident(leaf.ForeignKeyCol),
+				bun.Ident(baseAlias), bun.Ident(defaultParentJoinCol(leaf.ParentJoinCol)))
+	}
+
+	// Multi-level: build nested subqueries from base outward, count at leaf
+	var subq *bun.SelectQuery
+	for i := 0; i < len(chain)-1; i++ {
+		child := chain[i]
+		childParentJoinCol := defaultParentJoinCol(child.ParentJoinCol)
+
+		nextChild := chain[i+1]
+		selectCol := defaultParentJoinCol(nextChild.ParentJoinCol)
+
+		if i == 0 {
+			subq = db.NewSelect().
+				Table(child.TableName).
+				ColumnExpr("?.?", bun.Ident(child.TableName), bun.Ident(selectCol)).
+				Where("?.? = ?.?",
+					bun.Ident(child.TableName), bun.Ident(child.ForeignKeyCol),
+					bun.Ident(baseAlias), bun.Ident(childParentJoinCol))
+		} else {
+			subq = db.NewSelect().
+				Table(child.TableName).
+				ColumnExpr("?.?", bun.Ident(child.TableName), bun.Ident(selectCol)).
+				Where("?.? IN (?)",
+					bun.Ident(child.TableName), bun.Ident(child.ForeignKeyCol),
+					subq)
+		}
+	}
+
+	return db.NewSelect().
+		Table(leaf.TableName).
+		ColumnExpr("COUNT(*)").
+		Where("?.? IN (?)",
+			bun.Ident(leaf.TableName), bun.Ident(leaf.ForeignKeyCol),
+			subq)
+}
+
+// ComputeIncludeCounts computes per-item child relation counts for the given items.
+// Returns a map of relation name → {pk_string → count}. Items with zero counts are omitted.
+// Auth is checked via AllowedIncludes from context.
+func (w *Wrapper[T]) ComputeIncludeCounts(ctx context.Context, items []*T, includeCounts []string) (map[string]map[string]int, error) {
+	if len(items) == 0 || len(includeCounts) == 0 {
+		return nil, nil
+	}
+
+	meta, err := metadata.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	allowedIncludes := metadata.AllowedIncludesFromContext(ctx)
+
+	pks := make([]interface{}, len(items))
+	for i, item := range items {
+		pk := common.GetFieldAsString(item, meta.PKField)
+		if pk == "" {
+			return nil, fmt.Errorf("PK field %s not found", meta.PKField)
+		}
+		pks[i] = pk
+	}
+
+	result := make(map[string]map[string]int)
+
+	for _, relPath := range includeCounts {
+		relations := strings.Split(relPath, ".")
+
+		if !isRelationAuthorized(allowedIncludes, relPath) {
+			continue
+		}
+		childChain := w.resolveChildChain(meta, relations)
+		if len(childChain) == 0 {
+			continue
+		}
+
+		counts, err := w.queryRelationCounts(ctx, meta, childChain, pks)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to compute include count", "relation", relPath, "error", err)
+			continue
+		}
+
+		if len(counts) > 0 {
+			result[relPath] = counts
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// queryRelationCounts runs a grouped count query for a child relation chain.
+// Returns a map of parent PK (as string) → count of matching child records.
+func (w *Wrapper[T]) queryRelationCounts(ctx context.Context, baseMeta *metadata.TypeMetadata, chain []*metadata.TypeMetadata, pks []interface{}) (map[string]int, error) {
+	ctx, cancel := context.WithTimeout(ctx, w.Store.GetTimeout())
+	defer cancel()
+
+	db := w.Store.GetDB()
+
+	firstChild := chain[0]
+	leaf := chain[len(chain)-1]
+	query := db.NewSelect().
+		Table(leaf.TableName).
+		ColumnExpr("?.? AS parent_ref", bun.Ident(firstChild.TableName), bun.Ident(firstChild.ForeignKeyCol)).
+		ColumnExpr("COUNT(*) AS cnt")
+
+	// Add JOINs for intermediate levels (from leaf back to first child)
+	for i := len(chain) - 1; i > 0; i-- {
+		child := chain[i]
+		parent := chain[i-1]
+		query = query.Join("JOIN ? ON ?.? = ?.?",
+			bun.Ident(parent.TableName),
+			bun.Ident(child.TableName), bun.Ident(child.ForeignKeyCol),
+			bun.Ident(parent.TableName), bun.Ident(defaultParentJoinCol(child.ParentJoinCol)))
+	}
+
+	// WHERE first_child.fk IN (pks)
+	query = query.Where("?.? IN (?)",
+		bun.Ident(firstChild.TableName), bun.Ident(firstChild.ForeignKeyCol),
+		bun.In(pks))
+
+	// GROUP BY first_child.fk
+	query = query.GroupExpr("?.?",
+		bun.Ident(firstChild.TableName), bun.Ident(firstChild.ForeignKeyCol))
+
+	rows, err := query.Rows(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var parentRef interface{}
+		var cnt int
+		if err := rows.Scan(&parentRef, &cnt); err != nil {
+			return nil, err
+		}
+		counts[fmt.Sprintf("%v", parentRef)] = cnt
+	}
+
+	return counts, nil
+}
+
+// buildExistsChain builds nested EXISTS subqueries using Bun's query builder.
+// Each level correlates to its parent via FK = parent PK.
+// The optional innerFilter applies additional conditions to the deepest level's subquery.
+func (w *Wrapper[T]) buildExistsChain(baseMeta *metadata.TypeMetadata, chain []*metadata.TypeMetadata, innerFilter func(q *bun.SelectQuery) *bun.SelectQuery) *bun.SelectQuery {
+	if len(chain) == 0 {
+		return nil
+	}
+
+	db := w.Store.GetDB()
+
 	parents := make([]string, len(chain))
-	parents[0] = w.Store.GetDB().Table(baseMeta.ModelType).Alias
+	parents[0] = db.Table(baseMeta.ModelType).Alias
 	for i := 1; i < len(chain); i++ {
 		parents[i] = chain[i-1].TableName
 	}
 
-	// Wrap from deepest child up
-	sql := innerCondition
+	var innerSubq *bun.SelectQuery
 	for i := len(chain) - 1; i >= 0; i-- {
 		child := chain[i]
-		parentJoinCol := child.ParentJoinCol
-		if parentJoinCol == "" {
-			parentJoinCol = "id"
+
+		subq := db.NewSelect().
+			Table(child.TableName).
+			ColumnExpr("1").
+			Where("?.? = ?.?",
+				bun.Ident(child.TableName), bun.Ident(child.ForeignKeyCol),
+				bun.Ident(parents[i]), bun.Ident(defaultParentJoinCol(child.ParentJoinCol)))
+
+		if i == len(chain)-1 && innerFilter != nil {
+			subq = innerFilter(subq)
 		}
-		sql = fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.%s AND %s)",
-			child.TableName, child.TableName, child.ForeignKeyCol, parents[i], parentJoinCol, sql)
+
+		if innerSubq != nil {
+			subq = subq.Where("EXISTS (?)", innerSubq)
+		}
+
+		innerSubq = subq
 	}
-	return sql
+
+	return innerSubq
 }
 
 // translateError converts database errors to application errors

--- a/datastore/wrapper_internal_test.go
+++ b/datastore/wrapper_internal_test.go
@@ -3,9 +3,11 @@ package datastore
 import (
 	"database/sql"
 	"errors"
+	"reflect"
 	"testing"
 
 	apperrors "github.com/sjgoldie/go-restgen/errors"
+	"github.com/sjgoldie/go-restgen/metadata"
 )
 
 func TestTranslateError(t *testing.T) {
@@ -62,5 +64,46 @@ func TestTranslateError(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDefaultParentJoinCol(t *testing.T) {
+	if got := defaultParentJoinCol(""); got != "id" {
+		t.Errorf("expected 'id' for empty string, got %q", got)
+	}
+	if got := defaultParentJoinCol("nmi"); got != "nmi" {
+		t.Errorf("expected 'nmi', got %q", got)
+	}
+}
+
+func TestDerefType(t *testing.T) {
+	type Foo struct{}
+
+	direct := reflect.TypeOf(Foo{})
+	if got := derefType(direct); got != direct {
+		t.Errorf("expected non-pointer type returned as-is, got %v", got)
+	}
+
+	ptr := reflect.TypeOf((*Foo)(nil))
+	if got := derefType(ptr); got != direct {
+		t.Errorf("expected pointer type unwrapped to %v, got %v", direct, got)
+	}
+}
+
+func TestIsRelationAuthorized(t *testing.T) {
+	if !isRelationAuthorized(nil, "Posts") {
+		t.Error("nil allowedIncludes should authorize everything")
+	}
+
+	includes := metadata.AllowedIncludes{"Posts": true, "Comments": false}
+
+	if !isRelationAuthorized(includes, "Posts") {
+		t.Error("expected Posts to be authorized")
+	}
+	if !isRelationAuthorized(includes, "Comments") {
+		t.Error("expected Comments to be authorized")
+	}
+	if isRelationAuthorized(includes, "Tags") {
+		t.Error("expected Tags to be unauthorized")
 	}
 }

--- a/datastore/wrapper_test.go
+++ b/datastore/wrapper_test.go
@@ -3803,6 +3803,11 @@ func setupRelationFilterTestDB(t *testing.T) (*datastore.SQLite, func()) {
 		t.Fatal("Failed to create SQLite:", err)
 	}
 
+	if err := datastore.Initialize(db); err != nil {
+		db.Cleanup()
+		t.Fatal("Failed to initialize datastore:", err)
+	}
+
 	ctx := context.Background()
 	models := []interface{}{
 		(*RelUser)(nil),
@@ -3818,7 +3823,10 @@ func setupRelationFilterTestDB(t *testing.T) (*datastore.SQLite, func()) {
 		}
 	}
 
-	return db, func() { db.GetDB().Close() }
+	return db, func() {
+		datastore.Cleanup()
+		db.Cleanup()
+	}
 }
 
 // createRelationFilterTestMeta creates the full 5-level metadata chain
@@ -4832,7 +4840,11 @@ func TestRelationFilter_CombinedFilterAndInclude(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
 	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
-	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{
+		"Accounts":             false,
+		"Accounts.Sites":       false,
+		"Accounts.Sites.Bills": false,
+	})
 
 	users, _, _, _, err := userWrapper.GetAll(ctx)
 	if err != nil {
@@ -4847,6 +4859,612 @@ func TestRelationFilter_CombinedFilterAndInclude(t *testing.T) {
 	// Her accounts should be included
 	if len(users) > 0 && len(users[0].Accounts) == 0 {
 		t.Error("Expected Accounts to be included")
+	}
+}
+
+// ============================================================================
+// Issue #99: Existence Filter Tests
+// ============================================================================
+
+func TestExistsFilter_True(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Both Alice and Bob have accounts
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users with accounts, got %d", len(users))
+	}
+}
+
+func TestExistsFilter_False(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	// Add a user with no accounts
+	noAcctUser := RelUser{Name: "Charlie NoAccounts", Email: "charlie@example.com"}
+	_, err := db.GetDB().NewInsert().Model(&noAcctUser).Returning("*").Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create user:", err)
+	}
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "false", Operator: metadata.OpExists},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user without accounts, got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Name != "Charlie NoAccounts" {
+		t.Errorf("Expected Charlie, got %s", users[0].Name)
+	}
+}
+
+func TestExistsFilter_MultiLevel(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Both Alice and Bob have accounts with sites
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts.Sites": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users with accounts.sites, got %d", len(users))
+	}
+}
+
+func TestExistsFilter_Security_UnauthorizedRelation_Ignored(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	// Auth configured but Accounts NOT authorized
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Other": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter silently skipped — all users returned
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter skipped), got %d", len(users))
+	}
+}
+
+func TestExistsFilter_Security_MultiLevel_RequiresFullPath(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts.Sites": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	// Only "Accounts" authorized, NOT "Accounts.Sites" — filter must be blocked
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter blocked (Accounts.Sites not explicitly authorized) — all users returned
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter blocked, Accounts.Sites not authorized), got %d", len(users))
+	}
+}
+
+func TestExistsFilter_Security_OwnershipStillEnforced(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	// Ownership enforced — Bob should only see his own record
+	userMeta.OwnershipFields = []string{"Email"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AuthInfoKey, &metadata.AuthInfo{UserID: "bob@example.com", Scopes: []string{"user"}})
+	ctx = context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
+	ctx = context.WithValue(ctx, metadata.OwnershipUserIDKey, "bob@example.com")
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user (ownership enforced), got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Email != "bob@example.com" {
+		t.Errorf("Expected Bob, got %s", users[0].Email)
+	}
+}
+
+// ============================================================================
+// Issue #99: Count Filter Tests
+// ============================================================================
+
+func TestCountFilter_GreaterThan(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Alice has 2 accounts, Bob has 1
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "1", Operator: metadata.OpCountGt},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user with >1 accounts, got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Name != "Alice Smith" {
+		t.Errorf("Expected Alice, got %s", users[0].Name)
+	}
+}
+
+func TestCountFilter_Equal(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Bob has exactly 1 account
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "1", Operator: metadata.OpCountEq},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user with exactly 1 account, got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Name != "Bob Jones" {
+		t.Errorf("Expected Bob, got %s", users[0].Name)
+	}
+}
+
+func TestCountFilter_EqualZero(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	// Add user with no accounts
+	noAcctUser := RelUser{Name: "Charlie NoAccounts", Email: "charlie@example.com"}
+	_, err := db.GetDB().NewInsert().Model(&noAcctUser).Returning("*").Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create user:", err)
+	}
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "0", Operator: metadata.OpCountEq},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user with 0 accounts, got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Name != "Charlie NoAccounts" {
+		t.Errorf("Expected Charlie, got %s", users[0].Name)
+	}
+}
+
+func TestCountFilter_Security_UnauthorizedRelation_Ignored(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "1", Operator: metadata.OpCountGt},
+		},
+	}
+
+	// Auth configured but Accounts NOT authorized
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Other": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter silently skipped — all users returned
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter skipped), got %d", len(users))
+	}
+}
+
+func TestCountFilter_Security_MultiLevel_RequiresFullPath(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts.Sites": {Value: "2", Operator: metadata.OpCountGte},
+		},
+	}
+
+	// Only "Accounts" authorized, NOT "Accounts.Sites" — filter must be blocked
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter blocked — all users returned
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter blocked, Accounts.Sites not authorized), got %d", len(users))
+	}
+}
+
+func TestCountFilter_Security_OwnershipStillEnforced(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Alice has 2 accounts — but ownership should still restrict results
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "0", Operator: metadata.OpCountGt},
+		},
+	}
+
+	userMeta.OwnershipFields = []string{"Email"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AuthInfoKey, &metadata.AuthInfo{UserID: "alice@example.com", Scopes: []string{"user"}})
+	ctx = context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
+	ctx = context.WithValue(ctx, metadata.OwnershipUserIDKey, "alice@example.com")
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("Expected 1 user (ownership enforced), got %d", len(users))
+	}
+	if len(users) > 0 && users[0].Email != "alice@example.com" {
+		t.Errorf("Expected Alice, got %s", users[0].Email)
+	}
+}
+
+func TestCountFilter_Security_CantBypassOwnership(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Bob tries to find users with 2+ accounts (only Alice qualifies)
+	// but ownership should prevent Bob from seeing Alice
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "1", Operator: metadata.OpCountGt},
+		},
+	}
+
+	userMeta.OwnershipFields = []string{"Email"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AuthInfoKey, &metadata.AuthInfo{UserID: "bob@example.com", Scopes: []string{"user"}})
+	ctx = context.WithValue(ctx, metadata.OwnershipEnforcedKey, true)
+	ctx = context.WithValue(ctx, metadata.OwnershipUserIDKey, "bob@example.com")
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Bob only has 1 account so count_gt=1 + ownership = empty result
+	if len(users) != 0 {
+		t.Errorf("Expected 0 users (ownership prevents seeing Alice), got %d", len(users))
+	}
+	for _, user := range users {
+		if user.Email != "bob@example.com" {
+			t.Errorf("Data leak: Bob saw %s", user.Email)
+		}
+	}
+}
+
+// ============================================================================
+// Issue #99: Include Counts Tests
+// ============================================================================
+
+func TestIncludeCounts_Basic(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	accountCounts, ok := counts["Accounts"]
+	if !ok {
+		t.Fatal("Expected Accounts in counts")
+	}
+
+	aliceID := strconv.Itoa(users[0].ID)
+	bobID := strconv.Itoa(users[1].ID)
+
+	if accountCounts[aliceID] != 2 {
+		t.Errorf("Expected Alice to have 2 accounts, got %d", accountCounts[aliceID])
+	}
+	if accountCounts[bobID] != 1 {
+		t.Errorf("Expected Bob to have 1 account, got %d", accountCounts[bobID])
+	}
+}
+
+func TestIncludeCounts_Security_UnauthorizedRelation_Excluded(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Auth configured but Accounts NOT authorized
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Other": false})
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	// Counts should be nil/empty — Accounts not authorized
+	if len(counts) != 0 {
+		t.Errorf("Expected no counts (unauthorized relation), got %v", counts)
+	}
+}
+
+func TestIncludeCounts_Security_MultiLevel_RequiresFullPath(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// Only "Accounts" authorized, NOT "Accounts.Sites"
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts", "Accounts.Sites"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	// "Accounts" should have counts, "Accounts.Sites" should NOT
+	if _, ok := counts["Accounts"]; !ok {
+		t.Error("Expected Accounts counts (authorized)")
+	}
+	if _, ok := counts["Accounts.Sites"]; ok {
+		t.Error("Accounts.Sites should NOT have counts (not explicitly authorized)")
+	}
+}
+
+func TestChildFieldFilter_Security_MultiLevel_RequiresFullPath(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts.Sites.Bills.Status": {Value: "Overdue", Operator: metadata.OpEq},
+		},
+	}
+
+	// Only "Accounts" authorized, NOT the full chain — filter must be blocked
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Accounts": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter blocked — all users returned
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter blocked, Accounts.Sites.Bills not authorized), got %d", len(users))
+	}
+}
+
+func TestExistsFilter_Security_FalseWithUnauthorized_ReturnsAll(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	_, _, _, _, _ = seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+
+	// exists=false with unauthorized relation must NOT accidentally return empty set
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Accounts": {Value: "false", Operator: metadata.OpExists},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Other": false})
+
+	users, _, _, _, err := userWrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	// Filter skipped — all users returned (not an empty set)
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users (filter skipped, not empty set), got %d", len(users))
 	}
 }
 
@@ -4888,6 +5506,11 @@ func setupTenantTestDB(t *testing.T) (*datastore.SQLite, func()) {
 		t.Fatal("Failed to create test database:", err)
 	}
 
+	if err := datastore.Initialize(db); err != nil {
+		db.Cleanup()
+		t.Fatal("Failed to initialize datastore:", err)
+	}
+
 	ctx := context.Background()
 	models := []interface{}{
 		(*TestTenantOrg)(nil),
@@ -4907,6 +5530,7 @@ func setupTenantTestDB(t *testing.T) (*datastore.SQLite, func()) {
 		for _, model := range models {
 			db.GetDB().NewDropTable().Model(model).IfExists().Exec(ctx)
 		}
+		datastore.Cleanup()
 		db.Cleanup()
 	}
 
@@ -5679,5 +6303,416 @@ func TestTenant_ParentTenantFilter_SkipsParentWithNoTenantField(t *testing.T) {
 	}
 	if len(crossResults) != 0 {
 		t.Errorf("Expected 0 tasks (direct tenant filter still applies), got %d", len(crossResults))
+	}
+}
+
+// ============================================================================
+// Issue #99: Tenant Isolation for Relation Filters
+// Verify exists, count, and include_count respect tenant scoping
+// ============================================================================
+
+func seedTenantRelationData(t *testing.T, db *datastore.SQLite) (projects []TestTenantProject) {
+	t.Helper()
+	ctx := context.Background()
+
+	// org-a: P1 (3 tasks), P2 (0 tasks)
+	// org-b: P3 (2 tasks)
+	projects = []TestTenantProject{
+		{OrgID: "org-a", OwnerID: "alice", Name: "Alpha"},
+		{OrgID: "org-a", OwnerID: "alice", Name: "Beta"},
+		{OrgID: "org-b", OwnerID: "bob", Name: "Gamma"},
+	}
+	for i := range projects {
+		_, err := db.GetDB().NewInsert().Model(&projects[i]).Returning("*").Exec(ctx)
+		if err != nil {
+			t.Fatal("Failed to create project:", err)
+		}
+	}
+
+	tasks := []TestTenantTask{
+		{ProjectID: projects[0].ID, OrgID: "org-a", Title: "Task A1"},
+		{ProjectID: projects[0].ID, OrgID: "org-a", Title: "Task A2"},
+		{ProjectID: projects[0].ID, OrgID: "org-a", Title: "Task A3"},
+		{ProjectID: projects[2].ID, OrgID: "org-b", Title: "Task B1"},
+		{ProjectID: projects[2].ID, OrgID: "org-b", Title: "Task B2"},
+	}
+	for i := range tasks {
+		_, err := db.GetDB().NewInsert().Model(&tasks[i]).Returning("*").Exec(ctx)
+		if err != nil {
+			t.Fatal("Failed to create task:", err)
+		}
+	}
+
+	return projects
+}
+
+func TestTenant_ExistsFilter_ScopedByTenant(t *testing.T) {
+	db, cleanup := setupTenantTestDB(t)
+	defer cleanup()
+
+	_, projectMeta, _ := createTenantTestMeta()
+	seedTenantRelationData(t, db)
+
+	wrapper := &datastore.Wrapper[TestTenantProject]{Store: db}
+
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Tasks": {Value: "true", Operator: metadata.OpExists},
+		},
+	}
+
+	// org-a: P1 has tasks, P2 has none — expect 1 match
+	ctx := ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-a")
+
+	projects, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("Expected 1 project with tasks in org-a, got %d", len(projects))
+	}
+	if len(projects) > 0 && projects[0].Name != "Alpha" {
+		t.Errorf("Expected Alpha, got %s", projects[0].Name)
+	}
+
+	// org-b: P3 has tasks — expect 1 match
+	ctx = ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-b")
+
+	projects, _, _, _, err = wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("Expected 1 project with tasks in org-b, got %d", len(projects))
+	}
+	if len(projects) > 0 && projects[0].Name != "Gamma" {
+		t.Errorf("Expected Gamma, got %s", projects[0].Name)
+	}
+}
+
+func TestTenant_ExistsFilter_CrossTenant_NoLeakage(t *testing.T) {
+	db, cleanup := setupTenantTestDB(t)
+	defer cleanup()
+
+	_, projectMeta, _ := createTenantTestMeta()
+	seedTenantRelationData(t, db)
+
+	wrapper := &datastore.Wrapper[TestTenantProject]{Store: db}
+
+	// exists=false: org-a has P2 with no tasks, org-b has no projects without tasks
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Tasks": {Value: "false", Operator: metadata.OpExists},
+		},
+	}
+
+	ctx := ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-a")
+
+	projects, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("Expected 1 project without tasks in org-a, got %d", len(projects))
+	}
+	if len(projects) > 0 && projects[0].Name != "Beta" {
+		t.Errorf("Expected Beta, got %s", projects[0].Name)
+	}
+
+	// org-b has no projects without tasks
+	ctx = ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-b")
+
+	projects, _, _, _, err = wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 0 {
+		t.Errorf("Expected 0 projects without tasks in org-b, got %d", len(projects))
+	}
+}
+
+func TestTenant_CountFilter_ScopedByTenant(t *testing.T) {
+	db, cleanup := setupTenantTestDB(t)
+	defer cleanup()
+
+	_, projectMeta, _ := createTenantTestMeta()
+	seedTenantRelationData(t, db)
+
+	wrapper := &datastore.Wrapper[TestTenantProject]{Store: db}
+
+	// org-a P1 has 3 tasks: count_gt=2 should match P1 only
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Tasks": {Value: "2", Operator: metadata.OpCountGt},
+		},
+	}
+
+	ctx := ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-a")
+
+	projects, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("Expected 1 project with >2 tasks in org-a, got %d", len(projects))
+	}
+	if len(projects) > 0 && projects[0].Name != "Alpha" {
+		t.Errorf("Expected Alpha, got %s", projects[0].Name)
+	}
+
+	// org-b P3 has 2 tasks: count_gt=2 should NOT match
+	ctx = ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-b")
+
+	projects, _, _, _, err = wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 0 {
+		t.Errorf("Expected 0 projects with >2 tasks in org-b, got %d", len(projects))
+	}
+}
+
+func TestTenant_CountFilter_CrossTenant_NoLeakage(t *testing.T) {
+	db, cleanup := setupTenantTestDB(t)
+	defer cleanup()
+
+	_, projectMeta, _ := createTenantTestMeta()
+	seedTenantRelationData(t, db)
+
+	wrapper := &datastore.Wrapper[TestTenantProject]{Store: db}
+
+	// count_eq=0: org-a has Beta (0 tasks), org-b has none with 0 tasks
+	opts := &metadata.QueryOptions{
+		Filters: map[string]metadata.FilterValue{
+			"Tasks": {Value: "0", Operator: metadata.OpCountEq},
+		},
+	}
+
+	ctx := ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-a")
+
+	projects, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 1 {
+		t.Errorf("Expected 1 project with 0 tasks in org-a, got %d", len(projects))
+	}
+	if len(projects) > 0 && projects[0].Name != "Beta" {
+		t.Errorf("Expected Beta, got %s", projects[0].Name)
+	}
+
+	// org-b: all projects have tasks, count_eq=0 should match 0
+	ctx = ctxWithMeta(projectMeta)
+	ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+	ctx = ctxWithTenant(ctx, "org-b")
+
+	projects, _, _, _, err = wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	if len(projects) != 0 {
+		t.Errorf("Expected 0 projects with 0 tasks in org-b, got %d", len(projects))
+	}
+}
+
+func TestTenant_IncludeCounts_ScopedByTenant(t *testing.T) {
+	db, cleanup := setupTenantTestDB(t)
+	defer cleanup()
+
+	_, projectMeta, _ := createTenantTestMeta()
+	projects := seedTenantRelationData(t, db)
+
+	wrapper := &datastore.Wrapper[TestTenantProject]{Store: db}
+
+	// Get org-a's projects
+	ctx := ctxWithMeta(projectMeta)
+	ctx = ctxWithTenant(ctx, "org-a")
+
+	orgAProjects, _, _, _, err := wrapper.GetAll(ctx)
+	if err != nil {
+		t.Fatal("GetAll failed:", err)
+	}
+
+	counts, err := wrapper.ComputeIncludeCounts(ctx, orgAProjects, []string{"Tasks"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	taskCounts, ok := counts["Tasks"]
+	if !ok {
+		t.Fatal("Expected Tasks in counts")
+	}
+
+	// P1 (Alpha) should have 3 tasks
+	p1ID := strconv.Itoa(projects[0].ID)
+	if taskCounts[p1ID] != 3 {
+		t.Errorf("Expected Alpha to have 3 tasks, got %d", taskCounts[p1ID])
+	}
+
+	// P2 (Beta) has 0 tasks — omitted from counts map
+	p2ID := strconv.Itoa(projects[1].ID)
+	if taskCounts[p2ID] != 0 {
+		t.Errorf("Expected Beta to have 0 tasks (omitted), got %d", taskCounts[p2ID])
+	}
+
+	// Verify org-b's project count doesn't leak into org-a's results
+	p3ID := strconv.Itoa(projects[2].ID)
+	if taskCounts[p3ID] != 0 {
+		t.Errorf("Org-b's project should not appear in org-a's counts, got %d", taskCounts[p3ID])
+	}
+}
+
+// ============================================================================
+// Issue #99: Multi-Level Include Counts
+// ============================================================================
+
+func TestIncludeCounts_MultiLevel(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	// Count sites per user via Accounts.Sites (2-level chain)
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts.Sites"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	siteCounts, ok := counts["Accounts.Sites"]
+	if !ok {
+		t.Fatal("Expected Accounts.Sites in counts")
+	}
+
+	aliceID := strconv.Itoa(users[0].ID)
+	bobID := strconv.Itoa(users[1].ID)
+
+	// Alice: acct[0] has 2 sites + acct[1] has 1 site = 3 total
+	if siteCounts[aliceID] != 3 {
+		t.Errorf("Expected Alice to have 3 sites, got %d", siteCounts[aliceID])
+	}
+
+	// Bob: acct[2] has 1 site = 1 total
+	if siteCounts[bobID] != 1 {
+		t.Errorf("Expected Bob to have 1 site, got %d", siteCounts[bobID])
+	}
+}
+
+func TestIncludeCounts_MultiLevel_ThreeLevels(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	// Count bills per user via Accounts.Sites.Bills (3-level chain)
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts.Sites.Bills"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	billCounts, ok := counts["Accounts.Sites.Bills"]
+	if !ok {
+		t.Fatal("Expected Accounts.Sites.Bills in counts")
+	}
+
+	aliceID := strconv.Itoa(users[0].ID)
+	bobID := strconv.Itoa(users[1].ID)
+
+	// Alice: sites[0]=2 bills + sites[1]=1 bill + sites[2]=1 bill = 4 total
+	if billCounts[aliceID] != 4 {
+		t.Errorf("Expected Alice to have 4 bills, got %d", billCounts[aliceID])
+	}
+
+	// Bob: sites[3]=2 bills = 2 total
+	if billCounts[bobID] != 2 {
+		t.Errorf("Expected Bob to have 2 bills, got %d", billCounts[bobID])
+	}
+}
+
+func TestIncludeCounts_MultiLevel_Mixed(t *testing.T) {
+	db, cleanup := setupRelationFilterTestDB(t)
+	defer cleanup()
+
+	userMeta, _, _, _, _ := createRelationFilterTestMeta()
+	users, _, _, _, _ := seedRelationFilterTestData(t, db)
+
+	userWrapper := &datastore.Wrapper[RelUser]{Store: db}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, userMeta)
+
+	items := make([]*RelUser, len(users))
+	for i := range users {
+		items[i] = &users[i]
+	}
+
+	// Request both single-level and multi-level counts together
+	counts, err := userWrapper.ComputeIncludeCounts(ctx, items, []string{"Accounts", "Accounts.Sites"})
+	if err != nil {
+		t.Fatal("ComputeIncludeCounts failed:", err)
+	}
+
+	aliceID := strconv.Itoa(users[0].ID)
+	bobID := strconv.Itoa(users[1].ID)
+
+	// Verify single-level: Accounts
+	accountCounts, ok := counts["Accounts"]
+	if !ok {
+		t.Fatal("Expected Accounts in counts")
+	}
+	if accountCounts[aliceID] != 2 {
+		t.Errorf("Expected Alice to have 2 accounts, got %d", accountCounts[aliceID])
+	}
+	if accountCounts[bobID] != 1 {
+		t.Errorf("Expected Bob to have 1 account, got %d", accountCounts[bobID])
+	}
+
+	// Verify multi-level: Accounts.Sites
+	siteCounts, ok := counts["Accounts.Sites"]
+	if !ok {
+		t.Fatal("Expected Accounts.Sites in counts")
+	}
+	if siteCounts[aliceID] != 3 {
+		t.Errorf("Expected Alice to have 3 sites, got %d", siteCounts[aliceID])
+	}
+	if siteCounts[bobID] != 1 {
+		t.Errorf("Expected Bob to have 1 site, got %d", siteCounts[bobID])
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -371,6 +371,16 @@ func GetAll[T any](getAllFunc CustomGetAllFunc[T]) http.HandlerFunc {
 			response.Sums = sums
 		}
 
+		// Include counts if any were requested
+		if opts != nil && len(opts.IncludeCounts) > 0 {
+			counts, err := svc.ComputeIncludeCounts(ctx, items, opts.IncludeCounts)
+			if err != nil {
+				slog.WarnContext(ctx, "failed to compute include counts", "error", err)
+			} else if len(counts) > 0 {
+				response.Counts = counts
+			}
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -3350,3 +3350,198 @@ func TestBatchDelete_FileResource_Returns501(t *testing.T) {
 			http.StatusNotImplemented, w.Code, w.Body.String())
 	}
 }
+
+// ============================================================================
+// Issue #99: Include Counts Handler Integration Test
+// Tests the full handler → service → datastore flow for include_count
+// ============================================================================
+
+// TestHandlerPost is a child model with FK to users for include_count testing
+type TestHandlerPost struct {
+	bun.BaseModel `bun:"table:handler_posts"`
+	ID            int       `bun:"id,pk,autoincrement" json:"id"`
+	UserID        int       `bun:"user_id,notnull" json:"user_id"`
+	Title         string    `bun:"title,notnull" json:"title"`
+	CreatedAt     time.Time `bun:"created_at,notnull,default:current_timestamp" json:"created_at,omitempty"`
+}
+
+func TestHandler_GetAll_IncludeCounts(t *testing.T) {
+	db, _ := datastore.Get()
+
+	_, err := db.GetDB().NewCreateTable().Model((*TestHandlerPost)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create handler_posts table:", err)
+	}
+	defer db.GetDB().NewDropTable().Model((*TestHandlerPost)(nil)).IfExists().Exec(context.Background())
+
+	cleanTable(t)
+	_, _ = db.GetDB().NewDelete().Model((*TestHandlerPost)(nil)).Where("1=1").Exec(context.Background())
+
+	// Create users
+	users := []TestUser{
+		{Name: "Alice", Email: "alice@example.com"},
+		{Name: "Bob", Email: "bob@example.com"},
+	}
+	for i := range users {
+		_, err := db.GetDB().NewInsert().Model(&users[i]).Returning("*").Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert user:", err)
+		}
+	}
+
+	// Create posts: Alice=3, Bob=1
+	posts := []TestHandlerPost{
+		{UserID: users[0].ID, Title: "Alice Post 1"},
+		{UserID: users[0].ID, Title: "Alice Post 2"},
+		{UserID: users[0].ID, Title: "Alice Post 3"},
+		{UserID: users[1].ID, Title: "Bob Post 1"},
+	}
+	for _, p := range posts {
+		_, err := db.GetDB().NewInsert().Model(&p).Exec(context.Background())
+		if err != nil {
+			t.Fatal("Failed to insert post:", err)
+		}
+	}
+
+	postMeta := &metadata.TypeMetadata{
+		TypeID:        "test_handler_post",
+		TypeName:      "TestHandlerPost",
+		TableName:     "handler_posts",
+		URLParamUUID:  "postId",
+		PKField:       "ID",
+		ModelType:     reflect.TypeOf(TestHandlerPost{}),
+		ParentType:    reflect.TypeOf(TestUser{}),
+		ParentMeta:    userMeta,
+		ForeignKeyCol: "user_id",
+	}
+
+	countMeta := &metadata.TypeMetadata{
+		TypeID:           "test_user_id",
+		TypeName:         "TestUser",
+		TableName:        "users",
+		URLParamUUID:     "id",
+		PKField:          "ID",
+		ModelType:        reflect.TypeOf(TestUser{}),
+		FilterableFields: []string{"Name", "Email"},
+		SortableFields:   []string{"Name", "Email"},
+		ChildMeta: map[string]*metadata.TypeMetadata{
+			"Posts": postMeta,
+		},
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMeta(countMeta))
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users?include_count=Posts", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	if envelope.Counts == nil {
+		t.Fatal("Expected counts in response envelope")
+	}
+
+	postCounts, ok := envelope.Counts["Posts"]
+	if !ok {
+		t.Fatal("Expected Posts in counts")
+	}
+
+	aliceID := strconv.Itoa(users[0].ID)
+	bobID := strconv.Itoa(users[1].ID)
+
+	if postCounts[aliceID] != 3 {
+		t.Errorf("Expected Alice to have 3 posts, got %d", postCounts[aliceID])
+	}
+	if postCounts[bobID] != 1 {
+		t.Errorf("Expected Bob to have 1 post, got %d", postCounts[bobID])
+	}
+}
+
+func TestHandler_GetAll_IncludeCounts_NoAuth(t *testing.T) {
+	db, _ := datastore.Get()
+
+	_, err := db.GetDB().NewCreateTable().Model((*TestHandlerPost)(nil)).IfNotExists().Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create handler_posts table:", err)
+	}
+	defer db.GetDB().NewDropTable().Model((*TestHandlerPost)(nil)).IfExists().Exec(context.Background())
+
+	cleanTable(t)
+	_, _ = db.GetDB().NewDelete().Model((*TestHandlerPost)(nil)).Where("1=1").Exec(context.Background())
+
+	user := TestUser{Name: "Alice", Email: "alice@example.com"}
+	_, err = db.GetDB().NewInsert().Model(&user).Returning("*").Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert user:", err)
+	}
+
+	post := TestHandlerPost{UserID: user.ID, Title: "Post 1"}
+	_, err = db.GetDB().NewInsert().Model(&post).Exec(context.Background())
+	if err != nil {
+		t.Fatal("Failed to insert post:", err)
+	}
+
+	postMeta := &metadata.TypeMetadata{
+		TypeID:        "test_handler_post",
+		TypeName:      "TestHandlerPost",
+		TableName:     "handler_posts",
+		URLParamUUID:  "postId",
+		PKField:       "ID",
+		ModelType:     reflect.TypeOf(TestHandlerPost{}),
+		ParentType:    reflect.TypeOf(TestUser{}),
+		ForeignKeyCol: "user_id",
+	}
+
+	countMeta := &metadata.TypeMetadata{
+		TypeID:       "test_user_id",
+		TypeName:     "TestUser",
+		TableName:    "users",
+		URLParamUUID: "id",
+		PKField:      "ID",
+		ModelType:    reflect.TypeOf(TestUser{}),
+		ChildMeta: map[string]*metadata.TypeMetadata{
+			"Posts": postMeta,
+		},
+	}
+
+	// Auth configured but Posts NOT authorized — counts should be empty
+	withMetaAndAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), metadata.MetadataKey, countMeta)
+			opts := metadata.ParseQueryOptions(r.URL.Query())
+			ctx = context.WithValue(ctx, metadata.QueryOptionsKey, opts)
+			ctx = context.WithValue(ctx, metadata.AllowedIncludesKey, metadata.AllowedIncludes{"Other": false})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	r := chi.NewRouter()
+	r.Use(withMetaAndAuth)
+	r.Get("/users", handler.GetAll[TestUser](handler.StandardGetAll[TestUser]))
+
+	req := httptest.NewRequest(http.MethodGet, "/users?include_count=Posts", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope handler.ListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatal("Failed to unmarshal response:", err)
+	}
+
+	if envelope.Counts != nil {
+		t.Errorf("Expected no counts (Posts not authorized), got %v", envelope.Counts)
+	}
+}

--- a/handler/response.go
+++ b/handler/response.go
@@ -1,11 +1,12 @@
 package handler
 
 // ListResponse is the envelope returned by GetAll endpoints.
-// Data contains the result items. Pagination and Sums are omitted when empty.
+// Data contains the result items. Pagination, Sums, and Counts are omitted when empty.
 type ListResponse struct {
-	Data       any                `json:"data"`
-	Pagination *PaginationInfo    `json:"pagination,omitempty"`
-	Sums       map[string]float64 `json:"sums,omitempty"`
+	Data       any                       `json:"data"`
+	Pagination *PaginationInfo           `json:"pagination,omitempty"`
+	Sums       map[string]float64        `json:"sums,omitempty"`
+	Counts     map[string]map[string]int `json:"counts,omitempty"`
 }
 
 // PaginationInfo contains pagination metadata in the response envelope.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -256,15 +256,16 @@ func (m *TypeMetadata) Clone() *TypeMetadata {
 
 // QueryOptions holds parsed query parameters for filtering, sorting, and pagination
 type QueryOptions struct {
-	Filters    map[string]FilterValue // field -> value/operator
-	Sort       []SortField            // ordered list of sort fields
-	Limit      int                    // 0 means use default
-	Offset     int                    // 0 means start from beginning
-	After      string                 // cursor for forward pagination (next page)
-	Before     string                 // cursor for backward pagination (previous page)
-	CountTotal bool                   // whether to return total count
-	Include    []string               // relation names to include via ?include=
-	Sums       []string               // field names to compute sum aggregates via ?sum=
+	Filters       map[string]FilterValue // field -> value/operator
+	Sort          []SortField            // ordered list of sort fields
+	Limit         int                    // 0 means use default
+	Offset        int                    // 0 means start from beginning
+	After         string                 // cursor for forward pagination (next page)
+	Before        string                 // cursor for backward pagination (previous page)
+	CountTotal    bool                   // whether to return total count
+	Include       []string               // relation names to include via ?include=
+	Sums          []string               // field names to compute sum aggregates via ?sum=
+	IncludeCounts []string               // relation names to include counts via ?include_count=
 }
 
 // AllowedIncludes maps relation names to whether ownership filtering should be applied.
@@ -300,6 +301,15 @@ const (
 	OpNin  = "nin"  // Not in list
 	OpBt   = "bt"   // Between (inclusive)
 	OpNbt  = "nbt"  // Not between
+
+	// Relation-level operators (applied to child relations, not fields)
+	OpExists   = "exists"    // Existence filter: ?filter[Relation][exists]=true/false
+	OpCountEq  = "count_eq"  // Count equals: ?filter[Relation][count_eq]=5
+	OpCountNeq = "count_neq" // Count not equals
+	OpCountGt  = "count_gt"  // Count greater than
+	OpCountGte = "count_gte" // Count greater than or equal
+	OpCountLt  = "count_lt"  // Count less than
+	OpCountLte = "count_lte" // Count less than or equal
 )
 
 // FilterValue represents a filter with value and operator
@@ -434,6 +444,16 @@ func ParseQueryOptions(query url.Values) *QueryOptions {
 			field = strings.TrimSpace(field)
 			if field != "" {
 				opts.Sums = append(opts.Sums, field)
+			}
+		}
+	}
+
+	// Parse include_count: include_count=Relation1,Relation2
+	if includeCountStr := query.Get("include_count"); includeCountStr != "" {
+		for _, rel := range strings.Split(includeCountStr, ",") {
+			rel = strings.TrimSpace(rel)
+			if rel != "" {
+				opts.IncludeCounts = append(opts.IncludeCounts, rel)
 			}
 		}
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -883,6 +883,135 @@ func TestParseQueryOptions_Sum(t *testing.T) {
 	}
 }
 
+func TestParseQueryOptions_RelationOperators(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         url.Values
+		expectedField string
+		expectedValue string
+		expectedOp    string
+	}{
+		{
+			name:          "exists true",
+			query:         url.Values{"filter[Orders][exists]": {"true"}},
+			expectedField: "Orders",
+			expectedValue: "true",
+			expectedOp:    OpExists,
+		},
+		{
+			name:          "exists false",
+			query:         url.Values{"filter[Orders][exists]": {"false"}},
+			expectedField: "Orders",
+			expectedValue: "false",
+			expectedOp:    OpExists,
+		},
+		{
+			name:          "nested exists",
+			query:         url.Values{"filter[Orders.Items][exists]": {"true"}},
+			expectedField: "Orders.Items",
+			expectedValue: "true",
+			expectedOp:    OpExists,
+		},
+		{
+			name:          "count_gt",
+			query:         url.Values{"filter[Orders][count_gt]": {"5"}},
+			expectedField: "Orders",
+			expectedValue: "5",
+			expectedOp:    OpCountGt,
+		},
+		{
+			name:          "count_eq",
+			query:         url.Values{"filter[Orders][count_eq]": {"0"}},
+			expectedField: "Orders",
+			expectedValue: "0",
+			expectedOp:    OpCountEq,
+		},
+		{
+			name:          "count_lte nested",
+			query:         url.Values{"filter[Orders.Items][count_lte]": {"10"}},
+			expectedField: "Orders.Items",
+			expectedValue: "10",
+			expectedOp:    OpCountLte,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ParseQueryOptions(tt.query)
+
+			if len(opts.Filters) != 1 {
+				t.Fatalf("Expected 1 filter, got %d", len(opts.Filters))
+			}
+
+			filter, ok := opts.Filters[tt.expectedField]
+			if !ok {
+				t.Fatalf("Expected filter for field %q", tt.expectedField)
+			}
+			if filter.Value != tt.expectedValue {
+				t.Errorf("Expected value %q, got %q", tt.expectedValue, filter.Value)
+			}
+			if filter.Operator != tt.expectedOp {
+				t.Errorf("Expected operator %q, got %q", tt.expectedOp, filter.Operator)
+			}
+		})
+	}
+}
+
+func TestParseQueryOptions_IncludeCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    url.Values
+		expected []string
+	}{
+		{
+			name:     "single relation",
+			query:    url.Values{"include_count": {"Orders"}},
+			expected: []string{"Orders"},
+		},
+		{
+			name:     "multiple relations",
+			query:    url.Values{"include_count": {"Orders,Comments"}},
+			expected: []string{"Orders", "Comments"},
+		},
+		{
+			name:     "nested chain",
+			query:    url.Values{"include_count": {"Orders.Items"}},
+			expected: []string{"Orders.Items"},
+		},
+		{
+			name:     "with spaces",
+			query:    url.Values{"include_count": {"Orders, Comments"}},
+			expected: []string{"Orders", "Comments"},
+		},
+		{
+			name:     "empty ignored",
+			query:    url.Values{"include_count": {"Orders,,Comments"}},
+			expected: []string{"Orders", "Comments"},
+		},
+		{
+			name:     "not present",
+			query:    url.Values{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ParseQueryOptions(tt.query)
+
+			if len(opts.IncludeCounts) != len(tt.expected) {
+				t.Fatalf("IncludeCounts: expected %d, got %d", len(tt.expected), len(opts.IncludeCounts))
+			}
+
+			for i, exp := range tt.expected {
+				if opts.IncludeCounts[i] != exp {
+					t.Errorf("IncludeCounts[%d]: expected %q, got %q", i, exp, opts.IncludeCounts[i])
+				}
+			}
+		})
+	}
+}
+
 func TestTypeMetadata_Clone_SummableFields(t *testing.T) {
 	original := &TypeMetadata{
 		TypeID:         "test_id",

--- a/service/service.go
+++ b/service/service.go
@@ -163,6 +163,12 @@ func (s *Common[T]) Download(ctx context.Context, id string) (*DownloadResult, e
 	}, nil
 }
 
+// ComputeIncludeCounts computes per-item child relation counts for the given items.
+// Returns a map of relation name → {pk_string → count}.
+func (s *Common[T]) ComputeIncludeCounts(ctx context.Context, items []*T, includeCounts []string) (map[string]map[string]int, error) {
+	return s.store.ComputeIncludeCounts(ctx, items, includeCounts)
+}
+
 // BatchCreate creates multiple items in a single transaction.
 // All items succeed or none do (all-or-nothing).
 func (s *Common[T]) BatchCreate(ctx context.Context, items []T) ([]*T, error) {


### PR DESCRIPTION
## Summary
- Add `filter[Relation][exists]=true/false` for filtering parents by child existence
- Add `filter[Relation][count_gt|gte|lt|lte|eq|neq]=N` for filtering by child count
- Add `include_count=Relation` for per-item child counts in response envelope
- Refactor wrapper.go: extract shared helpers (`translateError`, `defaultParentJoinCol`, `derefType`, `isRelationAuthorized`), deduplicate CRUD error handling
- Update docs: README, SKILL.md, patterns.md, AGENT.md
- 15 new Bruno tests covering auth, ownership, edge cases

## Test plan
- [x] All unit tests pass (8 packages)
- [x] All benchmarks pass
- [x] All Bruno tests pass (including 15 new relation filter tests)
- [x] golangci-lint passes (all 13 pre-commit hooks green)

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)