### PR TITLE
feat: PostgreSQL Row-Level Security support on WithTenantScope

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -147,8 +147,9 @@ router.RegisterRoutes[Model](builder, "/path",
     router.WithBatchLimit(100),          // optional: limit items per batch
 
     // Multi-tenant isolation
-    router.WithTenantScope("OrgID"),  // auto-filter + auto-set tenant field from AuthInfo.TenantID
-    router.IsTenantTable(),           // marks route as the tenant entity (PK = tenant ID)
+    router.WithTenantScope("OrgID"),        // auto-filter + auto-set tenant field from AuthInfo.TenantID
+    router.WithTenantScope("OrgID", true),  // also enable PostgreSQL Row-Level Security (set_config app.tenant_id)
+    router.IsTenantTable(),                 // marks route as the tenant entity (PK = tenant ID)
 
     // Custom actions
     router.WithAction("publish", publishFn, router.AuthConfig{Scopes: []string{"user"}}),
@@ -286,6 +287,18 @@ authInfo := &router.AuthInfo{
 ```
 
 Behaviour: CREATE auto-sets tenant field, GET/LIST auto-filters, UPDATE re-enforces tenant field, cross-tenant returns 404, missing TenantID returns 401. Children inherit from parent.
+
+### PostgreSQL Row-Level Security (RLS)
+
+For PostgreSQL deployments, pass `true` as the second argument to `WithTenantScope` to enable defense-in-depth via RLS policies:
+
+```go
+router.WithTenantScope("OrgID", true)
+```
+
+When enabled, each request runs in a transaction with `SELECT set_config('app.tenant_id', '<id>', true)` so PostgreSQL RLS policies can scope queries. Application-level filtering still applies — RLS is purely additive. Configure RLS policies on your tables yourself (e.g., `CREATE POLICY tenant_isolation ON projects USING (org_id = current_setting('app.tenant_id'))`). The RLS middleware uses PostgreSQL-specific SQL — pointing it at SQLite will cause requests to fail with 500. Children inherit the parent's RLS setting.
+
+**Audit + RLS**: Audit inserts run in the same RLS transaction as the CRUD operation, so RLS policies on your audit table apply to the audit insert. Either leave audit tables without RLS (typical for global audit logs), or ensure your auditor builds records that satisfy the audit table's policies (e.g., set the tenant column to match `current_setting('app.tenant_id')`). Misconfigured RLS on the audit table will fail the audit insert and roll back the whole transaction.
 
 ## Pattern: Custom Handlers
 

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ go-restgen supports automatic multi-tenant data isolation, ensuring each tenant'
 
 Multi-tenancy is configured per-route using two options:
 
-- **`WithTenantScope(field)`** — Scopes all queries by the tenant ID stored in the named field. Auto-sets the field on create and update. Child routes inherit automatically.
+- **`WithTenantScope(field, useRLS...)`** — Scopes all queries by the tenant ID stored in the named field. Auto-sets the field on create and update. Child routes inherit automatically. Pass `true` as the optional second argument to enable PostgreSQL Row-Level Security (see [PostgreSQL Row-Level Security](#postgresql-row-level-security-rls)).
 - **`IsTenantTable()`** — Marks the route as the tenant entity itself (e.g., Organization). The model's primary key IS the tenant ID, so queries use `WHERE id = tenantID`.
 
 The tenant ID comes from `AuthInfo.TenantID`, which you populate in your auth middleware.
@@ -854,6 +854,41 @@ Tenant scoping works with all other go-restgen features:
 - **Query parameters** — Filters, sorts, and pagination apply within tenant scope
 
 See the [tenant example](./examples/tenant) for a complete working example with organizations, projects, tasks, and comprehensive cross-tenant isolation tests.
+
+### PostgreSQL Row-Level Security (RLS)
+
+For applications running on PostgreSQL, `WithTenantScope` accepts an optional second argument that enables defense-in-depth at the database level via Row-Level Security policies.
+
+```go
+// Application-level filtering only (default)
+router.WithTenantScope("OrgID")
+
+// Application-level filtering + PostgreSQL RLS
+router.WithTenantScope("OrgID", true)
+```
+
+When RLS is enabled, each request is wrapped in a transaction with `SELECT set_config('app.tenant_id', '<id>', true)` so PostgreSQL RLS policies can scope queries to the tenant. The transaction commits on 2xx/3xx responses and rolls back on 4xx/5xx.
+
+**Important:**
+- Application-level tenant filtering still applies — RLS is purely additive.
+- You must configure RLS policies on your tables yourself. Example:
+  ```sql
+  ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY tenant_isolation ON projects
+      USING (org_id = current_setting('app.tenant_id'));
+  ```
+- RLS uses PostgreSQL-specific SQL (`set_config`). Pointing it at SQLite will cause requests to fail. Only enable on PostgreSQL deployments.
+- Child routes inherit the parent's RLS setting along with the tenant scope.
+
+#### Audit and RLS
+
+When `WithAudit` is configured, the audit insert runs inside the same RLS transaction as the CRUD operation. This means any RLS policies on your audit table will apply to the audit insert. There are three scenarios:
+
+1. **Audit table has no RLS** — works normally. Recommended for global audit logs.
+2. **Audit table has matching per-tenant RLS** — works as defense-in-depth. The audit record's tenant column must match `current_setting('app.tenant_id')`, otherwise the insert fails. This *prevents* writing audit records to the wrong tenant.
+3. **Audit table has RLS policies that the audit record doesn't satisfy** — the audit insert fails, which rolls back the entire transaction (including the CRUD operation). Configure your audit table's policies to match how your auditor function builds records.
+
+The atomicity guarantee (CRUD + audit succeed or fail together) is preserved either way.
 
 ## Query Parameters: Filtering, Sorting & Pagination
 

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -4,6 +4,43 @@ Third party libraries used by go-restgen
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/DATA-DOG/go-sqlmock
+Version : v1.5.2
+Time    : 2024-01-06T21:33:25Z
+Licence : BSD-3-Clause
+
+Contents of probable licence file /Volumes/Overflow/go/pkg/mod/github.com/!d!a!t!a-!d!o!g/go-sqlmock@v1.5.2/LICENSE:
+
+The three clause BSD license (http://en.wikipedia.org/wiki/BSD_licenses)
+
+Copyright (c) 2013-2019, DATA-DOG team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* The name DataDog.lt may not be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
 Module  : github.com/go-chi/chi/v5
 Version : v5.2.5
 Time    : 2026-02-05T11:05:34Z
@@ -31,7 +68,6 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/google/uuid
@@ -68,7 +104,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/shopspring/decimal
@@ -124,7 +159,6 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/uptrace/bun
 Version : v1.2.17
@@ -157,7 +191,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/uptrace/bun/dialect/pgdialect
@@ -192,7 +225,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/uptrace/bun/dialect/sqlitedialect
 Version : v1.2.17
@@ -225,7 +257,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/uptrace/bun/driver/pgdriver
@@ -260,7 +291,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/uptrace/bun/driver/sqliteshim
 Version : v1.2.17
@@ -293,7 +323,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : go.opentelemetry.io/otel
@@ -534,7 +563,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 --------------------------------------------------------------------------------
 Module  : go.opentelemetry.io/otel/metric
 Version : v1.40.0
@@ -776,7 +804,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-
 ================================================================================
 Indirect dependencies
 
@@ -812,7 +839,6 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/davecgh/go-spew
 Version : v1.1.1
@@ -836,7 +862,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/dustin/go-humanize
@@ -867,7 +892,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 <http://www.opensource.org/licenses/mit-license.php>
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/go-logr/logr
@@ -1079,7 +1103,6 @@ Contents of probable licence file /Volumes/Overflow/go/pkg/mod/github.com/go-log
    See the License for the specific language governing permissions and
    limitations under the License.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/go-logr/stdr
 Version : v1.2.2
@@ -1290,7 +1313,6 @@ Contents of probable licence file /Volumes/Overflow/go/pkg/mod/github.com/go-log
    See the License for the specific language governing permissions and
    limitations under the License.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/google/go-cmp
 Version : v0.7.0
@@ -1326,7 +1348,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/google/pprof
@@ -1538,7 +1559,6 @@ Contents of probable licence file /Volumes/Overflow/go/pkg/mod/github.com/google
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/hashicorp/golang-lru/v2
@@ -1913,7 +1933,6 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/jinzhu/inflection
 Version : v1.0.0
@@ -1944,7 +1963,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/mattn/go-isatty
 Version : v0.0.20
@@ -1962,7 +1980,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/mattn/go-sqlite3
@@ -1994,7 +2011,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/ncruces/go-strftime
 Version : v1.0.0
@@ -2024,7 +2040,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/pmezard/go-difflib
@@ -2061,7 +2076,6 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/puzpuzpuz/xsync/v3
@@ -2273,7 +2287,6 @@ Contents of probable licence file /Volumes/Overflow/go/pkg/mod/github.com/puzpuz
    See the License for the specific language governing permissions and
    limitations under the License.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/remyoudompheng/bigfft
 Version : v0.0.0-20230129092748-24d4a6f8daec
@@ -2310,7 +2323,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/stretchr/testify
 Version : v1.11.1
@@ -2340,7 +2352,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
 
 --------------------------------------------------------------------------------
 Module  : github.com/tmthrgd/go-hex
@@ -2433,7 +2444,6 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/vmihailenco/msgpack/v5
 Version : v5.4.1
@@ -2468,7 +2478,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : github.com/vmihailenco/tagparser/v2
 Version : v2.0.0
@@ -2502,7 +2511,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : go.opentelemetry.io/auto/sdk
@@ -2713,7 +2721,6 @@ Contents of probable licence file /Volumes/Overflow/go/pkg/mod/go.opentelemetry.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
 
 --------------------------------------------------------------------------------
 Module  : go.opentelemetry.io/otel/trace
@@ -2954,7 +2961,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 --------------------------------------------------------------------------------
 Module  : golang.org/x/crypto
 Version : v0.48.0
@@ -2990,7 +2996,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : golang.org/x/exp
@@ -3028,7 +3033,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : golang.org/x/mod
 Version : v0.33.0
@@ -3064,7 +3068,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : golang.org/x/sync
@@ -3102,7 +3105,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : golang.org/x/sys
 Version : v0.41.0
@@ -3139,7 +3141,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : golang.org/x/tools
 Version : v0.42.0
@@ -3175,7 +3176,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : gopkg.in/yaml.v3
@@ -3236,7 +3236,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-
 --------------------------------------------------------------------------------
 Module  : mellium.im/sasl
 Version : v0.3.2
@@ -3268,7 +3267,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/cc/v4
@@ -3306,7 +3304,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/ccgo/v4
 Version : v4.30.2
@@ -3343,7 +3340,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/fileutil
 Version : v1.3.40
@@ -3379,7 +3375,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/gc/v2
@@ -3459,7 +3454,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------------------------
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/gc/v3
 Version : v3.1.2
@@ -3538,7 +3532,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------------------------
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/goabi0
 Version : v0.2.0
@@ -3573,7 +3566,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/libc
@@ -3611,7 +3603,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/mathutil
 Version : v1.7.1
@@ -3647,7 +3638,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/memory
@@ -3685,7 +3675,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/opt
 Version : v0.1.4
@@ -3721,7 +3710,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/sortutil
@@ -3759,7 +3747,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/sqlite
 Version : v1.46.1
@@ -3794,7 +3781,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 --------------------------------------------------------------------------------
 Module  : modernc.org/strutil
@@ -3832,7 +3818,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 --------------------------------------------------------------------------------
 Module  : modernc.org/token
 Version : v1.1.0
@@ -3868,6 +3853,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-

--- a/cmd/install-skill/cursor/go-restgen.mdc
+++ b/cmd/install-skill/cursor/go-restgen.mdc
@@ -196,7 +196,8 @@ router.RegisterRoutes[Model](builder, "/path",
     router.AsFileResource(),
 
     // Multi-tenant isolation
-    router.WithTenantScope("OrgID"),
+    router.WithTenantScope("OrgID"),        // app-level filtering
+    router.WithTenantScope("OrgID", true),  // app-level + PostgreSQL RLS (set_config app.tenant_id)
     router.IsTenantTable(),
 
     // Actions (POST /resource/{id}/{name})
@@ -480,6 +481,14 @@ router.RegisterRoutes[Project](b, "/projects",
 ```
 
 Auth middleware must set `TenantID` on `AuthInfo`.
+
+For PostgreSQL deployments, pass `true` as the second arg to enable Row-Level Security (RLS) as defense-in-depth. The middleware wraps requests in a transaction with `SELECT set_config('app.tenant_id', '<id>', true)`. Configure RLS policies on your tables yourself. App-level filtering still applies — RLS is additive. SQLite doesn't support `set_config`, so RLS routes will fail on SQLite.
+
+```go
+router.WithTenantScope("OrgID", true)  // app filtering + PostgreSQL RLS
+```
+
+Audit inserts share the RLS transaction, so RLS policies on the audit table apply to audit records. Either leave audit tables without RLS, or ensure auditor records satisfy the policies — misconfigured RLS on the audit table fails the audit insert and rolls back the whole transaction.
 
 ## Database Setup
 

--- a/cmd/install-skill/skill/patterns.md
+++ b/cmd/install-skill/skill/patterns.md
@@ -74,7 +74,8 @@ router.RegisterRoutes[Model](builder, "/path",
     router.AsFileResource(),
 
     // Multi-tenant isolation
-    router.WithTenantScope("OrgID"),
+    router.WithTenantScope("OrgID"),        // app-level filtering
+    router.WithTenantScope("OrgID", true),  // app-level + PostgreSQL RLS (set_config app.tenant_id)
     router.IsTenantTable(),
 
     // Actions (POST /resource/{id}/{name})
@@ -363,6 +364,14 @@ router.RegisterRoutes[Project](b, "/projects",
 ```
 
 Auth middleware must set `TenantID` on `AuthInfo`.
+
+For PostgreSQL deployments, pass `true` as the second arg to enable Row-Level Security (RLS) as defense-in-depth. The middleware wraps requests in a transaction with `SELECT set_config('app.tenant_id', '<id>', true)`. You configure RLS policies on your tables (e.g., `CREATE POLICY tenant_isolation ON projects USING (org_id = current_setting('app.tenant_id'))`). Application-level filtering still applies — RLS is additive. SQLite doesn't support `set_config`, so RLS-enabled routes will fail on SQLite.
+
+```go
+router.WithTenantScope("OrgID", true)  // app filtering + PostgreSQL RLS
+```
+
+Audit inserts share the RLS transaction, so RLS policies on the audit table apply to audit records. Either leave audit tables without RLS, or ensure auditor records satisfy the policies — misconfigured RLS on the audit table fails the audit insert and rolls back the whole transaction.
 
 ## Database Setup
 

--- a/datastore/helpers_test.go
+++ b/datastore/helpers_test.go
@@ -1449,3 +1449,75 @@ func TestBuildExistsChain_TenantIsolation(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Issue #118: RLS wrapper helper tests
+// =============================================================================
+
+func TestGetDB_ReturnsPoolByDefault(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	wrapper := &Wrapper[testParentType]{Store: db}
+
+	ctx := context.Background()
+	result := wrapper.getDB(ctx)
+
+	// Without RLS tx in context, should return the pool
+	if result != db.GetDB() {
+		t.Error("expected pool connection when no RLS tx in context")
+	}
+}
+
+func TestGetDB_ReturnsRLSTxFromContext(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	wrapper := &Wrapper[testParentType]{Store: db}
+
+	ctx := context.Background()
+	tx, err := db.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rlsCtx := context.WithValue(ctx, metadata.RLSTxKey, tx)
+	result := wrapper.getDB(rlsCtx)
+
+	// With RLS tx in context, should return the tx, not the pool
+	if result == db.GetDB() {
+		t.Error("expected RLS tx from context, got pool connection")
+	}
+}
+
+func TestRunInTx_UsesRLSTxFromContext(t *testing.T) {
+	db, cleanup := setupHelperTestDB(t)
+	defer cleanup()
+
+	wrapper := &Wrapper[testParentType]{Store: db}
+
+	ctx := context.Background()
+	tx, err := db.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rlsCtx := context.WithValue(ctx, metadata.RLSTxKey, tx)
+
+	var receivedTx bun.Tx
+	err = wrapper.runInTx(rlsCtx, func(_ context.Context, innerTx bun.Tx) error {
+		receivedTx = innerTx
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When RLS tx is in context, runInTx should pass it directly to fn
+	// instead of starting a new transaction
+	if receivedTx != tx {
+		t.Error("expected runInTx to use RLS tx from context, got a different transaction")
+	}
+}

--- a/datastore/wrapper.go
+++ b/datastore/wrapper.go
@@ -57,6 +57,27 @@ type preFetchResult[T any] struct {
 	existingItems []*T
 }
 
+// getDB returns the RLS transaction from context if available, otherwise the connection pool.
+// When RLS middleware wraps a request in a transaction with SET LOCAL app.tenant_id,
+// the transaction is stored in context. This ensures all queries in the request
+// execute within that transaction and see the RLS-scoped data.
+func (w *Wrapper[T]) getDB(ctx context.Context) bun.IDB {
+	if tx, ok := ctx.Value(metadata.RLSTxKey).(bun.Tx); ok {
+		return tx
+	}
+	return w.Store.GetDB()
+}
+
+// runInTx runs fn in a transaction. If an RLS transaction is already in context,
+// fn runs directly on that transaction (avoiding a nested transaction).
+// Otherwise, a new transaction is started via the connection pool.
+func (w *Wrapper[T]) runInTx(ctx context.Context, fn func(ctx context.Context, tx bun.Tx) error) error {
+	if tx, ok := ctx.Value(metadata.RLSTxKey).(bun.Tx); ok {
+		return fn(ctx, tx)
+	}
+	return w.Store.GetDB().RunInTx(ctx, nil, fn)
+}
+
 // defaultParentJoinCol returns the parent join column, defaulting to "id" if empty.
 func defaultParentJoinCol(col string) string {
 	if col == "" {
@@ -92,7 +113,7 @@ func (w *Wrapper[T]) GetAll(ctx context.Context) ([]*T, int, map[string]float64,
 	defer cancel()
 
 	items := []*T{}
-	query := w.Store.GetDB().NewSelect().Model(&items)
+	query := w.getDB(ctx).NewSelect().Model(&items)
 
 	// Get metadata from context
 	meta, err := metadata.FromContext(ctx)
@@ -265,7 +286,7 @@ func (w *Wrapper[T]) Create(ctx context.Context, item T) (*T, error) {
 
 	// If audit is configured, wrap in transaction
 	if meta.Auditor != nil {
-		err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			// Insert the item
 			_, err := tx.NewInsert().Model(&item).Returning("*").Exec(ctx)
 			if err != nil {
@@ -276,7 +297,7 @@ func (w *Wrapper[T]) Create(ctx context.Context, item T) (*T, error) {
 		})
 	} else {
 		// No audit, just insert directly
-		_, err = w.Store.GetDB().NewInsert().Model(&item).Returning("*").Exec(ctx)
+		_, err = w.getDB(ctx).NewInsert().Model(&item).Returning("*").Exec(ctx)
 	}
 
 	if err != nil {
@@ -332,7 +353,7 @@ func (w *Wrapper[T]) updateWithOp(ctx context.Context, id string, item T, op met
 
 	// If audit is configured, wrap in transaction
 	if meta.Auditor != nil {
-		err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			// Update the item
 			err := tx.NewUpdate().Model(&item).WherePK().Returning("*").Scan(ctx)
 			if err != nil {
@@ -343,7 +364,7 @@ func (w *Wrapper[T]) updateWithOp(ctx context.Context, id string, item T, op met
 		})
 	} else {
 		// No audit, just update directly
-		err = w.Store.GetDB().NewUpdate().Model(&item).WherePK().Returning("*").Scan(ctx)
+		err = w.getDB(ctx).NewUpdate().Model(&item).WherePK().Returning("*").Scan(ctx)
 	}
 
 	if err != nil {
@@ -385,7 +406,7 @@ func (w *Wrapper[T]) Delete(ctx context.Context, id string) error {
 
 	// If audit is configured, wrap in transaction
 	if meta.Auditor != nil {
-		err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			// Delete the item using ?TablePKs to support any PK type
 			var txErr error
 			result, txErr = tx.NewDelete().Model(&item).Where("?TablePKs = ?", id).Exec(ctx)
@@ -397,7 +418,7 @@ func (w *Wrapper[T]) Delete(ctx context.Context, id string) error {
 		})
 	} else {
 		// No audit, just delete directly using ?TablePKs to support any PK type
-		result, err = w.Store.GetDB().NewDelete().Model(&item).Where("?TablePKs = ?", id).Exec(ctx)
+		result, err = w.getDB(ctx).NewDelete().Model(&item).Where("?TablePKs = ?", id).Exec(ctx)
 	}
 
 	if err != nil {
@@ -429,7 +450,7 @@ func (w *Wrapper[T]) getWithMeta(ctx context.Context, meta *metadata.TypeMetadat
 
 	// Create new instance of the type from metadata
 	item := reflect.New(meta.ModelType).Interface()
-	query := w.Store.GetDB().NewSelect().Model(item)
+	query := w.getDB(ctx).NewSelect().Model(item)
 
 	// Apply parent filters and JOINs from metadata
 	query, err := w.applyParentFiltersWithMeta(ctx, query, meta)
@@ -963,7 +984,7 @@ func (w *Wrapper[T]) computeAggregates(ctx context.Context, query *bun.SelectQue
 	var sums map[string]float64
 
 	// Build aggregation query - clone the base query to preserve WHERE conditions
-	aggQuery := w.Store.GetDB().NewSelect().
+	aggQuery := w.getDB(ctx).NewSelect().
 		TableExpr("(?) AS subq", query.Clone())
 
 	// Track which fields to actually sum (valid ones)
@@ -1851,7 +1872,7 @@ func (w *Wrapper[T]) BatchCreate(ctx context.Context, items []T) ([]*T, error) {
 
 	results := make([]*T, 0, len(items))
 
-	err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+	err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		for i := range items {
 			item := &items[i]
 
@@ -1941,7 +1962,7 @@ func (w *Wrapper[T]) batchUpdateWithOp(ctx context.Context, items []T, op metada
 
 	results := make([]*T, 0, len(items))
 
-	err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+	err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		for i := range items {
 			item := &items[i]
 
@@ -1986,7 +2007,7 @@ func (w *Wrapper[T]) BatchDelete(ctx context.Context, items []T) error {
 		return err
 	}
 
-	err = w.Store.GetDB().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+	err = w.runInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		for i := range items {
 			item := &items[i]
 
@@ -2360,7 +2381,7 @@ func (w *Wrapper[T]) queryRelationCounts(ctx context.Context, baseMeta *metadata
 	ctx, cancel := context.WithTimeout(ctx, w.Store.GetTimeout())
 	defer cancel()
 
-	db := w.Store.GetDB()
+	db := w.getDB(ctx)
 
 	firstChild := chain[0]
 	leaf := chain[len(chain)-1]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sjgoldie/go-restgen
 go 1.26.2
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
 	github.com/shopspring/decimal v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -21,6 +23,7 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -118,6 +118,13 @@ type parentTenantKeyType string
 // Value is []*TypeMetadata - list of parent types in the chain that require tenant checks
 const ParentTenantKey parentTenantKeyType = "restgen_parent_tenant"
 
+// rlsTxKeyType is the context key type for the RLS transaction
+type rlsTxKeyType string
+
+// RLSTxKey is the context key for storing the RLS transaction.
+// When set, the datastore wrapper uses this transaction instead of the connection pool.
+const RLSTxKey rlsTxKeyType = "restgen_rls_tx"
+
 // PaginationMode controls whether cursor-based or offset-based pagination is used.
 // Zero value means no pagination mode configured.
 type PaginationMode int
@@ -156,6 +163,7 @@ type TypeMetadata struct {
 	// Multi-tenant scoping
 	TenantField   string // Go field name holding tenant ID (e.g., "OrgID"). Set by WithTenantScope, inherited by children.
 	IsTenantTable bool   // If true, this IS the tenant entity — filter by PK instead of TenantField.
+	UseRLS        bool   // If true, wrap requests in a transaction with SET LOCAL app.tenant_id (PostgreSQL RLS).
 
 	// Child routes for relation loading via ?include=
 	ChildMeta map[string]*TypeMetadata // relation name -> child type metadata
@@ -219,6 +227,7 @@ func (m *TypeMetadata) Clone() *TypeMetadata {
 		MaxUploadSize:   m.MaxUploadSize,
 		TenantField:     m.TenantField,
 		IsTenantTable:   m.IsTenantTable,
+		UseRLS:          m.UseRLS,
 	}
 
 	// Deep copy slices

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -2365,6 +2365,79 @@ func TestTenantAuth_WithOwnership_BothEnforced(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Issue #118: PostgreSQL Row-Level Security (RLS) Tests
+// =============================================================================
+
+func TestTenantRLS_ConfigDefaults(t *testing.T) {
+	t.Run("UseRLS defaults to false", func(t *testing.T) {
+		config := router.WithTenantScope("OrgID")
+		if config.RLS {
+			t.Error("expected RLS=false by default")
+		}
+	})
+
+	t.Run("UseRLS can be set to true", func(t *testing.T) {
+		config := router.WithTenantScope("OrgID", true)
+		if !config.RLS {
+			t.Error("expected RLS=true when explicitly set")
+		}
+	})
+
+	t.Run("UseRLS can be explicitly false", func(t *testing.T) {
+		config := router.WithTenantScope("OrgID", false)
+		if config.RLS {
+			t.Error("expected RLS=false when explicitly set to false")
+		}
+	})
+}
+
+func TestTenantRLS_MiddlewareWrapsRequestInTransaction(t *testing.T) {
+	setupTenantTest(t)
+
+	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
+	b := router.NewBuilder(r)
+
+	router.RegisterRoutes[TenantTestProject](b, "/projects",
+		router.WithTenantScope("OrgID", true),
+		router.IsAuthenticated(),
+	)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// When UseRLS=true, the RLS middleware should wrap requests in a transaction
+	// with SET LOCAL app.tenant_id. SET LOCAL is PostgreSQL-specific, so on SQLite
+	// the request should fail with 500. This proves the middleware actually
+	// attempts the RLS setup (vs. silently passing through).
+	if w.Code == http.StatusOK {
+		t.Error("expected 500 when UseRLS=true on SQLite (SET LOCAL fails), got 200 — middleware not wrapping in RLS transaction")
+	}
+}
+
+func TestTenantRLS_MiddlewareNotAppliedWhenRLSFalse(t *testing.T) {
+	setupTenantTest(t)
+
+	r := addTenantAuthMiddleware(chi.NewRouter(), "alice", "org-a", []string{"user"})
+	b := router.NewBuilder(r)
+
+	// UseRLS is false — middleware should be a no-op
+	router.RegisterRoutes[TenantTestProject](b, "/projects",
+		router.WithTenantScope("OrgID"),
+		router.IsAuthenticated(),
+	)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Without UseRLS, the request should succeed normally on SQLite
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 when UseRLS=false, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAuth_PatchRoute_AllPublic(t *testing.T) {
 	r := setupAuthTest(t, func(b *router.Builder) {
 		router.RegisterRoutes[AuthTestUser](b, "/users", router.AllPublic())

--- a/router/builder.go
+++ b/router/builder.go
@@ -112,6 +112,7 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 	var pkField string
 	var joinOn *JoinOnConfig
 	var tenantField string
+	var useRLS bool
 	var isTenantTable bool
 	var maxBodySize int64
 	var maxUploadSize int64
@@ -166,6 +167,7 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 			joinOn = &v
 		case TenantConfig:
 			tenantField = v.Field
+			useRLS = v.RLS
 		case TenantTableConfig:
 			isTenantTable = true
 		case MaxBodySizeConfig:
@@ -182,12 +184,12 @@ func RegisterRoutes[T any](b *Builder, path string, options ...interface{}) {
 		}
 	}
 
-	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, endpoints, sses, relationName, singleRoute, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize, maxUploadSize)
+	registerRoutesWithBuilder[T](b, path, nested, authConfigs, queryConfigs, validator, auditor, custom, batch, batchLimit, actions, endpoints, sses, relationName, singleRoute, isFileResource, pkField, joinOn, tenantField, useRLS, isTenantTable, maxBodySize, maxUploadSize)
 }
 
 // prepareMetadata assembles type metadata and auth configuration before route registration.
 // This extracts the setup phase from registerRoutesWithBuilder to reduce cyclomatic complexity.
-func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64, maxUploadSize int64) (string, *metadataSetup) {
+func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], batchLimit int, relationName string, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, useRLS bool, isTenantTable bool, maxBodySize int64, maxUploadSize int64) (string, *metadataSetup) {
 	// Ensure path starts with /
 	if len(path) > 0 && path[0] != '/' {
 		path = "/" + path
@@ -286,10 +288,13 @@ func prepareMetadata[T any](b *Builder, path string, authConfigs []AuthConfig, q
 	switch {
 	case isTenantTable:
 		meta.IsTenantTable = true
+		meta.UseRLS = useRLS
 	case tenantField != "":
 		meta.TenantField = tenantField
+		meta.UseRLS = useRLS
 	case b.parentMeta != nil && b.parentMeta.TenantField != "":
 		meta.TenantField = b.parentMeta.TenantField
+		meta.UseRLS = b.parentMeta.UseRLS
 	}
 
 	// Merge query configs (last wins for each setting)
@@ -375,8 +380,8 @@ func registerSingleRoutes[T any](r chi.Router, b *Builder, meta *metadata.TypeMe
 }
 
 // registerRoutesWithBuilder is the internal implementation
-func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], endpoints []endpointEntry[T], sses []sseEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, isTenantTable bool, maxBodySize int64, maxUploadSize int64) {
-	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField, joinOn, tenantField, isTenantTable, maxBodySize, maxUploadSize)
+func registerRoutesWithBuilder[T any](b *Builder, path string, nested NestedFunc, authConfigs []AuthConfig, queryConfigs []QueryConfig, validator metadata.ValidatorFunc[T], auditor metadata.AuditFunc[T], custom customHandlers[T], batch batchHandlers[T], batchLimit int, actions []actionEntry[T], endpoints []endpointEntry[T], sses []sseEntry[T], relationName string, singleRoute *SingleRouteConfig, isFileResource bool, pkField string, joinOn *JoinOnConfig, tenantField string, useRLS bool, isTenantTable bool, maxBodySize int64, maxUploadSize int64) {
+	path, setup := prepareMetadata[T](b, path, authConfigs, queryConfigs, validator, auditor, batchLimit, relationName, isFileResource, pkField, joinOn, tenantField, useRLS, isTenantTable, maxBodySize, maxUploadSize)
 	meta := setup.meta
 	authMap := setup.authMap
 	metadataMiddleware := setup.metadataMiddleware
@@ -622,9 +627,11 @@ func createMetadataMiddleware(meta *metadata.TypeMetadata) func(http.Handler) ht
 
 // wrapHandler wraps a handler with auth middleware if configured, otherwise blocks unauthorized access
 // The authConfig's ChildAuth field is used for ?include= authorization
+// When RLS is enabled on the route, the RLS middleware is also applied (auth runs first,
+// then RLS wraps the request in a transaction with set_config('app.tenant_id', ...)).
 func wrapHandler(h http.Handler, authConfig *AuthConfig) http.Handler {
 	if authConfig != nil {
-		return wrapWithAuth(h, authConfig)
+		return wrapWithAuth(wrapWithRLS(h), authConfig)
 	}
 	return blockUnauthorized(h)
 }

--- a/router/builder_internal_test.go
+++ b/router/builder_internal_test.go
@@ -719,7 +719,7 @@ func TestMaxUploadSizeDefault(t *testing.T) {
 		r := chi.NewRouter()
 		b := NewBuilder(r)
 
-		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, 0, 0)
+		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, false, 0, 0)
 
 		if setup.meta.MaxUploadSize != metadata.DefaultMaxUploadSize {
 			t.Errorf("expected default MaxUploadSize %d, got %d", metadata.DefaultMaxUploadSize, setup.meta.MaxUploadSize)
@@ -731,7 +731,7 @@ func TestMaxUploadSizeDefault(t *testing.T) {
 		b := NewBuilder(r)
 
 		customSize := int64(10 << 20)
-		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, 0, customSize)
+		_, setup := prepareMetadata[fileModel](b, "/files", nil, nil, nil, nil, 0, "", true, "", nil, "", false, false, 0, customSize)
 
 		if setup.meta.MaxUploadSize != customSize {
 			t.Errorf("expected MaxUploadSize %d, got %d", customSize, setup.meta.MaxUploadSize)
@@ -742,7 +742,7 @@ func TestMaxUploadSizeDefault(t *testing.T) {
 		r := chi.NewRouter()
 		b := NewBuilder(r)
 
-		_, setup := prepareMetadata[testModel](b, "/items", nil, nil, nil, nil, 0, "", false, "", nil, "", false, 0, 0)
+		_, setup := prepareMetadata[testModel](b, "/items", nil, nil, nil, nil, 0, "", false, "", nil, "", false, false, 0, 0)
 
 		if setup.meta.MaxUploadSize != metadata.DefaultMaxUploadSize {
 			t.Errorf("expected default MaxUploadSize %d, got %d", metadata.DefaultMaxUploadSize, setup.meta.MaxUploadSize)

--- a/router/builder_test.go
+++ b/router/builder_test.go
@@ -25,27 +25,8 @@ import (
 	"github.com/sjgoldie/go-restgen/service"
 )
 
-func TestMain(m *testing.M) {
-	// Initialize datastore for all tests
-	db, err := datastore.NewSQLite(":memory:")
-	if err != nil {
-		panic("failed to create test database: " + err.Error())
-	}
-
-	if err := datastore.Initialize(db); err != nil {
-		db.Cleanup()
-		panic("failed to initialize datastore: " + err.Error())
-	}
-
-	// Run tests
-	code := m.Run()
-
-	// Cleanup
-	datastore.Cleanup()
-	db.Cleanup()
-
-	os.Exit(code)
-}
+// TestMain lives in main_internal_test.go (package router) so it can install
+// a switchable Store that lets RLS unit tests swap in a sqlmock backend.
 
 // Test models with proper relationships
 type TestUser struct {

--- a/router/main_internal_test.go
+++ b/router/main_internal_test.go
@@ -1,0 +1,109 @@
+package router
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+)
+
+// switchableStore is test-only Store infrastructure that wraps a real SQLite
+// store by default but can be temporarily swapped to a sqlmock-backed bun.DB
+// for tests that need to verify exact SQL and transaction lifecycle.
+//
+// This exists because the datastore singleton is locked by sync.Once, so
+// individual tests can't replace it. The switchable wrapper is registered
+// once in TestMain; tests opt into mock mode via useSqlmock(t) which sets
+// the mock backend for the test's duration and restores SQLite via t.Cleanup.
+type switchableStore struct {
+	mu     sync.Mutex
+	sqlite datastore.Store
+	mockDB *bun.DB
+}
+
+func (s *switchableStore) GetDB() *bun.DB {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mockDB != nil {
+		return s.mockDB
+	}
+	return s.sqlite.GetDB()
+}
+
+func (s *switchableStore) GetTimeout() time.Duration { return 30 * time.Second }
+
+func (s *switchableStore) IlikeOp() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mockDB != nil {
+		// Mock backend uses pgdialect, so report PostgreSQL's case-insensitive operator
+		return "ILIKE"
+	}
+	return s.sqlite.IlikeOp()
+}
+
+func (s *switchableStore) Cleanup() {
+	if s.sqlite != nil {
+		s.sqlite.Cleanup()
+	}
+}
+
+// testStore is the package-level switchable store registered in TestMain.
+var testStore *switchableStore
+
+// useSqlmock installs a sqlmock-backed bun.DB as the active backend for the
+// duration of the test, returning the mock controller. Call mock.ExpectXxx()
+// to script expected queries. The mock and any expectations are cleaned up
+// automatically when the test completes.
+func useSqlmock(t *testing.T) sqlmock.Sqlmock {
+	t.Helper()
+
+	// Regexp matcher: bun's query layer inlines ? placeholders into the SQL
+	// string before reaching the driver, so tests assert against the rendered
+	// SQL via regex rather than parameter binding.
+	sqlDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	bunDB := bun.NewDB(sqlDB, pgdialect.New())
+
+	testStore.mu.Lock()
+	testStore.mockDB = bunDB
+	testStore.mu.Unlock()
+
+	t.Cleanup(func() {
+		testStore.mu.Lock()
+		testStore.mockDB = nil
+		testStore.mu.Unlock()
+		_ = bunDB.Close()
+		_ = sqlDB.Close()
+	})
+
+	return mock
+}
+
+func TestMain(m *testing.M) {
+	sqlite, err := datastore.NewSQLite(":memory:")
+	if err != nil {
+		panic("failed to create test sqlite database: " + err.Error())
+	}
+
+	testStore = &switchableStore{sqlite: sqlite}
+
+	if err := datastore.Initialize(testStore); err != nil {
+		sqlite.Cleanup()
+		panic("failed to initialize datastore: " + err.Error())
+	}
+
+	code := m.Run()
+
+	datastore.Cleanup()
+
+	os.Exit(code)
+}

--- a/router/rls_middleware.go
+++ b/router/rls_middleware.go
@@ -1,0 +1,99 @@
+package router
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/sjgoldie/go-restgen/datastore"
+	"github.com/sjgoldie/go-restgen/handler"
+	"github.com/sjgoldie/go-restgen/metadata"
+)
+
+// wrapWithRLS wraps a handler with PostgreSQL Row-Level Security support.
+// When the route has UseRLS=true and a tenant ID is in context, the request
+// is wrapped in a transaction with set_config('app.tenant_id', <id>, true)
+// so that PostgreSQL RLS policies can scope queries to the tenant.
+//
+// On commit/rollback: the transaction commits if the handler returns 2xx/3xx,
+// rolls back on 4xx/5xx. This is consistent with HTTP semantics — error
+// responses imply the request should not have side effects.
+//
+// If UseRLS is false or no tenant ID is set, this middleware is a pass-through.
+func wrapWithRLS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		meta, _ := metadata.FromContext(ctx)
+		if meta == nil || !meta.UseRLS {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		tenantID, ok := ctx.Value(metadata.TenantIDValueKey).(string)
+		if !ok || tenantID == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		store, err := datastore.Get()
+		if err != nil {
+			slog.ErrorContext(ctx, "RLS middleware: datastore not initialized", "error", err)
+			handler.WriteError(w, http.StatusInternalServerError, handler.ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
+			return
+		}
+
+		tx, err := store.GetDB().BeginTx(ctx, nil)
+		if err != nil {
+			slog.ErrorContext(ctx, "RLS middleware: failed to begin transaction", "error", err)
+			handler.WriteError(w, http.StatusInternalServerError, handler.ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
+			return
+		}
+
+		if _, err := tx.ExecContext(ctx, "SELECT set_config('app.tenant_id', ?, true)", tenantID); err != nil {
+			_ = tx.Rollback()
+			slog.ErrorContext(ctx, "RLS middleware: failed to set tenant ID", "error", err, "tenant_id", tenantID)
+			handler.WriteError(w, http.StatusInternalServerError, handler.ErrCodeInternalError, http.StatusText(http.StatusInternalServerError))
+			return
+		}
+
+		rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		ctx = context.WithValue(ctx, metadata.RLSTxKey, tx)
+		next.ServeHTTP(rw, r.WithContext(ctx))
+
+		if rw.status >= 400 {
+			if err := tx.Rollback(); err != nil {
+				slog.ErrorContext(ctx, "RLS middleware: rollback failed", "error", err)
+			}
+			return
+		}
+
+		if err := tx.Commit(); err != nil {
+			slog.ErrorContext(ctx, "RLS middleware: commit failed", "error", err)
+		}
+	})
+}
+
+// rlsStatusRecorder wraps http.ResponseWriter to capture the response status code
+// so the RLS middleware can decide whether to commit or roll back the transaction.
+type rlsStatusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (r *rlsStatusRecorder) WriteHeader(status int) {
+	if !r.wroteHeader {
+		r.status = status
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *rlsStatusRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.wroteHeader = true
+	}
+	return r.ResponseWriter.Write(b)
+}

--- a/router/rls_middleware_internal_test.go
+++ b/router/rls_middleware_internal_test.go
@@ -1,0 +1,153 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sjgoldie/go-restgen/metadata"
+)
+
+func TestRLSStatusRecorder_DefaultStatusIs200(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	if rw.status != http.StatusOK {
+		t.Errorf("expected default status 200, got %d", rw.status)
+	}
+}
+
+func TestRLSStatusRecorder_WriteHeaderCapturesStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rw.WriteHeader(http.StatusCreated)
+
+	if rw.status != http.StatusCreated {
+		t.Errorf("expected captured status 201, got %d", rw.status)
+	}
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected underlying ResponseWriter status 201, got %d", w.Code)
+	}
+}
+
+func TestRLSStatusRecorder_WriteHeaderIdempotent(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rw.WriteHeader(http.StatusCreated)
+	rw.WriteHeader(http.StatusInternalServerError)
+
+	if rw.status != http.StatusCreated {
+		t.Errorf("expected first captured status 201 (subsequent WriteHeader calls ignored), got %d", rw.status)
+	}
+}
+
+func TestRLSStatusRecorder_WriteMarksHeaderWritten(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	n, err := rw.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("expected 5 bytes written, got %d", n)
+	}
+	if !rw.wroteHeader {
+		t.Error("expected wroteHeader to be true after Write")
+	}
+	if rw.status != http.StatusOK {
+		t.Errorf("expected implicit status 200 when Write called first, got %d", rw.status)
+	}
+}
+
+func TestRLSStatusRecorder_WriteAfterWriteHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	rw := &rlsStatusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rw.WriteHeader(http.StatusAccepted)
+	_, _ = rw.Write([]byte("body"))
+
+	if rw.status != http.StatusAccepted {
+		t.Errorf("expected captured status 202, got %d", rw.status)
+	}
+}
+
+// TestWrapWithRLS_NoMetadataPassesThrough verifies the middleware is a no-op
+// when there's no metadata in context (e.g., if metadata middleware hasn't run).
+func TestWrapWithRLS_NoMetadataPassesThrough(t *testing.T) {
+	handlerCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := wrapWithRLS(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if !handlerCalled {
+		t.Error("expected handler to be called when no metadata in context")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// TestWrapWithRLS_UseRLSFalsePassesThrough verifies the middleware is a no-op
+// when UseRLS is false on the route metadata.
+func TestWrapWithRLS_UseRLSFalsePassesThrough(t *testing.T) {
+	handlerCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := wrapWithRLS(next)
+
+	meta := &metadata.TypeMetadata{UseRLS: false, TenantField: "OrgID"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, meta)
+
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if !handlerCalled {
+		t.Error("expected handler to be called when UseRLS=false")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// TestWrapWithRLS_MissingTenantIDPassesThrough verifies the middleware is a no-op
+// when UseRLS=true but no tenant ID is set in context. In practice the auth
+// middleware rejects this before reaching RLS, but the defensive check is
+// still worth testing.
+func TestWrapWithRLS_MissingTenantIDPassesThrough(t *testing.T) {
+	handlerCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := wrapWithRLS(next)
+
+	meta := &metadata.TypeMetadata{UseRLS: true, TenantField: "OrgID"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, meta)
+
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if !handlerCalled {
+		t.Error("expected handler to be called when tenant ID is missing (defensive pass-through)")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/router/rls_middleware_internal_test.go
+++ b/router/rls_middleware_internal_test.go
@@ -2,12 +2,31 @@ package router
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/sjgoldie/go-restgen/metadata"
 )
+
+// rlsRequestWithRLSMeta builds a request with the metadata + tenant ID context
+// values that wrapWithRLS expects when UseRLS=true.
+func rlsRequestWithRLSMeta(tenantID string) *http.Request {
+	meta := &metadata.TypeMetadata{UseRLS: true, TenantField: "OrgID"}
+	ctx := context.WithValue(context.Background(), metadata.MetadataKey, meta)
+	ctx = context.WithValue(ctx, metadata.TenantIDValueKey, tenantID)
+	return httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+}
+
+// setConfigSQLFor returns a regex pattern matching the SET LOCAL SQL bun
+// renders for the given tenant ID. bun inlines ? placeholders before reaching
+// the driver, so the tenant ID appears literally in the SQL string.
+func setConfigSQLFor(tenantID string) string {
+	return `^SELECT set_config\('app\.tenant_id', '` + tenantID + `', true\)$`
+}
 
 func TestRLSStatusRecorder_DefaultStatusIs200(t *testing.T) {
 	w := httptest.NewRecorder()
@@ -149,5 +168,191 @@ func TestWrapWithRLS_MissingTenantIDPassesThrough(t *testing.T) {
 	}
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// =============================================================================
+// sqlmock-backed unit tests for the RLS transaction lifecycle.
+// =============================================================================
+
+func TestWrapWithRLS_CommitsOnSuccess(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	handlerCalled := false
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if !handlerCalled {
+		t.Error("handler was not called")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_RollsBackOnClientError(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_RollsBackOnServerError(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-b")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-b"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_BeginTxErrorReturns500(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin().WillReturnError(errors.New("begin failed"))
+
+	handlerCalled := false
+	wrapped := wrapWithRLS(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 when BeginTx fails, got %d", w.Code)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called when BeginTx fails")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_SetConfigErrorRollsBackAndReturns500(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnError(errors.New("set_config failed"))
+	mock.ExpectRollback()
+
+	handlerCalled := false
+	wrapped := wrapWithRLS(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 when set_config fails, got %d", w.Code)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called when set_config fails")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_CommitErrorIsLoggedNotPropagated(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	// Commit failed but the response was already sent; status should be unchanged
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (response written before commit), got %d", w.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_RollbackErrorIsLoggedNotPropagated(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback().WillReturnError(errors.New("rollback failed"))
+
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 (response written before rollback), got %d", w.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
+	}
+}
+
+func TestWrapWithRLS_TxAvailableInHandlerContext(t *testing.T) {
+	mock := useSqlmock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec(setConfigSQLFor("org-a")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	var txInCtx interface{}
+	wrapped := wrapWithRLS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		txInCtx = r.Context().Value(metadata.RLSTxKey)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, rlsRequestWithRLSMeta("org-a"))
+
+	if txInCtx == nil {
+		t.Error("expected RLS transaction to be in handler context")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met: %v", err)
 	}
 }

--- a/router/tenant.go
+++ b/router/tenant.go
@@ -5,6 +5,7 @@ package router
 // All models in the hierarchy must have this field. Children inherit from parent.
 type TenantConfig struct {
 	Field string // Go field name holding tenant ID (e.g., "OrgID")
+	RLS   bool   // If true, wrap requests in a transaction with SET LOCAL app.tenant_id (PostgreSQL RLS)
 }
 
 // TenantTableConfig marks a route as the tenant entity itself.
@@ -14,9 +15,16 @@ type TenantTableConfig struct{}
 
 // WithTenantScope returns a TenantConfig that enables tenant scoping.
 // The field parameter is the Go struct field name holding the tenant ID.
+// The optional useRLS parameter enables PostgreSQL Row-Level Security support.
+// When RLS is enabled, each request is wrapped in a transaction with
+// SET LOCAL app.tenant_id set to the authenticated tenant ID.
 // Configure on the root route — child routes inherit automatically.
-func WithTenantScope(field string) TenantConfig {
-	return TenantConfig{Field: field}
+func WithTenantScope(field string, useRLS ...bool) TenantConfig {
+	rls := false
+	if len(useRLS) > 0 {
+		rls = useRLS[0]
+	}
+	return TenantConfig{Field: field, RLS: rls}
 }
 
 // IsTenantTable marks this route as the tenant entity itself (e.g., Organization).

--- a/scripts/templates/NOTICE.txt.tmpl
+++ b/scripts/templates/NOTICE.txt.tmpl
@@ -7,7 +7,7 @@ Time    : {{ $dep.VersionTime }}
 Licence : {{ $dep.LicenceType }}
 
 {{ $dep | licenceText }}
-{{ end }}
+{{- end }}
 {{- end -}}
 
 {{ "=" | line }}
@@ -21,4 +21,4 @@ Third party libraries used by go-restgen
 Indirect dependencies
 
 {{ template "depInfo" .Indirect }}
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
## Summary
- `WithTenantScope("OrgID", true)` opts into PostgreSQL RLS — the middleware wraps tenant-scoped requests in a transaction with `SELECT set_config('app.tenant_id', <id>, true)` so RLS policies can scope queries at the database level.
- Application-level tenant filtering is untouched — RLS is purely additive defense-in-depth. Auth, ownership, and other security paths unchanged.
- New `getDB(ctx)` / `runInTx(ctx, fn)` wrapper helpers route queries through the RLS transaction when present, falling back to the pool otherwise. Audit inserts share the RLS transaction, preserving atomicity.

## Design notes
- Opt-in via a second arg on `WithTenantScope`, no database-type detection anywhere — if you enable RLS and point at SQLite, `set_config` doesn't exist and the request fails with 500 (correct behaviour, no silent no-op).
- Transaction commits on 2xx/3xx responses and rolls back on 4xx/5xx, consistent with HTTP semantics.
- Child routes inherit the parent's `UseRLS` setting along with the tenant scope.

## Test plan
- [x] `go test ./metadata ./datastore ./router ./service ./handler ./errors ./filestore ./metrics` — all green
- [x] Bruno tenant suite (29 tests) — all green
- [x] Full Bruno suite — no regressions
- [x] New unit tests: wrapper `getDB`/`runInTx` use RLS tx from context; middleware wraps requests when UseRLS=true and is a no-op when UseRLS=false
- [ ] Manual verification on PostgreSQL with RLS policies (reviewer to confirm)

## Docs updated
- README.md (new RLS subsection under Multi-Tenant, including audit-interaction note)
- AGENT.md
- `cmd/install-skill/skill/patterns.md` and `cmd/install-skill/cursor/go-restgen.mdc`

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)