### PR TITLE
Release v0.6.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Install golangci-lint v2
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Check formatting
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run go vet
         run: go vet ./...
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run tests
         run: go test ./metadata ./datastore ./router ./service ./handler ./errors -race -coverprofile=coverage.out

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,12 +18,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
+
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
-        with:
-          args: '-exclude-generated ./metadata/... ./datastore/... ./router/... ./service/... ./handler/... ./errors/... ./filestore/...'
+        run: gosec -exclude-generated ./metadata/... ./datastore/... ./router/... ./service/... ./handler/... ./errors/... ./filestore/...
 
   govulncheck:
     name: Vulnerability Check
@@ -34,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -261,7 +261,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -303,7 +303,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -345,7 +345,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -387,7 +387,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -429,7 +429,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -471,7 +471,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -513,7 +513,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -555,7 +555,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -597,7 +597,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/examples/actions/go.mod
+++ b/examples/actions/go.mod
@@ -1,6 +1,6 @@
 module example/actions
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/anything/go.mod
+++ b/examples/anything/go.mod
@@ -1,6 +1,6 @@
 module example/anything
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/audit/go.mod
+++ b/examples/audit/go.mod
@@ -1,6 +1,6 @@
 module example/audit
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/auth/go.mod
+++ b/examples/auth/go.mod
@@ -1,6 +1,6 @@
 module example/auth
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/batch/go.mod
+++ b/examples/batch/go.mod
@@ -1,6 +1,6 @@
 module example/batch
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/custom/go.mod
+++ b/examples/custom/go.mod
@@ -1,6 +1,6 @@
 module example/custom
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/files_proxy/go.mod
+++ b/examples/files_proxy/go.mod
@@ -1,6 +1,6 @@
 module example/files_proxy
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/files_signed/go.mod
+++ b/examples/files_signed/go.mod
@@ -1,6 +1,6 @@
 module example/files_signed
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/nested_routes/go.mod
+++ b/examples/nested_routes/go.mod
@@ -1,6 +1,6 @@
 module example/nested_routes
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/relations/go.mod
+++ b/examples/relations/go.mod
@@ -1,6 +1,6 @@
 module example/relations
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -1,6 +1,6 @@
 module example/simple
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/tenant/go.mod
+++ b/examples/tenant/go.mod
@@ -1,6 +1,6 @@
 module example/tenant
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/uuid_pk/go.mod
+++ b/examples/uuid_pk/go.mod
@@ -1,6 +1,6 @@
 module example/uuid_pk
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/examples/validator/go.mod
+++ b/examples/validator/go.mod
@@ -1,6 +1,6 @@
 module example/validator
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sjgoldie/go-restgen
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Summary
- Bumps Go from 1.26.1 to 1.26.2 to resolve 4 stdlib vulnerabilities in `crypto/x509` and `crypto/tls` (GO-2026-4947, GO-2026-4946, GO-2026-4870, GO-2026-4866)
- Switches gosec CI from Docker action to binary install to use runner's Go version

## Changes since v0.6.1
- fix: bump Go from 1.26.1 to 1.26.2 to resolve stdlib vulnerabilities (#115)
- fix: install gosec as binary instead of Docker action

🤖 Generated with [Claude Code](https://claude.com/claude-code)